### PR TITLE
Add DP3 (3D Diffusion Policy) imitation-learning baseline

### DIFF
--- a/scripts/dp3/_bootstrap.py
+++ b/scripts/dp3/_bootstrap.py
@@ -1,0 +1,20 @@
+# Copyright (c) 2025-2026, The DexVerse Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+def prefer_workspace_source() -> None:
+    project_root = Path(__file__).resolve().parents[2]
+    source_root = project_root / "source" / "dexverse"
+    source_root_str = str(source_root)
+    if source_root.is_dir() and source_root_str not in sys.path:
+        sys.path.insert(0, source_root_str)
+
+
+prefer_workspace_source()

--- a/scripts/dp3/convert_demos_to_dp3.py
+++ b/scripts/dp3/convert_demos_to_dp3.py
@@ -1,0 +1,337 @@
+#!/usr/bin/env python3
+# Copyright (c) 2025-2026, The DexVerse Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Convert ``create_demo_files_sequential.py`` HDF5 demos into DP3-ready HDF5 format.
+
+The input HDF5 is produced by ``scripts/demo_tools/create_demo_files_sequential.py`` with at least
+the ``pointcloud`` and ``proprio`` observation groups captured (typically via
+``--obs-groups pointcloud`` or the ``pointcloud`` / ``3view_pointcloud`` preset).
+
+Expected input layout::
+
+    /                              attrs: task, observation_preset, num_episodes, ...
+      data/
+        demo_<i>/                  attrs: episode_index, success, num_samples, ...
+          actions                  (T, action_dim)  float32
+          obs/
+            pointcloud/
+              camera_point_cloud_w (T, num_points_in, 3)   single-view, or
+              merged_point_cloud_w (T, num_points_in, 3)   3-view preset
+            proprio/
+              <term>               (T, *)                  one or more terms
+
+Processing pipeline per episode:
+  1. Extract the point cloud term (single- or multi-view) and FPS-downsample
+     each frame from ``num_points_in`` to ``--num_points``.
+  2. Concatenate all proprio terms (sorted by key) into a flat ``agent_pos``.
+  3. Store point_cloud, agent_pos, and action as ``(T, *)`` arrays per episode.
+  4. Compute the workspace AABB over all valid points and store it as
+     dataset-level metadata for normalization.
+
+Usage::
+
+    # Step 1: Download teleop demos (HF dataset is gated; log in first):
+    python scripts/demo_tools/download_demos.py --task functional/Dexverse-GraspPan-v0
+
+    # Step 2: Replay headlessly and write HDF5 with the pointcloud preset:
+    python scripts/demo_tools/create_demo_files_sequential.py \\
+        --task functional/Dexverse-GraspPan-v0 \\
+        --obs-groups pointcloud \\
+        --output-dir outputs/demos_h5
+
+    # Step 3: Convert to DP3 HDF5 (this script):
+    python scripts/dp3/convert_demos_to_dp3.py \\
+        --input_h5 outputs/demos_h5/functional/Dexverse-GraspPan-v0/Dexverse-GraspPan-v0.pointcloud.seq.demo.h5 \\
+        --out_file outputs/dp3_graspPan.hdf5 \\
+        --num_points 512
+"""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import _bootstrap  # noqa: F401
+import h5py
+import numpy as np
+import torch
+
+# Observation paths inside a ``create_demo_files_sequential.py`` HDF5 demo group.
+_POINTCLOUD_GROUP = "obs/pointcloud"
+_PROPRIO_GROUP = "obs/proprio"
+_POINTCLOUD_TERM_PRIORITY = ("camera_point_cloud_w", "merged_point_cloud_w")
+_ACTION_KEY = "actions"
+
+
+def _fps_downsample_np(points: np.ndarray, num_points: int) -> np.ndarray:
+    """Farthest-point sample a ``(N, 3)`` numpy array down to ``num_points``."""
+    N = points.shape[0]
+    if N <= num_points:
+        if N == 0:
+            return np.zeros((num_points, 3), dtype=points.dtype)
+        pad_idx = np.random.choice(N, num_points - N, replace=True)
+        return np.concatenate([points, points[pad_idx]], axis=0)
+
+    pts = torch.from_numpy(points).float()
+    try:
+        import pytorch3d.ops as torch3d_ops
+
+        sampled, _ = torch3d_ops.sample_farthest_points(pts.unsqueeze(0), K=num_points)
+        return sampled.squeeze(0).numpy()
+    except ImportError:
+        pass
+
+    selected = np.zeros(num_points, dtype=np.int64)
+    dists = np.full(N, np.inf, dtype=np.float64)
+    selected[0] = np.random.randint(N)
+    for i in range(1, num_points):
+        last = points[selected[i - 1]]
+        d = np.sum((points - last) ** 2, axis=1)
+        dists = np.minimum(dists, d)
+        selected[i] = np.argmax(dists)
+    return points[selected]
+
+
+def _resolve_pointcloud_term(demo_group: h5py.Group) -> str:
+    """Return the pointcloud term name available in this demo, preferring single-view."""
+    if _POINTCLOUD_GROUP not in demo_group:
+        raise KeyError(
+            f"Demo group has no '{_POINTCLOUD_GROUP}'. "
+            "Run create_demo_files_sequential.py with --obs-groups pointcloud (or the "
+            "'pointcloud' / '3view_pointcloud' preset) first."
+        )
+    pcd_group = demo_group[_POINTCLOUD_GROUP]
+    for term in _POINTCLOUD_TERM_PRIORITY:
+        if term in pcd_group:
+            return term
+    available = list(pcd_group.keys())
+    raise KeyError(
+        f"None of {_POINTCLOUD_TERM_PRIORITY} found under '{_POINTCLOUD_GROUP}'. Available terms: {available}"
+    )
+
+
+def _load_pointcloud(demo_group: h5py.Group, term_name: str) -> np.ndarray:
+    """Load the per-frame pointcloud array. Reshape to (T, N, 3) regardless of flatten."""
+    arr = demo_group[f"{_POINTCLOUD_GROUP}/{term_name}"][...]
+    arr = np.asarray(arr, dtype=np.float32)
+    if arr.ndim == 3 and arr.shape[-1] == 3:
+        return arr
+    if arr.ndim == 2:
+        # (T, N*3) flat → (T, N, 3)
+        T = arr.shape[0]
+        if arr.shape[1] % 3 != 0:
+            raise ValueError(f"Pointcloud term {term_name!r} has shape {arr.shape}; trailing dim not divisible by 3.")
+        return arr.reshape(T, -1, 3)
+    raise ValueError(f"Unexpected pointcloud shape for term {term_name!r}: {arr.shape}")
+
+
+def _load_proprio(demo_group: h5py.Group) -> np.ndarray:
+    """Concatenate every proprio term (sorted by key) into a flat ``(T, D)`` agent_pos.
+
+    Sorting keeps the concat order deterministic across episodes. With the
+    default ``pointcloud`` preset there is only one term (``joint_pos``),
+    so ordering is moot — but custom setups can append more terms.
+    """
+    if _PROPRIO_GROUP not in demo_group:
+        raise KeyError(
+            f"Demo group has no '{_PROPRIO_GROUP}'. "
+            "create_demo_files_sequential.py must be run with the proprio group enabled."
+        )
+    proprio_group = demo_group[_PROPRIO_GROUP]
+    term_names = sorted(proprio_group.keys())
+    if not term_names:
+        raise ValueError(f"'{_PROPRIO_GROUP}' is empty in this demo.")
+
+    parts = []
+    T_ref = None
+    for name in term_names:
+        arr = np.asarray(proprio_group[name][...], dtype=np.float32)
+        if arr.ndim == 1:
+            arr = arr[:, None]
+        else:
+            arr = arr.reshape(arr.shape[0], -1)
+        if T_ref is None:
+            T_ref = arr.shape[0]
+        elif arr.shape[0] != T_ref:
+            raise ValueError(f"Proprio term {name!r} has T={arr.shape[0]} but expected {T_ref}.")
+        parts.append(arr)
+    return np.concatenate(parts, axis=1)
+
+
+def _load_actions(demo_group: h5py.Group) -> np.ndarray:
+    if _ACTION_KEY not in demo_group:
+        raise KeyError(f"Demo group has no '{_ACTION_KEY}' dataset.")
+    return np.asarray(demo_group[_ACTION_KEY][...], dtype=np.float32)
+
+
+def _compute_bbox(point_clouds: list[np.ndarray]) -> tuple[np.ndarray, np.ndarray]:
+    """Compute axis-aligned bbox over all valid points across a list of (T, N, 3) arrays."""
+    all_mins: list[np.ndarray] = []
+    all_maxs: list[np.ndarray] = []
+    for pcd_seq in point_clouds:
+        flat = pcd_seq.reshape(-1, 3)
+        valid = np.isfinite(flat).all(axis=1) & (np.abs(flat).sum(axis=1) > 1e-6)
+        if valid.any():
+            v = flat[valid]
+            all_mins.append(v.min(axis=0))
+            all_maxs.append(v.max(axis=0))
+    if not all_mins:
+        return np.zeros(3, dtype=np.float32), np.ones(3, dtype=np.float32)
+    return (
+        np.min(all_mins, axis=0).astype(np.float32),
+        np.max(all_maxs, axis=0).astype(np.float32),
+    )
+
+
+def convert(
+    input_h5: str,
+    out_file: str,
+    num_points: int = 512,
+    skip_failed: bool = True,
+) -> dict:
+    """Convert ``create_demo_files_sequential.py`` HDF5 into a DP3-ready HDF5."""
+    in_path = Path(input_h5).expanduser().resolve()
+    out_path = Path(out_file).expanduser().resolve()
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+
+    written = 0
+    pcd_arrays: list[np.ndarray] = []
+    point_cloud = agent_pos = actions = None  # for summary
+
+    with h5py.File(in_path, "r") as hf_in, h5py.File(out_path, "w") as hf_out:
+        task = str(hf_in.attrs.get("task", "unknown"))
+        observation_preset = str(hf_in.attrs.get("observation_preset", ""))
+        demo_names = sorted(hf_in["data"].keys(), key=lambda n: int(n.split("_")[-1]))
+
+        # Resolve pointcloud term from the first non-empty demo so we keep one
+        # consistent term across the whole file.
+        pcd_term_name = None
+        for name in demo_names:
+            group = hf_in["data"][name]
+            if int(group.attrs.get("num_samples", 0)) > 0:
+                pcd_term_name = _resolve_pointcloud_term(group)
+                break
+        if pcd_term_name is None:
+            raise ValueError(f"No non-empty demos found in {in_path}")
+
+        out_data = hf_out.create_group("data")
+        hf_out.attrs["task"] = task
+        hf_out.attrs["num_points"] = num_points
+        hf_out.attrs["source_h5"] = str(in_path)
+        hf_out.attrs["observation_preset"] = observation_preset
+        hf_out.attrs["pointcloud_term"] = pcd_term_name
+
+        for name in demo_names:
+            group = hf_in["data"][name]
+            num_samples = int(group.attrs.get("num_samples", 0))
+            success = bool(group.attrs.get("success", False))
+            has_success = bool(group.attrs.get("has_success_flag", False))
+            if num_samples == 0:
+                print(f"[convert] {name}: num_samples=0, skipping")
+                continue
+            if skip_failed and has_success and not success:
+                print(f"[convert] {name}: success=False, skipping")
+                continue
+
+            pcd_seq_raw = _load_pointcloud(group, pcd_term_name)  # (T, N, 3)
+            agent_pos = _load_proprio(group)  # (T, D)
+            actions = _load_actions(group)  # (T, Da)
+            T_pcd = pcd_seq_raw.shape[0]
+            if not (T_pcd == agent_pos.shape[0] == actions.shape[0]):
+                raise ValueError(
+                    f"{name}: T mismatch — pcd={T_pcd}, proprio={agent_pos.shape[0]}, actions={actions.shape[0]}"
+                )
+
+            pcd_down = np.stack(
+                [_fps_downsample_np(pcd_seq_raw[t], num_points) for t in range(T_pcd)],
+                axis=0,
+            )
+            pcd_arrays.append(pcd_down)
+            point_cloud = pcd_down
+
+            ep_group = out_data.create_group(f"episode_{written}")
+            obs_group = ep_group.create_group("obs")
+            obs_group.create_dataset("point_cloud", data=pcd_down, compression="gzip", compression_opts=4)
+            obs_group.create_dataset("agent_pos", data=agent_pos, compression="gzip", compression_opts=4)
+            ep_group.create_dataset("action", data=actions, compression="gzip", compression_opts=4)
+            ep_group.attrs["source_demo_name"] = name
+            ep_group.attrs["source_episode_index"] = int(group.attrs.get("episode_index", written))
+            ep_group.attrs["success"] = success
+            ep_group.attrs["num_steps"] = num_samples
+            written += 1
+
+            if (written % 5 == 0) or (name == demo_names[-1]):
+                print(
+                    f"[convert] {name} -> episode_{written - 1}: "
+                    f"T={T_pcd} pcd={pcd_down.shape} agent_pos={agent_pos.shape} action={actions.shape}"
+                )
+
+        if written == 0:
+            raise ValueError(f"No episodes written from {in_path} (all empty or filtered).")
+
+        bbox_min, bbox_max = _compute_bbox(pcd_arrays)
+        hf_out.attrs["bbox_min"] = bbox_min
+        hf_out.attrs["bbox_max"] = bbox_max
+        hf_out.attrs["num_episodes"] = written
+
+    summary = {
+        "task": task,
+        "observation_preset": observation_preset or None,
+        "pointcloud_term": pcd_term_name,
+        "num_episodes": written,
+        "num_points": num_points,
+        "bbox_min": bbox_min.tolist(),
+        "bbox_max": bbox_max.tolist(),
+        "output_file": str(out_path),
+        "point_cloud_shape": list(point_cloud.shape) if point_cloud is not None else None,
+        "agent_pos_dim": int(agent_pos.shape[-1]) if agent_pos is not None else None,
+        "action_dim": int(actions.shape[-1]) if actions is not None else None,
+    }
+    print(f"\n[convert] Done. Wrote {written} episodes to {out_path}")
+    for k, v in summary.items():
+        print(f"  {k}: {v}")
+    return summary
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Convert create_demo_files_sequential.py HDF5 demos into DP3-ready HDF5.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument(
+        "--input_h5",
+        type=str,
+        required=True,
+        help="HDF5 produced by scripts/demo_tools/create_demo_files_sequential.py (with pointcloud + proprio groups).",
+    )
+    parser.add_argument("--out_file", type=str, required=True, help="Output DP3 HDF5 path.")
+    parser.add_argument(
+        "--num_points",
+        type=int,
+        default=512,
+        help="Per-frame target point count after FPS downsampling (default: 512).",
+    )
+    parser.add_argument(
+        "--include_failed",
+        action="store_true",
+        default=False,
+        help="Include demos with success=False (default: skip them).",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    convert(
+        input_h5=args.input_h5,
+        out_file=args.out_file,
+        num_points=args.num_points,
+        skip_failed=not args.include_failed,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/dp3/eval_online.py
+++ b/scripts/dp3/eval_online.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+# Copyright (c) 2025-2026, The DexVerse Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Evaluate a trained DP3 policy online in a DexVerse simulator.
+
+Usage::
+
+    python scripts/dp3/eval_online.py \\
+        --ckpt runs/dp3_graspPan/best.pt \\
+        --task Dexverse-GraspPan-v0 \\
+        --observation_preset pointcloud \\
+        --num_episodes 20
+
+``--enable_cameras`` is auto-set when the preset includes a camera-driven
+group (``pointcloud`` / ``3view_pointcloud``); pass ``--no_auto_enable_cameras``
+if you need to override that behavior.
+"""
+from __future__ import annotations
+
+import argparse
+
+import _bootstrap  # noqa: F401
+from isaaclab.app import AppLauncher
+
+# Presets that need camera sensors live in the scene.
+_CAMERA_PRESETS = {
+    "rgb",
+    "rgb_depth",
+    "rgbd",
+    "pointcloud",
+    "3view_rgb",
+    "3view_rgb_depth",
+    "3view_rgbd",
+    "3view_pointcloud",
+}
+
+parser = argparse.ArgumentParser(description="Evaluate DP3 policy online in DexVerse simulation.")
+parser.add_argument("--ckpt", type=str, required=True, help="Path to DP3 training checkpoint")
+parser.add_argument("--task", type=str, required=True, help="DexVerse task name")
+parser.add_argument("--output_dir", type=str, default="runs/dp3_eval_online")
+parser.add_argument("--num_episodes", type=int, default=20)
+parser.add_argument("--max_steps", type=int, default=500)
+parser.add_argument("--replan_interval", type=int, default=8)
+parser.add_argument("--num_points", type=int, default=512)
+parser.add_argument(
+    "--observation_preset",
+    type=str,
+    default="pointcloud",
+    help=(
+        "Observation preset to apply to the env cfg before gym.make() "
+        "(default: pointcloud). Must match the preset used when generating demos."
+    ),
+)
+parser.add_argument(
+    "--no_auto_enable_cameras",
+    action="store_true",
+    default=False,
+    help="Disable the auto-setting of --enable_cameras based on the preset.",
+)
+parser.add_argument(
+    "--json_path", type=str, default=None, help="Path to template JSON spec (for *Template environments)"
+)
+parser.add_argument(
+    "--record_video", action="store_true", default=False, help="Record one MP4 per episode from a scene camera."
+)
+parser.add_argument(
+    "--video_camera",
+    type=str,
+    default="third_person_camera",
+    help="Name of the scene Camera sensor to render from (default: third_person_camera).",
+)
+parser.add_argument("--video_fps", type=int, default=30, help="Frames per second for written MP4s (default: 30).")
+AppLauncher.add_app_launcher_args(parser)
+args = parser.parse_args()
+
+# Force headless. Without this the app boots a windowed RTX pipeline and the
+# first camera render inside env.reset() spins indefinitely on a display-less
+# host. create_demo_files_sequential.py forces headless for the same reason.
+args.headless = True
+
+# Isaac Lab refuses to spawn Camera sensors unless --enable_cameras is set.
+# Mirror create_demo_files_sequential.py's auto-enable behavior so the user doesn't have
+# to remember the flag when picking a camera-driven preset.
+if not args.no_auto_enable_cameras and args.observation_preset in _CAMERA_PRESETS:
+    args.enable_cameras = True
+
+app_launcher = AppLauncher(args)
+simulation_app = app_launcher.app
+
+
+def main() -> None:
+    from dexverse.IL.dp3.config import DP3OnlineEvalConfig
+    from dexverse.IL.dp3.online_eval import eval_main
+
+    cfg = DP3OnlineEvalConfig(
+        ckpt=args.ckpt,
+        task=args.task,
+        output_dir=args.output_dir,
+        num_episodes=args.num_episodes,
+        max_steps=args.max_steps,
+        device=args.device,
+        replan_interval=args.replan_interval,
+        num_points=args.num_points,
+        observation_preset=args.observation_preset,
+        record_video=args.record_video,
+        video_camera=args.video_camera,
+        video_fps=args.video_fps,
+    )
+    if args.json_path is not None:
+        cfg.json_path = args.json_path
+    eval_main(cfg)
+
+
+if __name__ == "__main__":
+    main()
+    simulation_app.close()

--- a/scripts/dp3/train.py
+++ b/scripts/dp3/train.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+# Copyright (c) 2025-2026, The DexVerse Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Train a DP3 policy on DexVerse demonstrations.
+
+Usage:
+  python scripts/dp3/train.py \\
+      --hdf5_path outputs/dp3_graspPot.hdf5 \\
+      --output_dir runs/dp3_graspPot \\
+      --num_epochs 3000 \\
+      --batch_size 128
+"""
+from __future__ import annotations
+
+import argparse
+
+import _bootstrap  # noqa: F401
+
+
+def _parse_int_tuple(value: str) -> tuple[int, ...]:
+    items = [item.strip() for item in value.split(",") if item.strip()]
+    return tuple(int(item) for item in items)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Train DP3 on DexVerse demonstrations.")
+
+    # Dataset
+    parser.add_argument("--hdf5_path", type=str, required=True, help="DP3 HDF5 dataset path")
+    parser.add_argument("--val_ratio", type=float, default=0.1)
+    parser.add_argument("--horizon", type=int, default=16)
+    parser.add_argument("--n_obs_steps", type=int, default=2)
+    parser.add_argument("--n_action_steps", type=int, default=8)
+
+    # Training
+    parser.add_argument("--output_dir", type=str, required=True)
+    parser.add_argument("--batch_size", type=int, default=128)
+    parser.add_argument("--num_epochs", type=int, default=50)
+    parser.add_argument("--lr", type=float, default=1e-4)
+    parser.add_argument("--weight_decay", type=float, default=1e-6)
+    parser.add_argument("--use_ema", action="store_true", default=True)
+    parser.add_argument("--no_ema", action="store_true", default=False)
+    parser.add_argument("--grad_clip_norm", type=float, default=1.0)
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--device", type=str, default="cuda")
+    parser.add_argument("--num_workers", type=int, default=8)
+    parser.add_argument("--save_every_epochs", type=int, default=10)
+    parser.add_argument("--val_every", type=int, default=1)
+    parser.add_argument("--log_every", type=int, default=5)
+
+    # Policy architecture
+    parser.add_argument("--num_inference_steps", type=int, default=10)
+    parser.add_argument("--num_train_timesteps", type=int, default=100)
+    parser.add_argument("--encoder_output_dim", type=int, default=64)
+    parser.add_argument("--down_dims", type=str, default="512,1024,2048")
+    parser.add_argument("--condition_type", type=str, default="film")
+    parser.add_argument("--diffusion_step_embed_dim", type=int, default=128)
+
+    return parser.parse_args()
+
+
+def main() -> None:
+    from dexverse.IL.dp3.config import (
+        DP3DatasetConfig,
+        DP3PolicyConfig,
+        DP3TrainConfig,
+        PointcloudEncoderConfig,
+    )
+    from dexverse.IL.dp3.train import train_main
+
+    args = parse_args()
+
+    dataset_cfg = DP3DatasetConfig(
+        hdf5_path=args.hdf5_path,
+        horizon=args.horizon,
+        n_obs_steps=args.n_obs_steps,
+        n_action_steps=args.n_action_steps,
+        seed=args.seed,
+        val_ratio=args.val_ratio,
+    )
+
+    policy_cfg = DP3PolicyConfig(
+        horizon=args.horizon,
+        n_obs_steps=args.n_obs_steps,
+        n_action_steps=args.n_action_steps,
+        num_inference_steps=args.num_inference_steps,
+        num_train_timesteps=args.num_train_timesteps,
+        encoder_output_dim=args.encoder_output_dim,
+        down_dims=_parse_int_tuple(args.down_dims),
+        condition_type=args.condition_type,
+        diffusion_step_embed_dim=args.diffusion_step_embed_dim,
+        pointcloud_encoder_cfg=PointcloudEncoderConfig(),
+    )
+
+    train_cfg = DP3TrainConfig(
+        dataset=dataset_cfg,
+        policy=policy_cfg,
+        output_dir=args.output_dir,
+        batch_size=args.batch_size,
+        num_epochs=args.num_epochs,
+        lr=args.lr,
+        weight_decay=args.weight_decay,
+        use_ema=args.use_ema and not args.no_ema,
+        grad_clip_norm=args.grad_clip_norm,
+        seed=args.seed,
+        device=args.device,
+        num_workers=args.num_workers,
+        save_every_epochs=args.save_every_epochs,
+        val_every=args.val_every,
+        log_every=args.log_every,
+    )
+
+    train_main(train_cfg)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/dp3/visualize_dp3_dataset.py
+++ b/scripts/dp3/visualize_dp3_dataset.py
@@ -1,0 +1,364 @@
+#!/usr/bin/env python3
+# Copyright (c) 2025-2026, The DexVerse Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Visualize point clouds stored in a DP3 HDF5 dataset.
+
+Provides several visualization modes:
+  - Single frame: show point cloud at a specific timestep
+  - Animation: play through all frames of an episode
+  - Multi-frame: show multiple timesteps side-by-side
+  - Episode overview: show first/mid/last frames of an episode
+
+Usage:
+  # Show frame 0 of episode 0
+  python scripts/dp3/visualize_dp3_dataset.py --hdf5_file outputs/dp3_demo.hdf5
+
+  # Animate episode 2
+  python scripts/dp3/visualize_dp3_dataset.py --hdf5_file outputs/dp3_demo.hdf5 \\
+      --episode 2 --mode animate --interval 100
+
+  # Show 4 evenly-spaced frames from episode 0
+  python scripts/dp3/visualize_dp3_dataset.py --hdf5_file outputs/dp3_demo.hdf5 \\
+      --mode multi --num_frames 4
+
+  # Show overview of all episodes (first frame each)
+  python scripts/dp3/visualize_dp3_dataset.py --hdf5_file outputs/dp3_demo.hdf5 \\
+      --mode overview
+
+  # Save frame as image instead of showing interactively
+  python scripts/dp3/visualize_dp3_dataset.py --hdf5_file outputs/dp3_demo.hdf5 \\
+      --save_path outputs/pcd_vis.png
+"""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import h5py
+import numpy as np
+
+
+def _load_episode(hdf5_path: str, episode_idx: int) -> dict:
+    """Load a single episode from the DP3 HDF5 file."""
+    with h5py.File(hdf5_path, "r") as hf:
+        ep_name = f"episode_{episode_idx}"
+        if ep_name not in hf["data"]:
+            available = list(hf["data"].keys())
+            raise KeyError(f"Episode '{ep_name}' not found. Available: {available}")
+
+        ep = hf["data"][ep_name]
+        data = {
+            "point_cloud": ep["obs/point_cloud"][...],  # (T, N, 3)
+            "agent_pos": ep["obs/agent_pos"][...],  # (T, D)
+            "action": ep["action"][...],  # (T, Da)
+        }
+
+        # Load dataset-level metadata
+        data["bbox_min"] = hf.attrs.get("bbox_min", None)
+        data["bbox_max"] = hf.attrs.get("bbox_max", None)
+        data["task"] = hf.attrs.get("task", "unknown")
+        data["num_points"] = hf.attrs.get("num_points", data["point_cloud"].shape[1])
+        data["num_episodes"] = hf.attrs.get("num_episodes", 0)
+
+        return data
+
+
+def _load_metadata(hdf5_path: str) -> dict:
+    """Load dataset-level metadata."""
+    with h5py.File(hdf5_path, "r") as hf:
+        meta = {
+            "task": hf.attrs.get("task", "unknown"),
+            "num_episodes": hf.attrs.get("num_episodes", 0),
+            "num_points": hf.attrs.get("num_points", 0),
+            "bbox_min": hf.attrs.get("bbox_min", None),
+            "bbox_max": hf.attrs.get("bbox_max", None),
+        }
+        # Per-episode info
+        episodes = []
+        for ep_name in sorted(hf["data"].keys()):
+            ep = hf["data"][ep_name]
+            episodes.append({
+                "name": ep_name,
+                "num_steps": ep["obs/point_cloud"].shape[0],
+                "pcd_shape": ep["obs/point_cloud"].shape,
+                "agent_pos_dim": ep["obs/agent_pos"].shape[-1],
+                "action_dim": ep["action"].shape[-1],
+            })
+        meta["episodes"] = episodes
+        return meta
+
+
+def _plot_single_frame(
+    pcd: np.ndarray,
+    title: str = "",
+    bbox_min=None,
+    bbox_max=None,
+    ax=None,
+    color_by: str = "z",
+    point_size: float = 1.0,
+):
+    """Plot a single (N, 3) point cloud on a 3D axis."""
+    import matplotlib.pyplot as plt
+
+    if ax is None:
+        fig = plt.figure(figsize=(8, 8))
+        ax = fig.add_subplot(111, projection="3d")
+
+    x, y, z = pcd[:, 0], pcd[:, 1], pcd[:, 2]
+
+    # Color by coordinate
+    if color_by == "z":
+        colors = z
+    elif color_by == "x":
+        colors = x
+    elif color_by == "y":
+        colors = y
+    else:
+        colors = z
+
+    ax.scatter(x, y, z, c=colors, cmap="viridis", s=point_size, alpha=0.6)
+
+    # Draw bbox if provided
+    if bbox_min is not None and bbox_max is not None:
+        _draw_bbox(ax, bbox_min, bbox_max)
+
+    ax.set_xlabel("X")
+    ax.set_ylabel("Y")
+    ax.set_zlabel("Z")
+    ax.set_title(title)
+
+    # Equal aspect ratio
+    max_range = np.array([x.max() - x.min(), y.max() - y.min(), z.max() - z.min()]).max() / 2.0
+    mid_x = (x.max() + x.min()) * 0.5
+    mid_y = (y.max() + y.min()) * 0.5
+    mid_z = (z.max() + z.min()) * 0.5
+    ax.set_xlim(mid_x - max_range, mid_x + max_range)
+    ax.set_ylim(mid_y - max_range, mid_y + max_range)
+    ax.set_zlim(mid_z - max_range, mid_z + max_range)
+
+    return ax
+
+
+def _draw_bbox(ax, bbox_min, bbox_max):
+    """Draw a wireframe bounding box on a 3D axis."""
+    bmin = np.asarray(bbox_min)
+    bmax = np.asarray(bbox_max)
+    # 12 edges of a box
+    corners = np.array([
+        [bmin[0], bmin[1], bmin[2]],
+        [bmax[0], bmin[1], bmin[2]],
+        [bmax[0], bmax[1], bmin[2]],
+        [bmin[0], bmax[1], bmin[2]],
+        [bmin[0], bmin[1], bmax[2]],
+        [bmax[0], bmin[1], bmax[2]],
+        [bmax[0], bmax[1], bmax[2]],
+        [bmin[0], bmax[1], bmax[2]],
+    ])
+    edges = [
+        (0, 1),
+        (1, 2),
+        (2, 3),
+        (3, 0),  # bottom
+        (4, 5),
+        (5, 6),
+        (6, 7),
+        (7, 4),  # top
+        (0, 4),
+        (1, 5),
+        (2, 6),
+        (3, 7),  # vertical
+    ]
+    for i, j in edges:
+        ax.plot3D(*zip(corners[i], corners[j]), color="red", alpha=0.3, linewidth=0.8)
+
+
+def visualize_single(
+    hdf5_path: str, episode_idx: int, frame_idx: int, save_path: str | None = None, show_bbox: bool = True
+):
+    """Visualize a single frame from a DP3 dataset."""
+    import matplotlib.pyplot as plt
+
+    data = _load_episode(hdf5_path, episode_idx)
+    pcd = data["point_cloud"]  # (T, N, 3)
+    T = pcd.shape[0]
+    if frame_idx >= T:
+        raise ValueError(f"Frame {frame_idx} out of range (episode has {T} steps)")
+
+    fig = plt.figure(figsize=(10, 8))
+    ax = fig.add_subplot(111, projection="3d")
+    title = f"{data['task']} | Episode {episode_idx} | Frame {frame_idx}/{T-1} | {data['num_points']} pts"
+    bbox_min = data["bbox_min"] if show_bbox else None
+    bbox_max = data["bbox_max"] if show_bbox else None
+    _plot_single_frame(pcd[frame_idx], title=title, bbox_min=bbox_min, bbox_max=bbox_max, ax=ax)
+
+    if save_path:
+        plt.savefig(save_path, dpi=150, bbox_inches="tight")
+        print(f"Saved to {save_path}")
+    else:
+        plt.show()
+
+
+def visualize_animate(
+    hdf5_path: str, episode_idx: int, interval: int = 100, save_path: str | None = None, show_bbox: bool = True
+):
+    """Animate through all frames of an episode."""
+    import matplotlib.pyplot as plt
+    from matplotlib.animation import FuncAnimation
+
+    data = _load_episode(hdf5_path, episode_idx)
+    pcd = data["point_cloud"]  # (T, N, 3)
+    T = pcd.shape[0]
+    bbox_min = data["bbox_min"] if show_bbox else None
+    bbox_max = data["bbox_max"] if show_bbox else None
+
+    fig = plt.figure(figsize=(10, 8))
+    ax = fig.add_subplot(111, projection="3d")
+
+    def update(frame_idx):
+        ax.cla()
+        title = f"{data['task']} | Episode {episode_idx} | Frame {frame_idx}/{T-1} | {data['num_points']} pts"
+        _plot_single_frame(pcd[frame_idx], title=title, bbox_min=bbox_min, bbox_max=bbox_max, ax=ax, point_size=1.5)
+
+    anim = FuncAnimation(fig, update, frames=T, interval=interval, repeat=True)
+
+    if save_path:
+        if save_path.endswith(".gif"):
+            anim.save(save_path, writer="pillow", fps=1000 // interval)
+        else:
+            anim.save(save_path, fps=1000 // interval)
+        print(f"Saved animation to {save_path}")
+    else:
+        plt.show()
+
+
+def visualize_multi(
+    hdf5_path: str, episode_idx: int, num_frames: int = 4, save_path: str | None = None, show_bbox: bool = True
+):
+    """Show multiple evenly-spaced frames side by side."""
+    import matplotlib.pyplot as plt
+
+    data = _load_episode(hdf5_path, episode_idx)
+    pcd = data["point_cloud"]  # (T, N, 3)
+    T = pcd.shape[0]
+    bbox_min = data["bbox_min"] if show_bbox else None
+    bbox_max = data["bbox_max"] if show_bbox else None
+
+    frame_indices = np.linspace(0, T - 1, num_frames, dtype=int)
+
+    fig = plt.figure(figsize=(5 * num_frames, 5))
+    fig.suptitle(f"{data['task']} | Episode {episode_idx} | {data['num_points']} pts", fontsize=14)
+
+    for i, fi in enumerate(frame_indices):
+        ax = fig.add_subplot(1, num_frames, i + 1, projection="3d")
+        _plot_single_frame(pcd[fi], title=f"Frame {fi}", bbox_min=bbox_min, bbox_max=bbox_max, ax=ax, point_size=0.5)
+
+    plt.tight_layout()
+    if save_path:
+        plt.savefig(save_path, dpi=150, bbox_inches="tight")
+        print(f"Saved to {save_path}")
+    else:
+        plt.show()
+
+
+def visualize_overview(hdf5_path: str, save_path: str | None = None, max_episodes: int = 16):
+    """Show first frame of each episode in a grid."""
+    import matplotlib.pyplot as plt
+
+    meta = _load_metadata(hdf5_path)
+    num_eps = min(len(meta["episodes"]), max_episodes)
+
+    cols = min(4, num_eps)
+    rows = (num_eps + cols - 1) // cols
+
+    fig = plt.figure(figsize=(5 * cols, 5 * rows))
+    fig.suptitle(f"{meta['task']} | {meta['num_episodes']} episodes | {meta['num_points']} pts", fontsize=14)
+
+    for i in range(num_eps):
+        data = _load_episode(hdf5_path, i)
+        pcd = data["point_cloud"][0]  # first frame
+        ax = fig.add_subplot(rows, cols, i + 1, projection="3d")
+        _plot_single_frame(pcd, title=f"Ep {i} (T={data['point_cloud'].shape[0]})", ax=ax, point_size=0.5)
+
+    plt.tight_layout()
+    if save_path:
+        plt.savefig(save_path, dpi=150, bbox_inches="tight")
+        print(f"Saved to {save_path}")
+    else:
+        plt.show()
+
+
+def print_dataset_info(hdf5_path: str):
+    """Print dataset metadata and per-episode statistics."""
+    meta = _load_metadata(hdf5_path)
+    print(f"Dataset: {hdf5_path}")
+    print(f"  Task: {meta['task']}")
+    print(f"  Num episodes: {meta['num_episodes']}")
+    print(f"  Points per frame: {meta['num_points']}")
+    if meta["bbox_min"] is not None:
+        print(f"  Workspace bbox min: {meta['bbox_min']}")
+        print(f"  Workspace bbox max: {meta['bbox_max']}")
+    print(f"\n  {'Episode':<12} {'Steps':<8} {'PCD shape':<20} {'AgentPos':<12} {'Action':<10}")
+    print(f"  {'-'*62}")
+    for ep in meta["episodes"]:
+        print(
+            f"  {ep['name']:<12} {ep['num_steps']:<8} {str(ep['pcd_shape']):<20} "
+            f"{ep['agent_pos_dim']:<12} {ep['action_dim']:<10}"
+        )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Visualize point clouds from a DP3 HDF5 dataset.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("--hdf5_file", type=str, required=True, help="Path to the DP3 HDF5 dataset")
+    parser.add_argument("--episode", type=int, default=0, help="Episode index to visualize (default: 0)")
+    parser.add_argument("--frame", type=int, default=0, help="Frame index for 'single' mode (default: 0)")
+    parser.add_argument(
+        "--mode",
+        type=str,
+        default="single",
+        choices=["single", "animate", "multi", "overview", "info"],
+        help="Visualization mode (default: single)",
+    )
+    parser.add_argument("--num_frames", type=int, default=4, help="Number of frames for 'multi' mode (default: 4)")
+    parser.add_argument(
+        "--interval", type=int, default=100, help="Animation interval in ms for 'animate' mode (default: 100)"
+    )
+    parser.add_argument(
+        "--save_path", type=str, default=None, help="Save visualization to file instead of showing interactively"
+    )
+    parser.add_argument(
+        "--no_bbox", action="store_true", default=False, help="Hide the workspace bounding box wireframe"
+    )
+    parser.add_argument(
+        "--max_episodes", type=int, default=16, help="Max episodes to show in 'overview' mode (default: 16)"
+    )
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    show_bbox = not args.no_bbox
+
+    if args.mode == "info":
+        print_dataset_info(args.hdf5_file)
+    elif args.mode == "single":
+        visualize_single(args.hdf5_file, args.episode, args.frame, save_path=args.save_path, show_bbox=show_bbox)
+    elif args.mode == "animate":
+        visualize_animate(
+            args.hdf5_file, args.episode, interval=args.interval, save_path=args.save_path, show_bbox=show_bbox
+        )
+    elif args.mode == "multi":
+        visualize_multi(
+            args.hdf5_file, args.episode, num_frames=args.num_frames, save_path=args.save_path, show_bbox=show_bbox
+        )
+    elif args.mode == "overview":
+        visualize_overview(args.hdf5_file, save_path=args.save_path, max_episodes=args.max_episodes)
+
+
+if __name__ == "__main__":
+    main()

--- a/source/dexverse/dexverse/IL/__init__.py
+++ b/source/dexverse/dexverse/IL/__init__.py
@@ -1,0 +1,6 @@
+# Copyright (c) 2025-2026, The DexVerse Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Imitation learning modules for DexVerse."""

--- a/source/dexverse/dexverse/IL/dp3/README.md
+++ b/source/dexverse/dexverse/IL/dp3/README.md
@@ -1,0 +1,238 @@
+# DexVerse DP3 Baseline
+
+This package adds a DexVerse imitation-learning baseline based on 3D Diffusion Policy (DP3). DP3 conditions on a table-cropped point cloud plus proprioception and predicts temporally chunked robot actions with a diffusion policy.
+
+The implementation is self-contained under `dexverse.IL.dp3`. The original DP3 algorithm components are vendored in `dp3_core/` and adapted from [3D-Diffusion-Policy](https://github.com/YanjieZe/3D-Diffusion-Policy), so users do not need to install the upstream package.
+
+## Layout
+
+```text
+source/dexverse/dexverse/IL/dp3/
+|-- config.py          # Dataclass configs for dataset, policy, training, and eval
+|-- dataset.py         # HDF5 dataset loader and windowed sequence sampler
+|-- model.py           # DP3 policy, scheduler, EMA, and checkpoint helpers
+|-- train.py           # Training loop
+|-- runner.py          # Closed-loop inference runner
+|-- online_eval.py     # Online simulator evaluation
+`-- dp3_core/          # Vendored DP3 network, normalizer, EMA, PointNet, and utils
+
+scripts/dp3/
+|-- convert_demos_to_dp3.py      # create_demo_files_sequential.py HDF5 -> DP3 HDF5
+|-- train.py                     # Training CLI
+|-- eval_online.py               # Online evaluation CLI
+`-- visualize_dp3_dataset.py     # Dataset inspection and point cloud visualization
+```
+
+## Inputs and Data Format
+
+DP3 expects HDF5 datasets produced by `scripts/dp3/convert_demos_to_dp3.py`:
+
+```text
+dp3_dataset.hdf5
+|-- attrs:
+|   |-- task
+|   |-- observation_preset       # the preset used to record demos (e.g. "pointcloud")
+|   |-- pointcloud_term          # "camera_point_cloud_w" or "merged_point_cloud_w"
+|   |-- num_points
+|   |-- bbox_min                 # workspace AABB over valid points
+|   |-- bbox_max
+|   |-- source_h5
+|   `-- num_episodes
+`-- data/
+    `-- episode_0/
+        |-- obs/
+        |   |-- point_cloud      # (T, num_points, 3), world frame
+        |   `-- agent_pos        # (T, proprio_dim)
+        `-- action               # (T, action_dim)
+```
+
+The point cloud is back-projected from the `third_person_camera` depth in DexVerse, cropped to the table workspace by `mdp.camera_point_cloud_w`, and then per-frame downsampled to `num_points` with farthest-point sampling (uses `pytorch3d` when available, falls back to a built-in iterative FPS otherwise).
+
+`agent_pos` is the concatenation of every term in the env's `proprio` observation group (sorted by term name). Under the `pointcloud` observation preset there is a single term (`joint_pos`) and `flatten_history_dim=True` already folds the 3-frame proprio history into the trailing dim, so `proprio_dim` is `history_length * num_joints`.
+
+The dataset loader fits a `LinearNormalizer` over point clouds, proprioception, and actions from the training split. `num_points`, `proprio_dim`, and `action_dim` are derived from the dataset at runtime, so changing any of them in the converter requires no policy-config changes.
+
+## Setup
+
+Run commands from the repository root with the IsaacLab/DexVerse Python environment activated:
+
+```bash
+python -m pip install -e "source/dexverse[dp3]"
+# (equivalent: python -m pip install -e source/dexverse diffusers einops h5py omegaconf termcolor)
+```
+
+Optional packages:
+
+```bash
+# Faster farthest-point sampling, if compatible with your CUDA/PyTorch install.
+python -m pip install pytorch3d
+
+# Only needed for scripts/dp3/visualize_dp3_dataset.py.
+python -m pip install matplotlib pillow
+```
+
+## End-to-End Usage
+
+### 0. Fetch assets and teleop demonstrations
+
+The DexVerse Hugging Face dataset is gated — log in once and accept the
+terms on the dataset page before running these:
+
+```bash
+huggingface-cli login                          # one-time
+python scripts/asset_tools/download_assets.py              # USD assets into source/dexverse/dexverse/assets/
+python scripts/demo_tools/download_demos.py --task functional/Dexverse-GraspPan-v0
+# (or --category functional for the whole category, or --all for everything)
+```
+
+Demos land under `source/dexverse/demonstrations/<category>/<task>/*.pkl`. These are
+teleop trajectories (joint-target actions + per-episode initial scene state) and do
+**not** ship vision data — that gets regenerated in step 1.
+
+### 1. Replay demos headlessly and capture point clouds
+
+`scripts/demo_tools/create_demo_files_sequential.py` is the canonical headless replayer: it rolls the
+recorded actions through the simulator one episode at a time, captures the active
+observation groups, and writes one HDF5 per task with the layout
+`data/demo_<i>/obs/<group>/<term>`.
+
+```bash
+python scripts/demo_tools/create_demo_files_sequential.py \
+    --task functional/Dexverse-GraspPan-v0 \
+    --obs-groups pointcloud \
+    --output-dir outputs/demos_h5
+```
+
+`--obs-groups pointcloud` applies the `pointcloud` observation preset (single
+front-view camera; enables `policy`, `proprio`, `goal`, `pointcloud`; 3-frame
+`policy` / `proprio` history). For the 3-view variant, pass `--obs-groups 3view_pointcloud`
+instead. `--enable_cameras` is auto-set by `create_demo_files_sequential.py` when a
+camera-driven group/preset is selected.
+
+The output file ends in `.pointcloud.seq.demo.h5` (the preset name is mixed into
+the filename) and the root attribute `observation_preset` records which preset
+was used, so downstream tools can spawn the env with the same obs space.
+
+### 2. Convert to DP3 HDF5
+
+```bash
+python scripts/dp3/convert_demos_to_dp3.py \
+    --input_h5 outputs/demos_h5/functional/Dexverse-GraspPan-v0/Dexverse-GraspPan-v0.pointcloud.seq.demo.h5 \
+    --out_file outputs/dp3_graspPan.hdf5 \
+    --num_points 512
+```
+
+The converter auto-detects whether the pointcloud term is `camera_point_cloud_w`
+(single-view) or `merged_point_cloud_w` (3-view) and stores it in the root
+attribute `pointcloud_term`. By default, demos marked `success=False` are
+dropped; pass `--include_failed` to keep them.
+
+### 3. Inspect the converted dataset
+
+```bash
+python scripts/dp3/visualize_dp3_dataset.py --hdf5_file outputs/dp3_graspPan.hdf5 --mode info
+python scripts/dp3/visualize_dp3_dataset.py --hdf5_file outputs/dp3_graspPan.hdf5 --episode 0 --frame 0
+```
+
+### 4. Train
+
+```bash
+python scripts/dp3/train.py \
+    --hdf5_path outputs/dp3_graspPan.hdf5 \
+    --output_dir runs/dp3_graspPan \
+    --num_epochs 3000 \
+    --batch_size 128 \
+    --horizon 16 \
+    --n_obs_steps 2 \
+    --n_action_steps 8 \
+    --device cuda
+```
+
+Training writes:
+
+- `last.pt`: checkpoint from the latest epoch
+- `best.pt`: checkpoint with the best nonzero validation loss
+- `epoch_XXXX.pt`: periodic checkpoints controlled by `--save_every_epochs`
+- `metrics.json`: config, per-epoch losses, and summary metrics
+
+### 5. Evaluate online in simulation
+
+```bash
+python scripts/dp3/eval_online.py \
+    --ckpt runs/dp3_graspPan/best.pt \
+    --task Dexverse-GraspPan-v0 \
+    --observation_preset pointcloud \
+    --output_dir runs/dp3_graspPan_eval \
+    --num_episodes 20 \
+    --max_steps 500 \
+    --replan_interval 8
+```
+
+`--enable_cameras` is auto-set when the preset includes a camera-driven group
+(`pointcloud` / `3view_pointcloud`). Pass `--no_auto_enable_cameras` if you need
+to override that. For template tasks, pass the template JSON through `--json_path`.
+
+> The preset used at eval time **must** match the preset that recorded the demos
+> in step 1 (e.g. both `pointcloud`, or both `3view_pointcloud`). The obs preset
+> controls history stacking on `policy` / `proprio`, so a mismatch silently
+> changes `proprio_dim`.
+
+## Programmatic API
+
+Training can be called directly:
+
+```python
+from dexverse.IL.dp3.config import DP3DatasetConfig, DP3PolicyConfig, DP3TrainConfig
+from dexverse.IL.dp3.train import train_main
+
+cfg = DP3TrainConfig(
+    dataset=DP3DatasetConfig(hdf5_path="outputs/dp3_graspPan.hdf5"),
+    policy=DP3PolicyConfig(),
+    output_dir="runs/dp3_graspPan",
+    num_epochs=3000,
+    batch_size=128,
+)
+summary = train_main(cfg)
+```
+
+For closed-loop inference from an existing environment:
+
+```python
+from dexverse.IL.dp3.runner import load_runner_from_checkpoint
+
+runner, ckpt = load_runner_from_checkpoint(
+    "runs/dp3_graspPan/best.pt",
+    device="cuda",
+    replan_interval=8,
+)
+
+obs, _ = env.reset()       # env constructed with observation_preset="pointcloud"
+runner.reset()
+action = runner.act(obs)   # reads obs["pointcloud"] and obs["proprio"]
+```
+
+`runner.act(obs)` expects an observation dict containing the `pointcloud` and
+`proprio` groups as produced by the `pointcloud` / `3view_pointcloud` preset.
+
+## Key Configuration
+
+Dataset options are in `DP3DatasetConfig`:
+
+- `hdf5_path`: converted DP3 HDF5 dataset
+- `horizon`: full sequence length used by the diffusion model
+- `n_obs_steps`: number of observation frames used for conditioning
+- `n_action_steps`: number of predicted actions per policy call
+- `val_ratio`: episode-level validation split
+
+Policy options are in `DP3PolicyConfig`:
+
+- `num_points`: point cloud size, filled from the dataset at runtime
+- `proprio_dim` and `action_dim`: filled from the dataset at runtime
+- `num_train_timesteps`: DDIM training noise steps
+- `num_inference_steps`: DDIM sampling steps at inference
+- `encoder_output_dim`: PointNet feature size
+- `down_dims`, `condition_type`, and diffusion UNet settings
+
+Evaluation options are in `DP3OnlineEvalConfig`, including checkpoint path,
+task, episode count, maximum rollout length, device, `replan_interval`, and
+`observation_preset`.

--- a/source/dexverse/dexverse/IL/dp3/__init__.py
+++ b/source/dexverse/dexverse/IL/dp3/__init__.py
@@ -1,0 +1,14 @@
+# Copyright (c) 2025-2026, The DexVerse Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# 3D Diffusion Policy (DP3) integration for DexVerse.
+#
+# This package provides the training, evaluation, and inference pipeline for
+# using 3D Diffusion Policy with DexVerse environments.
+#
+# The core algorithm components (policy network, point cloud encoder, diffusion
+# model, normalizer, etc.) are vendored in the dp3_core/ sub-package, adapted
+# from the original 3D-Diffusion-Policy repository:
+#   https://github.com/YanjieZe/3D-Diffusion-Policy

--- a/source/dexverse/dexverse/IL/dp3/config.py
+++ b/source/dexverse/dexverse/IL/dp3/config.py
@@ -1,0 +1,121 @@
+# Copyright (c) 2025-2026, The DexVerse Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Configuration dataclasses for the DP3 integration."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass
+class PointcloudEncoderConfig:
+    """PointNet encoder configuration."""
+
+    in_channels: int = 3
+    out_channels: int = 64
+    use_layernorm: bool = True
+    final_norm: str = "layernorm"
+    normal_channel: bool = False
+
+
+@dataclass
+class DP3PolicyConfig:
+    """DP3 policy network configuration."""
+
+    # Observation dimensions (derived from dataset at runtime)
+    num_points: int = 512
+    proprio_dim: int = 0
+    action_dim: int = 0
+
+    # Temporal horizons
+    horizon: int = 16
+    n_obs_steps: int = 2
+    n_action_steps: int = 8
+
+    # Diffusion
+    num_inference_steps: int = 10
+    num_train_timesteps: int = 100
+
+    # Architecture
+    encoder_output_dim: int = 64
+    diffusion_step_embed_dim: int = 128
+    down_dims: tuple[int, ...] = (512, 1024, 2048)
+    kernel_size: int = 5
+    n_groups: int = 8
+    condition_type: str = "film"
+    use_down_condition: bool = True
+    use_mid_condition: bool = True
+    use_up_condition: bool = True
+    use_pc_color: bool = False
+    pointnet_type: str = "pointnet"
+
+    # PointNet encoder
+    pointcloud_encoder_cfg: PointcloudEncoderConfig = field(default_factory=PointcloudEncoderConfig)
+
+
+@dataclass
+class DP3DatasetConfig:
+    """Configuration for the DP3 dataset loader."""
+
+    hdf5_path: str = ""
+    horizon: int = 16
+    n_obs_steps: int = 2
+    n_action_steps: int = 8
+    seed: int = 42
+    val_ratio: float = 0.1
+
+
+@dataclass
+class DP3TrainConfig:
+    """Training loop configuration."""
+
+    # Dataset
+    dataset: DP3DatasetConfig = field(default_factory=DP3DatasetConfig)
+
+    # Policy (dimensions filled from dataset at runtime)
+    policy: DP3PolicyConfig = field(default_factory=DP3PolicyConfig)
+
+    # Training
+    output_dir: str = "runs/dp3"
+    batch_size: int = 128
+    num_epochs: int = 50
+    lr: float = 1e-4
+    weight_decay: float = 1e-6
+    betas: tuple[float, float] = (0.95, 0.999)
+    use_ema: bool = True
+    grad_clip_norm: float = 1.0
+    seed: int = 42
+    device: str = "cuda"
+    num_workers: int = 8
+
+    # Logging / checkpointing
+    save_every_epochs: int = 10
+    val_every: int = 1
+    log_every: int = 5
+
+
+@dataclass
+class DP3OnlineEvalConfig:
+    """Online evaluation configuration."""
+
+    ckpt: str = ""
+    task: str = ""
+    output_dir: str = "runs/dp3_eval_online"
+    num_episodes: int = 20
+    max_steps: int = 500
+    device: str = "cuda"
+    replan_interval: int = 8
+    num_points: int = 512
+    json_path: str | None = None
+    # Observation preset applied to the env cfg before gym.make(). Must match
+    # the preset used when training data was generated. "pointcloud" enables
+    # {policy, proprio, goal, pointcloud}; "3view_pointcloud" swaps the
+    # single-source point cloud for a 3-view merged cloud.
+    observation_preset: str = "pointcloud"
+
+    # Video recording — write one MP4 per episode from a named camera sensor.
+    record_video: bool = False
+    video_camera: str = "third_person_camera"
+    video_fps: int = 30

--- a/source/dexverse/dexverse/IL/dp3/dataset.py
+++ b/source/dexverse/dexverse/IL/dp3/dataset.py
@@ -1,0 +1,191 @@
+# Copyright (c) 2025-2026, The DexVerse Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""DP3 dataset loader for DexVerse.
+
+Loads HDF5 files produced by ``scripts/dp3/convert_demos_to_dp3.py`` and
+provides windowed sequence sampling compatible with the DP3 policy's
+``compute_loss`` and ``predict_action`` interfaces.
+
+Each sample returns::
+
+    {
+        "obs": {
+            "point_cloud": Tensor (horizon, num_points, 3),
+            "agent_pos":   Tensor (horizon, proprio_dim),
+        },
+        "action": Tensor (horizon, action_dim),
+    }
+"""
+from __future__ import annotations
+
+import copy
+from typing import Dict
+
+import h5py
+import numpy as np
+import torch
+from torch.utils.data import Dataset
+
+from .config import DP3DatasetConfig
+from .dp3_core.normalizer import LinearNormalizer
+
+
+class DexVerseDP3Dataset(Dataset):
+    """Dataset for DP3 training on DexVerse demonstrations.
+
+    Loads all episodes into memory from an HDF5 file and provides windowed
+    sequence sampling with edge-padding, matching the convention used by DP3.
+    """
+
+    def __init__(self, cfg: DP3DatasetConfig, split: str = "train"):
+        self.cfg = cfg
+        self.split = split
+        self.horizon = cfg.horizon
+        self.pad_before = cfg.n_obs_steps - 1
+        self.pad_after = cfg.n_action_steps - 1
+
+        # Load all episodes from HDF5 into memory
+        self.episodes, self.metadata = self._load_hdf5(cfg.hdf5_path)
+
+        # Train/val split by episode
+        self._all_episode_indices = list(range(len(self.episodes)))
+        self._train_indices, self._val_indices = self._split_episodes(len(self.episodes), cfg.val_ratio, cfg.seed)
+        self._active_indices = self._train_indices if split == "train" else self._val_indices
+
+        # Build flat sample index: list of (episode_idx, start_t)
+        self._sample_indices = self._build_sample_indices()
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    @property
+    def num_points(self) -> int:
+        return int(self.metadata.get("num_points", self.episodes[0]["point_cloud"].shape[1]))
+
+    @property
+    def proprio_dim(self) -> int:
+        return int(self.episodes[0]["agent_pos"].shape[-1])
+
+    @property
+    def action_dim(self) -> int:
+        return int(self.episodes[0]["action"].shape[-1])
+
+    @property
+    def bbox_min(self) -> np.ndarray | None:
+        return self.metadata.get("bbox_min")
+
+    @property
+    def bbox_max(self) -> np.ndarray | None:
+        return self.metadata.get("bbox_max")
+
+    def get_normalizer(self, mode: str = "limits") -> LinearNormalizer:
+        """Fit a LinearNormalizer on the active (train) split data."""
+        all_pcd = []
+        all_agent_pos = []
+        all_action = []
+        for idx in self._active_indices:
+            ep = self.episodes[idx]
+            all_pcd.append(ep["point_cloud"].reshape(-1, 3))
+            all_agent_pos.append(ep["agent_pos"])
+            all_action.append(ep["action"])
+
+        data = {
+            "point_cloud": np.concatenate(all_pcd, axis=0),
+            "agent_pos": np.concatenate(all_agent_pos, axis=0),
+            "action": np.concatenate(all_action, axis=0),
+        }
+        normalizer = LinearNormalizer()
+        normalizer.fit(data=data, last_n_dims=1, mode=mode)
+        return normalizer
+
+    def get_validation_dataset(self) -> "DexVerseDP3Dataset":
+        """Return a copy of this dataset pointing to the validation split."""
+        val_ds = copy.copy(self)
+        val_ds.split = "val"
+        val_ds._active_indices = self._val_indices
+        val_ds._sample_indices = val_ds._build_sample_indices()
+        return val_ds
+
+    # ------------------------------------------------------------------
+    # Dataset interface
+    # ------------------------------------------------------------------
+
+    def __len__(self) -> int:
+        return len(self._sample_indices)
+
+    def __getitem__(self, idx: int) -> Dict[str, torch.Tensor]:
+        ep_idx, start_t = self._sample_indices[idx]
+        ep = self.episodes[ep_idx]
+        T_ep = ep["point_cloud"].shape[0]
+
+        # Gather indices for the full horizon window, clamping at episode edges
+        indices = []
+        for t in range(start_t - self.pad_before, start_t - self.pad_before + self.horizon):
+            indices.append(np.clip(t, 0, T_ep - 1))
+
+        pcd = ep["point_cloud"][indices]  # (horizon, N, 3)
+        agent_pos = ep["agent_pos"][indices]  # (horizon, D)
+        action = ep["action"][indices]  # (horizon, Da)
+
+        return {
+            "obs": {
+                "point_cloud": torch.from_numpy(pcd).float(),
+                "agent_pos": torch.from_numpy(agent_pos).float(),
+            },
+            "action": torch.from_numpy(action).float(),
+        }
+
+    # ------------------------------------------------------------------
+    # Internal
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _load_hdf5(hdf5_path: str) -> tuple[list[dict], dict]:
+        """Load all episodes and metadata from HDF5."""
+        episodes = []
+        with h5py.File(hdf5_path, "r") as hf:
+            metadata = {
+                "task": hf.attrs.get("task", "unknown"),
+                "num_points": int(hf.attrs.get("num_points", 0)),
+                "bbox_min": hf.attrs.get("bbox_min"),
+                "bbox_max": hf.attrs.get("bbox_max"),
+            }
+            for ep_name in sorted(hf["data"].keys()):
+                ep = hf["data"][ep_name]
+                episodes.append({
+                    "point_cloud": ep["obs/point_cloud"][...],  # (T, N, 3)
+                    "agent_pos": ep["obs/agent_pos"][...],  # (T, D)
+                    "action": ep["action"][...],  # (T, Da)
+                })
+        if not episodes:
+            raise ValueError(f"No episodes found in {hdf5_path}")
+        return episodes, metadata
+
+    @staticmethod
+    def _split_episodes(n_episodes: int, val_ratio: float, seed: int) -> tuple[list[int], list[int]]:
+        """Split episode indices into train/val sets."""
+        rng = np.random.RandomState(seed)
+        perm = rng.permutation(n_episodes)
+        val_count = max(1, int(round(n_episodes * val_ratio)))
+        # Ensure at least 1 training episode
+        val_count = min(val_count, n_episodes - 1)
+        val_indices = sorted(perm[:val_count].tolist())
+        train_indices = sorted(perm[val_count:].tolist())
+        return train_indices, val_indices
+
+    def _build_sample_indices(self) -> list[tuple[int, int]]:
+        """Build a flat list of (episode_idx, start_timestep) pairs.
+
+        Each timestep in each active episode becomes one sample. The windowed
+        __getitem__ handles edge-padding via clamping.
+        """
+        indices = []
+        for ep_idx in self._active_indices:
+            T_ep = self.episodes[ep_idx]["point_cloud"].shape[0]
+            for t in range(T_ep):
+                indices.append((ep_idx, t))
+        return indices

--- a/source/dexverse/dexverse/IL/dp3/dp3_core/__init__.py
+++ b/source/dexverse/dexverse/IL/dp3/dp3_core/__init__.py
@@ -1,0 +1,13 @@
+# Copyright (c) 2025-2026, The DexVerse Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# dp3_core: self-contained copy of the core components of 3D Diffusion Policy.
+#
+# Adapted from: https://github.com/YanjieZe/3D-Diffusion-Policy
+# Original package: diffusion_policy_3d
+#
+# All source files in this directory have been copied from the original DP3
+# repository. Their internal imports have been rewritten to use relative
+# imports within this package.

--- a/source/dexverse/dexverse/IL/dp3/dp3_core/base_policy.py
+++ b/source/dexverse/dexverse/IL/dp3/dp3_core/base_policy.py
@@ -1,0 +1,34 @@
+# Copyright (c) 2025-2026, The DexVerse Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# Adapted from 3D-Diffusion-Policy (https://github.com/YanjieZe/3D-Diffusion-Policy)
+# Original file: diffusion_policy_3d/policy/base_policy.py
+from typing import Dict
+
+import torch
+
+from .module_attr_mixin import ModuleAttrMixin
+from .normalizer import LinearNormalizer
+
+
+class BasePolicy(ModuleAttrMixin):
+    # init accepts keyword argument shape_meta, see config/task/*_image.yaml
+
+    def predict_action(self, obs_dict: Dict[str, torch.Tensor]) -> Dict[str, torch.Tensor]:
+        """
+        obs_dict:
+            str: B,To,*
+        return: B,Ta,Da
+        """
+        raise NotImplementedError()
+
+    # reset state for stateful policies
+    def reset(self):
+        pass
+
+    # ========== training ===========
+    # no standard training interface except setting normalizer
+    def set_normalizer(self, normalizer: LinearNormalizer):
+        raise NotImplementedError()

--- a/source/dexverse/dexverse/IL/dp3/dp3_core/conditional_unet1d.py
+++ b/source/dexverse/dexverse/IL/dp3/dp3_core/conditional_unet1d.py
@@ -1,0 +1,370 @@
+# Copyright (c) 2025-2026, The DexVerse Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+import logging
+
+# Adapted from 3D-Diffusion-Policy (https://github.com/YanjieZe/3D-Diffusion-Policy)
+# Original file: diffusion_policy_3d/model/diffusion/conditional_unet1d.py
+from typing import Union
+
+import einops
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from einops.layers.torch import Rearrange
+from termcolor import cprint
+
+from .conv1d_components import Conv1dBlock, Downsample1d, Upsample1d
+from .positional_embedding import SinusoidalPosEmb
+
+logger = logging.getLogger(__name__)
+
+
+class CrossAttention(nn.Module):
+    def __init__(self, in_dim, cond_dim, out_dim):
+        super().__init__()
+        self.query_proj = nn.Linear(in_dim, out_dim)
+        self.key_proj = nn.Linear(cond_dim, out_dim)
+        self.value_proj = nn.Linear(cond_dim, out_dim)
+
+    def forward(self, x, cond):
+        # x: [batch_size, t_act, in_dim]
+        # cond: [batch_size, t_obs, cond_dim]
+
+        # Project x and cond to query, key, and value
+        query = self.query_proj(x)  # [batch_size, horizon, out_dim]
+        key = self.key_proj(cond)  # [batch_size, horizon, out_dim]
+        value = self.value_proj(cond)  # [batch_size, horizon, out_dim]
+
+        # Compute attention
+        attn_weights = torch.matmul(query, key.transpose(-2, -1))  # [batch_size, horizon, horizon]
+        attn_weights = F.softmax(attn_weights, dim=-1)
+
+        # Apply attention
+        attn_output = torch.matmul(attn_weights, value)  # [batch_size, horizon, out_dim]
+
+        return attn_output
+
+
+class ConditionalResidualBlock1D(nn.Module):
+
+    def __init__(self, in_channels, out_channels, cond_dim, kernel_size=3, n_groups=8, condition_type="film"):
+        super().__init__()
+
+        self.blocks = nn.ModuleList([
+            Conv1dBlock(in_channels, out_channels, kernel_size, n_groups=n_groups),
+            Conv1dBlock(out_channels, out_channels, kernel_size, n_groups=n_groups),
+        ])
+
+        self.condition_type = condition_type
+
+        cond_channels = out_channels
+        if condition_type == "film":  # FiLM modulation https://arxiv.org/abs/1709.07871
+            # predicts per-channel scale and bias
+            cond_channels = out_channels * 2
+            self.cond_encoder = nn.Sequential(
+                nn.Mish(),
+                nn.Linear(cond_dim, cond_channels),
+                Rearrange("batch t -> batch t 1"),
+            )
+        elif condition_type == "add":
+            self.cond_encoder = nn.Sequential(
+                nn.Mish(),
+                nn.Linear(cond_dim, out_channels),
+                Rearrange("batch t -> batch t 1"),
+            )
+        elif condition_type == "cross_attention_add":
+            self.cond_encoder = CrossAttention(in_channels, cond_dim, out_channels)
+        elif condition_type == "cross_attention_film":
+            cond_channels = out_channels * 2
+            self.cond_encoder = CrossAttention(in_channels, cond_dim, cond_channels)
+        elif condition_type == "mlp_film":
+            cond_channels = out_channels * 2
+            self.cond_encoder = nn.Sequential(
+                nn.Mish(),
+                nn.Linear(cond_dim, cond_dim),
+                nn.Mish(),
+                nn.Linear(cond_dim, cond_channels),
+                Rearrange("batch t -> batch t 1"),
+            )
+        else:
+            raise NotImplementedError(f"condition_type {condition_type} not implemented")
+
+        self.out_channels = out_channels
+        # make sure dimensions compatible
+        self.residual_conv = nn.Conv1d(in_channels, out_channels, 1) if in_channels != out_channels else nn.Identity()
+
+    def forward(self, x, cond=None):
+        """
+        x : [ batch_size x in_channels x horizon ]
+        cond : [ batch_size x cond_dim]
+
+        returns:
+        out : [ batch_size x out_channels x horizon ]
+        """
+        out = self.blocks[0](x)
+        if cond is not None:
+            if self.condition_type == "film":
+                embed = self.cond_encoder(cond)
+                embed = embed.reshape(embed.shape[0], 2, self.out_channels, 1)
+                scale = embed[:, 0, ...]
+                bias = embed[:, 1, ...]
+                out = scale * out + bias
+            elif self.condition_type == "add":
+                embed = self.cond_encoder(cond)
+                out = out + embed
+            elif self.condition_type == "cross_attention_add":
+                embed = self.cond_encoder(x.permute(0, 2, 1), cond)
+                embed = embed.permute(0, 2, 1)  # [batch_size, out_channels, horizon]
+                out = out + embed
+            elif self.condition_type == "cross_attention_film":
+                embed = self.cond_encoder(x.permute(0, 2, 1), cond)
+                embed = embed.permute(0, 2, 1)
+                embed = embed.reshape(embed.shape[0], 2, self.out_channels, -1)
+                scale = embed[:, 0, ...]
+                bias = embed[:, 1, ...]
+                out = scale * out + bias
+            elif self.condition_type == "mlp_film":
+                embed = self.cond_encoder(cond)
+                embed = embed.reshape(embed.shape[0], 2, self.out_channels, -1)
+                scale = embed[:, 0, ...]
+                bias = embed[:, 1, ...]
+                out = scale * out + bias
+            else:
+                raise NotImplementedError(f"condition_type {self.condition_type} not implemented")
+        out = self.blocks[1](out)
+        out = out + self.residual_conv(x)
+        return out
+
+
+class ConditionalUnet1D(nn.Module):
+    def __init__(
+        self,
+        input_dim,
+        local_cond_dim=None,
+        global_cond_dim=None,
+        diffusion_step_embed_dim=256,
+        down_dims=[256, 512, 1024],
+        kernel_size=3,
+        n_groups=8,
+        condition_type="film",
+        use_down_condition=True,
+        use_mid_condition=True,
+        use_up_condition=True,
+    ):
+        super().__init__()
+        self.condition_type = condition_type
+
+        self.use_down_condition = use_down_condition
+        self.use_mid_condition = use_mid_condition
+        self.use_up_condition = use_up_condition
+
+        all_dims = [input_dim] + list(down_dims)
+        start_dim = down_dims[0]
+
+        dsed = diffusion_step_embed_dim
+        diffusion_step_encoder = nn.Sequential(
+            SinusoidalPosEmb(dsed),
+            nn.Linear(dsed, dsed * 4),
+            nn.Mish(),
+            nn.Linear(dsed * 4, dsed),
+        )
+        cond_dim = dsed
+        if global_cond_dim is not None:
+            cond_dim += global_cond_dim
+
+        in_out = list(zip(all_dims[:-1], all_dims[1:]))
+
+        local_cond_encoder = None
+        if local_cond_dim is not None:
+            _, dim_out = in_out[0]
+            dim_in = local_cond_dim
+            local_cond_encoder = nn.ModuleList([
+                # down encoder
+                ConditionalResidualBlock1D(
+                    dim_in,
+                    dim_out,
+                    cond_dim=cond_dim,
+                    kernel_size=kernel_size,
+                    n_groups=n_groups,
+                    condition_type=condition_type,
+                ),
+                # up encoder
+                ConditionalResidualBlock1D(
+                    dim_in,
+                    dim_out,
+                    cond_dim=cond_dim,
+                    kernel_size=kernel_size,
+                    n_groups=n_groups,
+                    condition_type=condition_type,
+                ),
+            ])
+
+        mid_dim = all_dims[-1]
+        self.mid_modules = nn.ModuleList([
+            ConditionalResidualBlock1D(
+                mid_dim,
+                mid_dim,
+                cond_dim=cond_dim,
+                kernel_size=kernel_size,
+                n_groups=n_groups,
+                condition_type=condition_type,
+            ),
+            ConditionalResidualBlock1D(
+                mid_dim,
+                mid_dim,
+                cond_dim=cond_dim,
+                kernel_size=kernel_size,
+                n_groups=n_groups,
+                condition_type=condition_type,
+            ),
+        ])
+
+        down_modules = nn.ModuleList([])
+        for ind, (dim_in, dim_out) in enumerate(in_out):
+            is_last = ind >= (len(in_out) - 1)
+            down_modules.append(
+                nn.ModuleList([
+                    ConditionalResidualBlock1D(
+                        dim_in,
+                        dim_out,
+                        cond_dim=cond_dim,
+                        kernel_size=kernel_size,
+                        n_groups=n_groups,
+                        condition_type=condition_type,
+                    ),
+                    ConditionalResidualBlock1D(
+                        dim_out,
+                        dim_out,
+                        cond_dim=cond_dim,
+                        kernel_size=kernel_size,
+                        n_groups=n_groups,
+                        condition_type=condition_type,
+                    ),
+                    Downsample1d(dim_out) if not is_last else nn.Identity(),
+                ])
+            )
+
+        up_modules = nn.ModuleList([])
+        for ind, (dim_in, dim_out) in enumerate(reversed(in_out[1:])):
+            is_last = ind >= (len(in_out) - 1)
+            up_modules.append(
+                nn.ModuleList([
+                    ConditionalResidualBlock1D(
+                        dim_out * 2,
+                        dim_in,
+                        cond_dim=cond_dim,
+                        kernel_size=kernel_size,
+                        n_groups=n_groups,
+                        condition_type=condition_type,
+                    ),
+                    ConditionalResidualBlock1D(
+                        dim_in,
+                        dim_in,
+                        cond_dim=cond_dim,
+                        kernel_size=kernel_size,
+                        n_groups=n_groups,
+                        condition_type=condition_type,
+                    ),
+                    Upsample1d(dim_in) if not is_last else nn.Identity(),
+                ])
+            )
+
+        final_conv = nn.Sequential(
+            Conv1dBlock(start_dim, start_dim, kernel_size=kernel_size),
+            nn.Conv1d(start_dim, input_dim, 1),
+        )
+
+        self.diffusion_step_encoder = diffusion_step_encoder
+        self.local_cond_encoder = local_cond_encoder
+        self.up_modules = up_modules
+        self.down_modules = down_modules
+        self.final_conv = final_conv
+
+        logger.info("number of parameters: %e", sum(p.numel() for p in self.parameters()))
+
+    def forward(
+        self,
+        sample: torch.Tensor,
+        timestep: Union[torch.Tensor, float, int],
+        local_cond=None,
+        global_cond=None,
+        **kwargs,
+    ):
+        """
+        x: (B,T,input_dim)
+        timestep: (B,) or int, diffusion step
+        local_cond: (B,T,local_cond_dim)
+        global_cond: (B,global_cond_dim)
+        output: (B,T,input_dim)
+        """
+        sample = einops.rearrange(sample, "b h t -> b t h")
+
+        # 1. time
+        timesteps = timestep
+        if not torch.is_tensor(timesteps):
+            timesteps = torch.tensor([timesteps], dtype=torch.long, device=sample.device)
+        elif torch.is_tensor(timesteps) and len(timesteps.shape) == 0:
+            timesteps = timesteps[None].to(sample.device)
+        # broadcast to batch dimension in a way that's compatible with ONNX/Core ML
+        timesteps = timesteps.expand(sample.shape[0])
+
+        timestep_embed = self.diffusion_step_encoder(timesteps)
+        if global_cond is not None:
+            if self.condition_type == "cross_attention":
+                timestep_embed = timestep_embed.unsqueeze(1).expand(-1, global_cond.shape[1], -1)
+            global_feature = torch.cat([timestep_embed, global_cond], axis=-1)
+
+        # encode local features
+        h_local = list()
+        if local_cond is not None:
+            local_cond = einops.rearrange(local_cond, "b h t -> b t h")
+            resnet, resnet2 = self.local_cond_encoder
+            x = resnet(local_cond, global_feature)
+            h_local.append(x)
+            x = resnet2(local_cond, global_feature)
+            h_local.append(x)
+
+        x = sample
+        h = []
+        for idx, (resnet, resnet2, downsample) in enumerate(self.down_modules):
+            if self.use_down_condition:
+                x = resnet(x, global_feature)
+                if idx == 0 and len(h_local) > 0:
+                    x = x + h_local[0]
+                x = resnet2(x, global_feature)
+            else:
+                x = resnet(x)
+                if idx == 0 and len(h_local) > 0:
+                    x = x + h_local[0]
+                x = resnet2(x)
+            h.append(x)
+            x = downsample(x)
+
+        for mid_module in self.mid_modules:
+            if self.use_mid_condition:
+                x = mid_module(x, global_feature)
+            else:
+                x = mid_module(x)
+
+        for idx, (resnet, resnet2, upsample) in enumerate(self.up_modules):
+            x = torch.cat((x, h.pop()), dim=1)
+            if self.use_up_condition:
+                x = resnet(x, global_feature)
+                if idx == len(self.up_modules) and len(h_local) > 0:
+                    x = x + h_local[1]
+                x = resnet2(x, global_feature)
+            else:
+                x = resnet(x)
+                if idx == len(self.up_modules) and len(h_local) > 0:
+                    x = x + h_local[1]
+                x = resnet2(x)
+            x = upsample(x)
+
+        x = self.final_conv(x)
+
+        x = einops.rearrange(x, "b t h -> b h t")
+
+        return x

--- a/source/dexverse/dexverse/IL/dp3/dp3_core/conv1d_components.py
+++ b/source/dexverse/dexverse/IL/dp3/dp3_core/conv1d_components.py
@@ -1,0 +1,46 @@
+# Copyright (c) 2025-2026, The DexVerse Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# Adapted from 3D-Diffusion-Policy (https://github.com/YanjieZe/3D-Diffusion-Policy)
+# Original file: diffusion_policy_3d/model/diffusion/conv1d_components.py
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+class Downsample1d(nn.Module):
+    def __init__(self, dim):
+        super().__init__()
+        self.conv = nn.Conv1d(dim, dim, 3, 2, 1)
+
+    def forward(self, x):
+        return self.conv(x)
+
+
+class Upsample1d(nn.Module):
+    def __init__(self, dim):
+        super().__init__()
+        self.conv = nn.ConvTranspose1d(dim, dim, 4, 2, 1)
+
+    def forward(self, x):
+        return self.conv(x)
+
+
+class Conv1dBlock(nn.Module):
+    """
+    Conv1d --> GroupNorm --> Mish
+    """
+
+    def __init__(self, inp_channels, out_channels, kernel_size, n_groups=8):
+        super().__init__()
+
+        self.block = nn.Sequential(
+            nn.Conv1d(inp_channels, out_channels, kernel_size, padding=kernel_size // 2),
+            nn.GroupNorm(n_groups, out_channels),
+            nn.Mish(),
+        )
+
+    def forward(self, x):
+        return self.block(x)

--- a/source/dexverse/dexverse/IL/dp3/dp3_core/dict_of_tensor_mixin.py
+++ b/source/dexverse/dexverse/IL/dp3/dp3_core/dict_of_tensor_mixin.py
@@ -1,0 +1,46 @@
+# Copyright (c) 2025-2026, The DexVerse Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# Adapted from 3D-Diffusion-Policy (https://github.com/YanjieZe/3D-Diffusion-Policy)
+# Original file: diffusion_policy_3d/model/common/dict_of_tensor_mixin.py
+import torch
+import torch.nn as nn
+
+
+class DictOfTensorMixin(nn.Module):
+    def __init__(self, params_dict=None):
+        super().__init__()
+        if params_dict is None:
+            params_dict = nn.ParameterDict()
+        self.params_dict = params_dict
+
+    @property
+    def device(self):
+        return next(iter(self.parameters())).device
+
+    def _load_from_state_dict(
+        self, state_dict, prefix, local_metadata, strict, missing_keys, unexpected_keys, error_msgs
+    ):
+        def dfs_add(dest, keys, value: torch.Tensor):
+            if len(keys) == 1:
+                dest[keys[0]] = value
+                return
+
+            if keys[0] not in dest:
+                dest[keys[0]] = nn.ParameterDict()
+            dfs_add(dest[keys[0]], keys[1:], value)
+
+        def load_dict(state_dict, prefix):
+            out_dict = nn.ParameterDict()
+            for key, value in state_dict.items():
+                value: torch.Tensor
+                if key.startswith(prefix):
+                    param_keys = key[len(prefix) :].split(".")[1:]
+                    dfs_add(out_dict, param_keys, value.clone())
+            return out_dict
+
+        self.params_dict = load_dict(state_dict, prefix + "params_dict")
+        self.params_dict.requires_grad_(False)
+        return

--- a/source/dexverse/dexverse/IL/dp3/dp3_core/dp3_policy.py
+++ b/source/dexverse/dexverse/IL/dp3/dp3_core/dp3_policy.py
@@ -1,0 +1,340 @@
+# Copyright (c) 2025-2026, The DexVerse Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+import copy
+
+# Adapted from 3D-Diffusion-Policy (https://github.com/YanjieZe/3D-Diffusion-Policy)
+# Original file: diffusion_policy_3d/policy/dp3.py
+from typing import Dict
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from diffusers.schedulers.scheduling_ddpm import DDPMScheduler
+from einops import reduce
+from termcolor import cprint
+
+from .base_policy import BasePolicy
+from .conditional_unet1d import ConditionalUnet1D
+from .mask_generator import LowdimMaskGenerator
+from .model_util import print_params
+from .normalizer import LinearNormalizer
+from .pointnet_extractor import DP3Encoder
+from .pytorch_util import dict_apply
+
+
+class DP3(BasePolicy):
+    def __init__(
+        self,
+        shape_meta: dict,
+        noise_scheduler: DDPMScheduler,
+        horizon,
+        n_action_steps,
+        n_obs_steps,
+        num_inference_steps=None,
+        obs_as_global_cond=True,
+        diffusion_step_embed_dim=256,
+        down_dims=(256, 512, 1024),
+        kernel_size=5,
+        n_groups=8,
+        condition_type="film",
+        use_down_condition=True,
+        use_mid_condition=True,
+        use_up_condition=True,
+        encoder_output_dim=256,
+        crop_shape=None,
+        use_pc_color=False,
+        pointnet_type="pointnet",
+        pointcloud_encoder_cfg=None,
+        # parameters passed to step
+        **kwargs,
+    ):
+        super().__init__()
+
+        self.condition_type = condition_type
+
+        # parse shape_meta
+        action_shape = shape_meta["action"]["shape"]
+        self.action_shape = action_shape
+        if len(action_shape) == 1:
+            action_dim = action_shape[0]
+        elif len(action_shape) == 2:  # use multiple hands
+            action_dim = action_shape[0] * action_shape[1]
+        else:
+            raise NotImplementedError(f"Unsupported action shape {action_shape}")
+
+        obs_shape_meta = shape_meta["obs"]
+        obs_dict = dict_apply(obs_shape_meta, lambda x: x["shape"])
+
+        obs_encoder = DP3Encoder(
+            observation_space=obs_dict,
+            img_crop_shape=crop_shape,
+            out_channel=encoder_output_dim,
+            pointcloud_encoder_cfg=pointcloud_encoder_cfg,
+            use_pc_color=use_pc_color,
+            pointnet_type=pointnet_type,
+        )
+
+        # create diffusion model
+        obs_feature_dim = obs_encoder.output_shape()
+        input_dim = action_dim + obs_feature_dim
+        global_cond_dim = None
+        if obs_as_global_cond:
+            input_dim = action_dim
+            if "cross_attention" in self.condition_type:
+                global_cond_dim = obs_feature_dim
+            else:
+                global_cond_dim = obs_feature_dim * n_obs_steps
+
+        self.use_pc_color = use_pc_color
+        self.pointnet_type = pointnet_type
+        cprint(f"[DiffusionUnetHybridPointcloudPolicy] use_pc_color: {self.use_pc_color}", "yellow")
+        cprint(f"[DiffusionUnetHybridPointcloudPolicy] pointnet_type: {self.pointnet_type}", "yellow")
+
+        model = ConditionalUnet1D(
+            input_dim=input_dim,
+            local_cond_dim=None,
+            global_cond_dim=global_cond_dim,
+            diffusion_step_embed_dim=diffusion_step_embed_dim,
+            down_dims=down_dims,
+            kernel_size=kernel_size,
+            n_groups=n_groups,
+            condition_type=condition_type,
+            use_down_condition=use_down_condition,
+            use_mid_condition=use_mid_condition,
+            use_up_condition=use_up_condition,
+        )
+
+        self.obs_encoder = obs_encoder
+        self.model = model
+        self.noise_scheduler = noise_scheduler
+
+        self.noise_scheduler_pc = copy.deepcopy(noise_scheduler)
+        self.mask_generator = LowdimMaskGenerator(
+            action_dim=action_dim,
+            obs_dim=0 if obs_as_global_cond else obs_feature_dim,
+            max_n_obs_steps=n_obs_steps,
+            fix_obs_steps=True,
+            action_visible=False,
+        )
+
+        self.normalizer = LinearNormalizer()
+        self.horizon = horizon
+        self.obs_feature_dim = obs_feature_dim
+        self.action_dim = action_dim
+        self.n_action_steps = n_action_steps
+        self.n_obs_steps = n_obs_steps
+        self.obs_as_global_cond = obs_as_global_cond
+        self.kwargs = kwargs
+
+        if num_inference_steps is None:
+            num_inference_steps = noise_scheduler.config.num_train_timesteps
+        self.num_inference_steps = num_inference_steps
+
+        print_params(self)
+
+    # ========= inference  ============
+    def conditional_sample(
+        self,
+        condition_data,
+        condition_mask,
+        condition_data_pc=None,
+        condition_mask_pc=None,
+        local_cond=None,
+        global_cond=None,
+        generator=None,
+        # keyword arguments to scheduler.step
+        **kwargs,
+    ):
+        model = self.model
+        scheduler = self.noise_scheduler
+
+        trajectory = torch.randn(size=condition_data.shape, dtype=condition_data.dtype, device=condition_data.device)
+
+        # set step values
+        scheduler.set_timesteps(self.num_inference_steps)
+
+        for t in scheduler.timesteps:
+            # 1. apply conditioning
+            trajectory[condition_mask] = condition_data[condition_mask]
+
+            model_output = model(sample=trajectory, timestep=t, local_cond=local_cond, global_cond=global_cond)
+
+            # 3. compute previous image: x_t -> x_t-1
+            trajectory = scheduler.step(
+                model_output,
+                t,
+                trajectory,
+            ).prev_sample
+
+        # finally make sure conditioning is enforced
+        trajectory[condition_mask] = condition_data[condition_mask]
+
+        return trajectory
+
+    def predict_action(self, obs_dict: Dict[str, torch.Tensor]) -> Dict[str, torch.Tensor]:
+        """
+        obs_dict: must include "obs" key
+        result: must include "action" key
+        """
+        # normalize input
+        nobs = self.normalizer.normalize(obs_dict)
+        if not self.use_pc_color:
+            nobs["point_cloud"] = nobs["point_cloud"][..., :3]
+        this_n_point_cloud = nobs["point_cloud"]
+
+        value = next(iter(nobs.values()))
+        B, To = value.shape[:2]
+        T = self.horizon
+        Da = self.action_dim
+        Do = self.obs_feature_dim
+        To = self.n_obs_steps
+
+        # build input
+        device = self.device
+        dtype = self.dtype
+
+        # handle different ways of passing observation
+        local_cond = None
+        global_cond = None
+        if self.obs_as_global_cond:
+            # condition through global feature
+            this_nobs = dict_apply(nobs, lambda x: x[:, :To, ...].reshape(-1, *x.shape[2:]))
+            nobs_features = self.obs_encoder(this_nobs)
+            if "cross_attention" in self.condition_type:
+                # treat as a sequence
+                global_cond = nobs_features.reshape(B, self.n_obs_steps, -1)
+            else:
+                # reshape back to B, Do
+                global_cond = nobs_features.reshape(B, -1)
+            # empty data for action
+            cond_data = torch.zeros(size=(B, T, Da), device=device, dtype=dtype)
+            cond_mask = torch.zeros_like(cond_data, dtype=torch.bool)
+        else:
+            # condition through impainting
+            this_nobs = dict_apply(nobs, lambda x: x[:, :To, ...].reshape(-1, *x.shape[2:]))
+            nobs_features = self.obs_encoder(this_nobs)
+            # reshape back to B, T, Do
+            nobs_features = nobs_features.reshape(B, To, -1)
+            cond_data = torch.zeros(size=(B, T, Da + Do), device=device, dtype=dtype)
+            cond_mask = torch.zeros_like(cond_data, dtype=torch.bool)
+            cond_data[:, :To, Da:] = nobs_features
+            cond_mask[:, :To, Da:] = True
+
+        # run sampling
+        nsample = self.conditional_sample(
+            cond_data, cond_mask, local_cond=local_cond, global_cond=global_cond, **self.kwargs
+        )
+
+        # unnormalize prediction
+        naction_pred = nsample[..., :Da]
+        action_pred = self.normalizer["action"].unnormalize(naction_pred)
+
+        # get action
+        start = To - 1
+        end = start + self.n_action_steps
+        action = action_pred[:, start:end]
+
+        result = {
+            "action": action,
+            "action_pred": action_pred,
+        }
+
+        return result
+
+    # ========= training  ============
+    def set_normalizer(self, normalizer: LinearNormalizer):
+        self.normalizer.load_state_dict(normalizer.state_dict())
+
+    def compute_loss(self, batch):
+        # normalize input
+        nobs = self.normalizer.normalize(batch["obs"])
+        nactions = self.normalizer["action"].normalize(batch["action"])
+
+        if not self.use_pc_color:
+            nobs["point_cloud"] = nobs["point_cloud"][..., :3]
+
+        batch_size = nactions.shape[0]
+        horizon = nactions.shape[1]
+
+        # handle different ways of passing observation
+        local_cond = None
+        global_cond = None
+        trajectory = nactions
+        cond_data = trajectory
+
+        if self.obs_as_global_cond:
+            # reshape B, T, ... to B*T
+            this_nobs = dict_apply(nobs, lambda x: x[:, : self.n_obs_steps, ...].reshape(-1, *x.shape[2:]))
+            nobs_features = self.obs_encoder(this_nobs)
+
+            if "cross_attention" in self.condition_type:
+                # treat as a sequence
+                global_cond = nobs_features.reshape(batch_size, self.n_obs_steps, -1)
+            else:
+                # reshape back to B, Do
+                global_cond = nobs_features.reshape(batch_size, -1)
+            this_n_point_cloud = this_nobs["point_cloud"].reshape(batch_size, -1, *this_nobs["point_cloud"].shape[1:])
+            this_n_point_cloud = this_n_point_cloud[..., :3]
+        else:
+            # reshape B, T, ... to B*T
+            this_nobs = dict_apply(nobs, lambda x: x.reshape(-1, *x.shape[2:]))
+            nobs_features = self.obs_encoder(this_nobs)
+            # reshape back to B, T, Do
+            nobs_features = nobs_features.reshape(batch_size, horizon, -1)
+            cond_data = torch.cat([nactions, nobs_features], dim=-1)
+            trajectory = cond_data.detach()
+
+        # generate impainting mask
+        condition_mask = self.mask_generator(trajectory.shape)
+
+        # Sample noise that we'll add to the images
+        noise = torch.randn(trajectory.shape, device=trajectory.device)
+
+        bsz = trajectory.shape[0]
+        # Sample a random timestep for each image
+        timesteps = torch.randint(
+            0, self.noise_scheduler.config.num_train_timesteps, (bsz,), device=trajectory.device
+        ).long()
+
+        # Add noise to the clean images according to the noise magnitude at each timestep
+        # (this is the forward diffusion process)
+        noisy_trajectory = self.noise_scheduler.add_noise(trajectory, noise, timesteps)
+
+        # compute loss mask
+        loss_mask = ~condition_mask
+
+        # apply conditioning
+        noisy_trajectory[condition_mask] = cond_data[condition_mask]
+
+        # Predict the noise residual
+        pred = self.model(sample=noisy_trajectory, timestep=timesteps, local_cond=local_cond, global_cond=global_cond)
+
+        pred_type = self.noise_scheduler.config.prediction_type
+        if pred_type == "epsilon":
+            target = noise
+        elif pred_type == "sample":
+            target = trajectory
+        elif pred_type == "v_prediction":
+            self.noise_scheduler.alpha_t = self.noise_scheduler.alpha_t.to(self.device)
+            self.noise_scheduler.sigma_t = self.noise_scheduler.sigma_t.to(self.device)
+            alpha_t, sigma_t = self.noise_scheduler.alpha_t[timesteps], self.noise_scheduler.sigma_t[timesteps]
+            alpha_t = alpha_t.unsqueeze(-1).unsqueeze(-1)
+            sigma_t = sigma_t.unsqueeze(-1).unsqueeze(-1)
+            v_t = alpha_t * noise - sigma_t * trajectory
+            target = v_t
+        else:
+            raise ValueError(f"Unsupported prediction type {pred_type}")
+
+        loss = F.mse_loss(pred, target, reduction="none")
+        loss = loss * loss_mask.type(loss.dtype)
+        loss = reduce(loss, "b ... -> b (...)", "mean")
+        loss = loss.mean()
+
+        loss_dict = {
+            "bc_loss": loss.item(),
+        }
+
+        return loss, loss_dict

--- a/source/dexverse/dexverse/IL/dp3/dp3_core/ema_model.py
+++ b/source/dexverse/dexverse/IL/dp3/dp3_core/ema_model.py
@@ -1,0 +1,77 @@
+# Copyright (c) 2025-2026, The DexVerse Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# Adapted from 3D-Diffusion-Policy (https://github.com/YanjieZe/3D-Diffusion-Policy)
+# Original file: diffusion_policy_3d/model/diffusion/ema_model.py
+import copy
+
+import torch
+from torch.nn.modules.batchnorm import _BatchNorm
+
+
+class EMAModel:
+    """
+    Exponential Moving Average of models weights
+    """
+
+    def __init__(self, model, update_after_step=0, inv_gamma=1.0, power=2 / 3, min_value=0.0, max_value=0.9999):
+        """
+        @crowsonkb's notes on EMA Warmup:
+            If gamma=1 and power=1, implements a simple average. gamma=1, power=2/3 are good values for models you plan
+            to train for a million or more steps (reaches decay factor 0.999 at 31.6K steps, 0.9999 at 1M steps),
+            gamma=1, power=3/4 for models you plan to train for less (reaches decay factor 0.999 at 10K steps, 0.9999
+            at 215.4k steps).
+        Args:
+            inv_gamma (float): Inverse multiplicative factor of EMA warmup. Default: 1.
+            power (float): Exponential factor of EMA warmup. Default: 2/3.
+            min_value (float): The minimum EMA decay rate. Default: 0.
+        """
+
+        self.averaged_model = model
+        self.averaged_model.eval()
+        self.averaged_model.requires_grad_(False)
+
+        self.update_after_step = update_after_step
+        self.inv_gamma = inv_gamma
+        self.power = power
+        self.min_value = min_value
+        self.max_value = max_value
+
+        self.decay = 0.0
+        self.optimization_step = 0
+
+    def get_decay(self, optimization_step):
+        """
+        Compute the decay factor for the exponential moving average.
+        """
+        step = max(0, optimization_step - self.update_after_step - 1)
+        value = 1 - (1 + step / self.inv_gamma) ** -self.power
+
+        if step <= 0:
+            return 0.0
+
+        return max(self.min_value, min(value, self.max_value))
+
+    @torch.no_grad()
+    def step(self, new_model):
+        self.decay = self.get_decay(self.optimization_step)
+
+        all_dataptrs = set()
+        for module, ema_module in zip(new_model.modules(), self.averaged_model.modules()):
+            for param, ema_param in zip(module.parameters(recurse=False), ema_module.parameters(recurse=False)):
+                # iterative over immediate parameters only.
+                if isinstance(param, dict):
+                    raise RuntimeError("Dict parameter not supported")
+
+                if isinstance(module, _BatchNorm):
+                    # skip batchnorms
+                    ema_param.copy_(param.to(dtype=ema_param.dtype).data)
+                elif not param.requires_grad:
+                    ema_param.copy_(param.to(dtype=ema_param.dtype).data)
+                else:
+                    ema_param.mul_(self.decay)
+                    ema_param.add_(param.data.to(dtype=ema_param.dtype), alpha=1 - self.decay)
+
+        self.optimization_step += 1

--- a/source/dexverse/dexverse/IL/dp3/dp3_core/mask_generator.py
+++ b/source/dexverse/dexverse/IL/dp3/dp3_core/mask_generator.py
@@ -1,0 +1,206 @@
+# Copyright (c) 2025-2026, The DexVerse Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# Adapted from 3D-Diffusion-Policy (https://github.com/YanjieZe/3D-Diffusion-Policy)
+# Original file: diffusion_policy_3d/model/diffusion/mask_generator.py
+from typing import Optional, Sequence
+
+import torch
+from torch import nn
+
+from .module_attr_mixin import ModuleAttrMixin
+
+
+def get_intersection_slice_mask(shape: tuple, dim_slices: Sequence[slice], device: Optional[torch.device] = None):
+    assert len(shape) == len(dim_slices)
+    mask = torch.zeros(size=shape, dtype=torch.bool, device=device)
+    mask[dim_slices] = True
+    return mask
+
+
+def get_union_slice_mask(shape: tuple, dim_slices: Sequence[slice], device: Optional[torch.device] = None):
+    assert len(shape) == len(dim_slices)
+    mask = torch.zeros(size=shape, dtype=torch.bool, device=device)
+    for i in range(len(dim_slices)):
+        this_slices = [slice(None)] * len(shape)
+        this_slices[i] = dim_slices[i]
+        mask[this_slices] = True
+    return mask
+
+
+class DummyMaskGenerator(ModuleAttrMixin):
+    def __init__(self):
+        super().__init__()
+
+    @torch.no_grad()
+    def forward(self, shape):
+        device = self.device
+        mask = torch.ones(size=shape, dtype=torch.bool, device=device)
+        return mask
+
+
+class LowdimMaskGenerator(ModuleAttrMixin):
+    def __init__(
+        self,
+        action_dim,
+        obs_dim,
+        # obs mask setup
+        max_n_obs_steps=2,
+        fix_obs_steps=True,
+        # action mask
+        action_visible=False,
+    ):
+        super().__init__()
+        self.action_dim = action_dim
+        self.obs_dim = obs_dim
+        self.max_n_obs_steps = max_n_obs_steps
+        self.fix_obs_steps = fix_obs_steps
+        self.action_visible = action_visible
+
+    @torch.no_grad()
+    def forward(self, shape, seed=None):
+        device = self.device
+        B, T, D = shape
+        assert D == (self.action_dim + self.obs_dim)
+
+        # create all tensors on this device
+        rng = torch.Generator(device=device)
+        if seed is not None:
+            rng = rng.manual_seed(seed)
+
+        # generate dim mask
+        dim_mask = torch.zeros(size=shape, dtype=torch.bool, device=device)
+        is_action_dim = dim_mask.clone()
+        is_action_dim[..., : self.action_dim] = True
+        is_obs_dim = ~is_action_dim
+
+        # generate obs mask
+        if self.fix_obs_steps:
+            obs_steps = torch.full((B,), fill_value=self.max_n_obs_steps, device=device)
+        else:
+            obs_steps = torch.randint(low=1, high=self.max_n_obs_steps + 1, size=(B,), generator=rng, device=device)
+
+        steps = torch.arange(0, T, device=device).reshape(1, T).expand(B, T)
+        obs_mask = (steps.T < obs_steps).T.reshape(B, T, 1).expand(B, T, D)
+        obs_mask = obs_mask & is_obs_dim
+
+        # generate action mask
+        if self.action_visible:
+            action_steps = torch.maximum(obs_steps - 1, torch.tensor(0, dtype=obs_steps.dtype, device=obs_steps.device))
+            action_mask = (steps.T < action_steps).T.reshape(B, T, 1).expand(B, T, D)
+            action_mask = action_mask & is_action_dim
+
+        mask = obs_mask
+        if self.action_visible:
+            mask = mask | action_mask
+
+        return mask
+
+
+class KeypointMaskGenerator(ModuleAttrMixin):
+    def __init__(
+        self,
+        # dimensions
+        action_dim,
+        keypoint_dim,
+        # obs mask setup
+        max_n_obs_steps=2,
+        fix_obs_steps=True,
+        # keypoint mask setup
+        keypoint_visible_rate=0.7,
+        time_independent=False,
+        # action mask
+        action_visible=False,
+        context_dim=0,  # dim for context
+        n_context_steps=1,
+    ):
+        super().__init__()
+        self.action_dim = action_dim
+        self.keypoint_dim = keypoint_dim
+        self.context_dim = context_dim
+        self.max_n_obs_steps = max_n_obs_steps
+        self.fix_obs_steps = fix_obs_steps
+        self.keypoint_visible_rate = keypoint_visible_rate
+        self.time_independent = time_independent
+        self.action_visible = action_visible
+        self.n_context_steps = n_context_steps
+
+    @torch.no_grad()
+    def forward(self, shape, seed=None):
+        device = self.device
+        B, T, D = shape
+        all_keypoint_dims = D - self.action_dim - self.context_dim
+        n_keypoints = all_keypoint_dims // self.keypoint_dim
+
+        # create all tensors on this device
+        rng = torch.Generator(device=device)
+        if seed is not None:
+            rng = rng.manual_seed(seed)
+
+        # generate dim mask
+        dim_mask = torch.zeros(size=shape, dtype=torch.bool, device=device)
+        is_action_dim = dim_mask.clone()
+        is_action_dim[..., : self.action_dim] = True
+        is_context_dim = dim_mask.clone()
+        if self.context_dim > 0:
+            is_context_dim[..., -self.context_dim :] = True
+        is_obs_dim = ~(is_action_dim | is_context_dim)
+
+        # generate obs mask
+        if self.fix_obs_steps:
+            obs_steps = torch.full((B,), fill_value=self.max_n_obs_steps, device=device)
+        else:
+            obs_steps = torch.randint(low=1, high=self.max_n_obs_steps + 1, size=(B,), generator=rng, device=device)
+
+        steps = torch.arange(0, T, device=device).reshape(1, T).expand(B, T)
+        obs_mask = (steps.T < obs_steps).T.reshape(B, T, 1).expand(B, T, D)
+        obs_mask = obs_mask & is_obs_dim
+
+        # generate action mask
+        if self.action_visible:
+            action_steps = torch.maximum(obs_steps - 1, torch.tensor(0, dtype=obs_steps.dtype, device=obs_steps.device))
+            action_mask = (steps.T < action_steps).T.reshape(B, T, 1).expand(B, T, D)
+            action_mask = action_mask & is_action_dim
+
+        # generate keypoint mask
+        if self.time_independent:
+            visible_kps = (
+                torch.rand(size=(B, T, n_keypoints), generator=rng, device=device) < self.keypoint_visible_rate
+            )
+            visible_dims = torch.repeat_interleave(visible_kps, repeats=self.keypoint_dim, dim=-1)
+            visible_dims_mask = torch.cat(
+                [
+                    torch.ones((B, T, self.action_dim), dtype=torch.bool, device=device),
+                    visible_dims,
+                    torch.ones((B, T, self.context_dim), dtype=torch.bool, device=device),
+                ],
+                axis=-1,
+            )
+            keypoint_mask = visible_dims_mask
+        else:
+            visible_kps = torch.rand(size=(B, n_keypoints), generator=rng, device=device) < self.keypoint_visible_rate
+            visible_dims = torch.repeat_interleave(visible_kps, repeats=self.keypoint_dim, dim=-1)
+            visible_dims_mask = torch.cat(
+                [
+                    torch.ones((B, self.action_dim), dtype=torch.bool, device=device),
+                    visible_dims,
+                    torch.ones((B, self.context_dim), dtype=torch.bool, device=device),
+                ],
+                axis=-1,
+            )
+            keypoint_mask = visible_dims_mask.reshape(B, 1, D).expand(B, T, D)
+        keypoint_mask = keypoint_mask & is_obs_dim
+
+        # generate context mask
+        context_mask = is_context_dim.clone()
+        context_mask[:, self.n_context_steps :, :] = False
+
+        mask = obs_mask & keypoint_mask
+        if self.action_visible:
+            mask = mask | action_mask
+        if self.context_dim > 0:
+            mask = mask | context_mask
+
+        return mask

--- a/source/dexverse/dexverse/IL/dp3/dp3_core/model_util.py
+++ b/source/dexverse/dexverse/IL/dp3/dp3_core/model_util.py
@@ -1,0 +1,30 @@
+# Copyright (c) 2025-2026, The DexVerse Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# Adapted from 3D-Diffusion-Policy (https://github.com/YanjieZe/3D-Diffusion-Policy)
+# Original file: diffusion_policy_3d/common/model_util.py
+from termcolor import cprint
+
+
+def print_params(model):
+    """
+    Print the number of parameters in each part of the model.
+    """
+    params_dict = {}
+
+    all_num_param = sum(p.numel() for p in model.parameters())
+
+    for name, param in model.named_parameters():
+        part_name = name.split(".")[0]
+        if part_name not in params_dict:
+            params_dict[part_name] = 0
+        params_dict[part_name] += param.numel()
+
+    cprint(f"----------------------------------", "cyan")
+    cprint(f"Class name: {model.__class__.__name__}", "cyan")
+    cprint(f"  Number of parameters: {all_num_param / 1e6:.4f}M", "cyan")
+    for part_name, num_params in params_dict.items():
+        cprint(f"   {part_name}: {num_params / 1e6:.4f}M ({num_params / all_num_param:.2%})", "cyan")
+    cprint(f"----------------------------------", "cyan")

--- a/source/dexverse/dexverse/IL/dp3/dp3_core/module_attr_mixin.py
+++ b/source/dexverse/dexverse/IL/dp3/dp3_core/module_attr_mixin.py
@@ -1,0 +1,22 @@
+# Copyright (c) 2025-2026, The DexVerse Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# Adapted from 3D-Diffusion-Policy (https://github.com/YanjieZe/3D-Diffusion-Policy)
+# Original file: diffusion_policy_3d/model/common/module_attr_mixin.py
+import torch.nn as nn
+
+
+class ModuleAttrMixin(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self._dummy_variable = nn.Parameter()
+
+    @property
+    def device(self):
+        return next(iter(self.parameters())).device
+
+    @property
+    def dtype(self):
+        return next(iter(self.parameters())).dtype

--- a/source/dexverse/dexverse/IL/dp3/dp3_core/normalizer.py
+++ b/source/dexverse/dexverse/IL/dp3/dp3_core/normalizer.py
@@ -1,0 +1,288 @@
+# Copyright (c) 2025-2026, The DexVerse Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# Adapted from 3D-Diffusion-Policy (https://github.com/YanjieZe/3D-Diffusion-Policy)
+# Original file: diffusion_policy_3d/model/common/normalizer.py
+from typing import Dict, Union
+
+import numpy as np
+import torch
+import torch.nn as nn
+
+from .dict_of_tensor_mixin import DictOfTensorMixin
+from .pytorch_util import dict_apply
+
+
+class LinearNormalizer(DictOfTensorMixin):
+    avaliable_modes = ["limits", "gaussian"]
+
+    @torch.no_grad()
+    def fit(
+        self,
+        data: Union[Dict, torch.Tensor, np.ndarray],
+        last_n_dims=1,
+        dtype=torch.float32,
+        mode="limits",
+        output_max=1.0,
+        output_min=-1.0,
+        range_eps=1e-4,
+        fit_offset=True,
+    ):
+        if isinstance(data, dict):
+            for key, value in data.items():
+                self.params_dict[key] = _fit(
+                    value,
+                    last_n_dims=last_n_dims,
+                    dtype=dtype,
+                    mode=mode,
+                    output_max=output_max,
+                    output_min=output_min,
+                    range_eps=range_eps,
+                    fit_offset=fit_offset,
+                )
+        else:
+            self.params_dict["_default"] = _fit(
+                data,
+                last_n_dims=last_n_dims,
+                dtype=dtype,
+                mode=mode,
+                output_max=output_max,
+                output_min=output_min,
+                range_eps=range_eps,
+                fit_offset=fit_offset,
+            )
+
+    def __call__(self, x: Union[Dict, torch.Tensor, np.ndarray]) -> torch.Tensor:
+        return self.normalize(x)
+
+    def __getitem__(self, key: str):
+        return SingleFieldLinearNormalizer(self.params_dict[key])
+
+    def __setitem__(self, key: str, value: "SingleFieldLinearNormalizer"):
+        self.params_dict[key] = value.params_dict
+
+    def _normalize_impl(self, x, forward=True):
+        if isinstance(x, dict):
+            result = dict()
+            for key, value in x.items():
+                params = self.params_dict[key]
+                result[key] = _normalize(value, params, forward=forward)
+            return result
+        else:
+            if "_default" not in self.params_dict:
+                raise RuntimeError("Not initialized")
+            params = self.params_dict["_default"]
+            return _normalize(x, params, forward=forward)
+
+    def normalize(self, x: Union[Dict, torch.Tensor, np.ndarray]) -> torch.Tensor:
+        return self._normalize_impl(x, forward=True)
+
+    def unnormalize(self, x: Union[Dict, torch.Tensor, np.ndarray]) -> torch.Tensor:
+        return self._normalize_impl(x, forward=False)
+
+    def get_input_stats(self) -> Dict:
+        if len(self.params_dict) == 0:
+            raise RuntimeError("Not initialized")
+        if len(self.params_dict) == 1 and "_default" in self.params_dict:
+            return self.params_dict["_default"]["input_stats"]
+
+        result = dict()
+        for key, value in self.params_dict.items():
+            if key != "_default":
+                result[key] = value["input_stats"]
+        return result
+
+    def get_output_stats(self, key="_default"):
+        input_stats = self.get_input_stats()
+        if "min" in input_stats:
+            # no dict
+            return dict_apply(input_stats, self.normalize)
+
+        result = dict()
+        for key, group in input_stats.items():
+            this_dict = dict()
+            for name, value in group.items():
+                this_dict[name] = self.normalize({key: value})[key]
+            result[key] = this_dict
+        return result
+
+
+class SingleFieldLinearNormalizer(DictOfTensorMixin):
+    avaliable_modes = ["limits", "gaussian"]
+
+    @torch.no_grad()
+    def fit(
+        self,
+        data: Union[torch.Tensor, np.ndarray],
+        last_n_dims=1,
+        dtype=torch.float32,
+        mode="limits",
+        output_max=1.0,
+        output_min=-1.0,
+        range_eps=1e-4,
+        fit_offset=True,
+    ):
+        self.params_dict = _fit(
+            data,
+            last_n_dims=last_n_dims,
+            dtype=dtype,
+            mode=mode,
+            output_max=output_max,
+            output_min=output_min,
+            range_eps=range_eps,
+            fit_offset=fit_offset,
+        )
+
+    @classmethod
+    def create_fit(cls, data: Union[torch.Tensor, np.ndarray], **kwargs):
+        obj = cls()
+        obj.fit(data, **kwargs)
+        return obj
+
+    @classmethod
+    def create_manual(
+        cls,
+        scale: Union[torch.Tensor, np.ndarray],
+        offset: Union[torch.Tensor, np.ndarray],
+        input_stats_dict: Dict[str, Union[torch.Tensor, np.ndarray]],
+    ):
+        def to_tensor(x):
+            if not isinstance(x, torch.Tensor):
+                x = torch.from_numpy(x)
+            x = x.flatten()
+            return x
+
+        # check
+        for x in [offset] + list(input_stats_dict.values()):
+            assert x.shape == scale.shape
+            assert x.dtype == scale.dtype
+
+        params_dict = nn.ParameterDict({
+            "scale": to_tensor(scale),
+            "offset": to_tensor(offset),
+            "input_stats": nn.ParameterDict(dict_apply(input_stats_dict, to_tensor)),
+        })
+        return cls(params_dict)
+
+    @classmethod
+    def create_identity(cls, dtype=torch.float32):
+        scale = torch.tensor([1], dtype=dtype)
+        offset = torch.tensor([0], dtype=dtype)
+        input_stats_dict = {
+            "min": torch.tensor([-1], dtype=dtype),
+            "max": torch.tensor([1], dtype=dtype),
+            "mean": torch.tensor([0], dtype=dtype),
+            "std": torch.tensor([1], dtype=dtype),
+        }
+        return cls.create_manual(scale, offset, input_stats_dict)
+
+    def normalize(self, x: Union[torch.Tensor, np.ndarray]) -> torch.Tensor:
+        return _normalize(x, self.params_dict, forward=True)
+
+    def unnormalize(self, x: Union[torch.Tensor, np.ndarray]) -> torch.Tensor:
+        return _normalize(x, self.params_dict, forward=False)
+
+    def get_input_stats(self):
+        return self.params_dict["input_stats"]
+
+    def get_output_stats(self):
+        return dict_apply(self.params_dict["input_stats"], self.normalize)
+
+    def __call__(self, x: Union[torch.Tensor, np.ndarray]) -> torch.Tensor:
+        return self.normalize(x)
+
+
+def _fit(
+    data: Union[torch.Tensor, np.ndarray],
+    last_n_dims=1,
+    dtype=torch.float32,
+    mode="limits",
+    output_max=1.0,
+    output_min=-1.0,
+    range_eps=1e-4,
+    fit_offset=True,
+):
+    assert mode in ["limits", "gaussian"]
+    assert last_n_dims >= 0
+    assert output_max > output_min
+
+    # convert data to torch and type
+    if isinstance(data, np.ndarray):
+        data = torch.from_numpy(data)
+    if dtype is not None:
+        data = data.type(dtype)
+
+    # convert shape
+    dim = 1
+    if last_n_dims > 0:
+        dim = np.prod(data.shape[-last_n_dims:])
+    data = data.reshape(-1, dim)
+
+    # compute input stats min max mean std
+    input_min, _ = data.min(axis=0)
+    input_max, _ = data.max(axis=0)
+    input_mean = data.mean(axis=0)
+    input_std = data.std(axis=0)
+
+    # compute scale and offset
+    if mode == "limits":
+        if fit_offset:
+            # unit scale
+            input_range = input_max - input_min
+            ignore_dim = input_range < range_eps
+            input_range[ignore_dim] = output_max - output_min
+            scale = (output_max - output_min) / input_range
+            offset = output_min - scale * input_min
+            offset[ignore_dim] = (output_max + output_min) / 2 - input_min[ignore_dim]
+            # ignore dims scaled to mean of output max and min
+        else:
+            # use this when data is pre-zero-centered.
+            assert output_max > 0
+            assert output_min < 0
+            # unit abs
+            output_abs = min(abs(output_min), abs(output_max))
+            input_abs = torch.maximum(torch.abs(input_min), torch.abs(input_max))
+            ignore_dim = input_abs < range_eps
+            input_abs[ignore_dim] = output_abs
+            # don't scale constant channels
+            scale = output_abs / input_abs
+            offset = torch.zeros_like(input_mean)
+    elif mode == "gaussian":
+        ignore_dim = input_std < range_eps
+        scale = input_std.clone()
+        scale[ignore_dim] = 1
+        scale = 1 / scale
+
+        if fit_offset:
+            offset = -input_mean * scale
+        else:
+            offset = torch.zeros_like(input_mean)
+
+    # save
+    this_params = nn.ParameterDict({
+        "scale": scale,
+        "offset": offset,
+        "input_stats": nn.ParameterDict({"min": input_min, "max": input_max, "mean": input_mean, "std": input_std}),
+    })
+    for p in this_params.parameters():
+        p.requires_grad_(False)
+    return this_params
+
+
+def _normalize(x, params, forward=True):
+    assert "scale" in params
+    if isinstance(x, np.ndarray):
+        x = torch.from_numpy(x)
+    scale = params["scale"]
+    offset = params["offset"]
+    x = x.to(device=scale.device, dtype=scale.dtype)
+    src_shape = x.shape
+    x = x.reshape(-1, scale.shape[0])
+    if forward:
+        x = x * scale + offset
+    else:
+        x = (x - offset) / scale
+    x = x.reshape(src_shape)
+    return x

--- a/source/dexverse/dexverse/IL/dp3/dp3_core/pointnet_extractor.py
+++ b/source/dexverse/dexverse/IL/dp3/dp3_core/pointnet_extractor.py
@@ -1,0 +1,213 @@
+# Copyright (c) 2025-2026, The DexVerse Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+from typing import Dict, List, Optional, Tuple, Type, Union
+
+# Adapted from 3D-Diffusion-Policy (https://github.com/YanjieZe/3D-Diffusion-Policy)
+# Original file: diffusion_policy_3d/model/vision/pointnet_extractor.py
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from termcolor import cprint
+
+
+def create_mlp(
+    input_dim: int,
+    output_dim: int,
+    net_arch: List[int],
+    activation_fn: Type[nn.Module] = nn.ReLU,
+    squash_output: bool = False,
+) -> List[nn.Module]:
+    """
+    Create a multi layer perceptron (MLP), which is
+    a collection of fully-connected layers each followed by an activation function.
+    """
+    if len(net_arch) > 0:
+        modules = [nn.Linear(input_dim, net_arch[0]), activation_fn()]
+    else:
+        modules = []
+
+    for idx in range(len(net_arch) - 1):
+        modules.append(nn.Linear(net_arch[idx], net_arch[idx + 1]))
+        modules.append(activation_fn())
+
+    if output_dim > 0:
+        last_layer_dim = net_arch[-1] if len(net_arch) > 0 else input_dim
+        modules.append(nn.Linear(last_layer_dim, output_dim))
+    if squash_output:
+        modules.append(nn.Tanh())
+    return modules
+
+
+class PointNetEncoderXYZRGB(nn.Module):
+    """Encoder for Pointcloud (XYZ + RGB, 6 channels)"""
+
+    def __init__(
+        self,
+        in_channels: int,
+        out_channels: int = 1024,
+        use_layernorm: bool = False,
+        final_norm: str = "none",
+        use_projection: bool = True,
+        **kwargs,
+    ):
+        super().__init__()
+        block_channel = [64, 128, 256, 512]
+        cprint("pointnet use_layernorm: {}".format(use_layernorm), "cyan")
+        cprint("pointnet use_final_norm: {}".format(final_norm), "cyan")
+
+        self.mlp = nn.Sequential(
+            nn.Linear(in_channels, block_channel[0]),
+            nn.LayerNorm(block_channel[0]) if use_layernorm else nn.Identity(),
+            nn.ReLU(),
+            nn.Linear(block_channel[0], block_channel[1]),
+            nn.LayerNorm(block_channel[1]) if use_layernorm else nn.Identity(),
+            nn.ReLU(),
+            nn.Linear(block_channel[1], block_channel[2]),
+            nn.LayerNorm(block_channel[2]) if use_layernorm else nn.Identity(),
+            nn.ReLU(),
+            nn.Linear(block_channel[2], block_channel[3]),
+        )
+
+        if final_norm == "layernorm":
+            self.final_projection = nn.Sequential(
+                nn.Linear(block_channel[-1], out_channels), nn.LayerNorm(out_channels)
+            )
+        elif final_norm == "none":
+            self.final_projection = nn.Linear(block_channel[-1], out_channels)
+        else:
+            raise NotImplementedError(f"final_norm: {final_norm}")
+
+    def forward(self, x):
+        x = self.mlp(x)
+        x = torch.max(x, 1)[0]
+        x = self.final_projection(x)
+        return x
+
+
+class PointNetEncoderXYZ(nn.Module):
+    """Encoder for Pointcloud (XYZ only, 3 channels)"""
+
+    def __init__(
+        self,
+        in_channels: int = 3,
+        out_channels: int = 1024,
+        use_layernorm: bool = False,
+        final_norm: str = "none",
+        use_projection: bool = True,
+        **kwargs,
+    ):
+        super().__init__()
+        block_channel = [64, 128, 256]
+        cprint("[PointNetEncoderXYZ] use_layernorm: {}".format(use_layernorm), "cyan")
+        cprint("[PointNetEncoderXYZ] use_final_norm: {}".format(final_norm), "cyan")
+
+        assert in_channels == 3, cprint(f"PointNetEncoderXYZ only supports 3 channels, but got {in_channels}", "red")
+
+        self.mlp = nn.Sequential(
+            nn.Linear(in_channels, block_channel[0]),
+            nn.LayerNorm(block_channel[0]) if use_layernorm else nn.Identity(),
+            nn.ReLU(),
+            nn.Linear(block_channel[0], block_channel[1]),
+            nn.LayerNorm(block_channel[1]) if use_layernorm else nn.Identity(),
+            nn.ReLU(),
+            nn.Linear(block_channel[1], block_channel[2]),
+            nn.LayerNorm(block_channel[2]) if use_layernorm else nn.Identity(),
+            nn.ReLU(),
+        )
+
+        if final_norm == "layernorm":
+            self.final_projection = nn.Sequential(
+                nn.Linear(block_channel[-1], out_channels), nn.LayerNorm(out_channels)
+            )
+        elif final_norm == "none":
+            self.final_projection = nn.Linear(block_channel[-1], out_channels)
+        else:
+            raise NotImplementedError(f"final_norm: {final_norm}")
+
+        self.use_projection = use_projection
+        if not use_projection:
+            self.final_projection = nn.Identity()
+            cprint("[PointNetEncoderXYZ] not use projection", "yellow")
+
+    def forward(self, x):
+        x = self.mlp(x)
+        x = torch.max(x, 1)[0]
+        x = self.final_projection(x)
+        return x
+
+
+class DP3Encoder(nn.Module):
+    def __init__(
+        self,
+        observation_space: Dict,
+        img_crop_shape=None,
+        out_channel=256,
+        state_mlp_size=(64, 64),
+        state_mlp_activation_fn=nn.ReLU,
+        pointcloud_encoder_cfg=None,
+        use_pc_color=False,
+        pointnet_type="pointnet",
+    ):
+        super().__init__()
+        self.imagination_key = "imagin_robot"
+        self.state_key = "agent_pos"
+        self.point_cloud_key = "point_cloud"
+        self.rgb_image_key = "image"
+        self.n_output_channels = out_channel
+
+        self.use_imagined_robot = self.imagination_key in observation_space.keys()
+        self.point_cloud_shape = observation_space[self.point_cloud_key]
+        self.state_shape = observation_space[self.state_key]
+        if self.use_imagined_robot:
+            self.imagination_shape = observation_space[self.imagination_key]
+        else:
+            self.imagination_shape = None
+
+        cprint(f"[DP3Encoder] point cloud shape: {self.point_cloud_shape}", "yellow")
+        cprint(f"[DP3Encoder] state shape: {self.state_shape}", "yellow")
+        cprint(f"[DP3Encoder] imagination point shape: {self.imagination_shape}", "yellow")
+
+        self.use_pc_color = use_pc_color
+        self.pointnet_type = pointnet_type
+        if pointnet_type == "pointnet":
+            if use_pc_color:
+                pointcloud_encoder_cfg.in_channels = 6
+                self.extractor = PointNetEncoderXYZRGB(**pointcloud_encoder_cfg)
+            else:
+                pointcloud_encoder_cfg.in_channels = 3
+                self.extractor = PointNetEncoderXYZ(**pointcloud_encoder_cfg)
+        else:
+            raise NotImplementedError(f"pointnet_type: {pointnet_type}")
+
+        if len(state_mlp_size) == 0:
+            raise RuntimeError(f"State mlp size is empty")
+        elif len(state_mlp_size) == 1:
+            net_arch = []
+        else:
+            net_arch = state_mlp_size[:-1]
+        output_dim = state_mlp_size[-1]
+
+        self.n_output_channels += output_dim
+        self.state_mlp = nn.Sequential(*create_mlp(self.state_shape[0], output_dim, net_arch, state_mlp_activation_fn))
+
+        cprint(f"[DP3Encoder] output dim: {self.n_output_channels}", "red")
+
+    def forward(self, observations: Dict) -> torch.Tensor:
+        points = observations[self.point_cloud_key]
+        assert len(points.shape) == 3, cprint(f"point cloud shape: {points.shape}, length should be 3", "red")
+        if self.use_imagined_robot:
+            img_points = observations[self.imagination_key][..., : points.shape[-1]]  # align the last dim
+            points = torch.concat([points, img_points], dim=1)
+
+        pn_feat = self.extractor(points)  # B * out_channel
+
+        state = observations[self.state_key]
+        state_feat = self.state_mlp(state)  # B * 64
+        final_feat = torch.cat([pn_feat, state_feat], dim=-1)
+        return final_feat
+
+    def output_shape(self):
+        return self.n_output_channels

--- a/source/dexverse/dexverse/IL/dp3/dp3_core/positional_embedding.py
+++ b/source/dexverse/dexverse/IL/dp3/dp3_core/positional_embedding.py
@@ -1,0 +1,26 @@
+# Copyright (c) 2025-2026, The DexVerse Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# Adapted from 3D-Diffusion-Policy (https://github.com/YanjieZe/3D-Diffusion-Policy)
+# Original file: diffusion_policy_3d/model/diffusion/positional_embedding.py
+import math
+
+import torch
+import torch.nn as nn
+
+
+class SinusoidalPosEmb(nn.Module):
+    def __init__(self, dim):
+        super().__init__()
+        self.dim = dim
+
+    def forward(self, x):
+        device = x.device
+        half_dim = self.dim // 2
+        emb = math.log(10000) / (half_dim - 1)
+        emb = torch.exp(torch.arange(half_dim, device=device) * -emb)
+        emb = x[:, None] * emb[None, :]
+        emb = torch.cat((emb.sin(), emb.cos()), dim=-1)
+        return emb

--- a/source/dexverse/dexverse/IL/dp3/dp3_core/pytorch_util.py
+++ b/source/dexverse/dexverse/IL/dp3/dp3_core/pytorch_util.py
@@ -1,0 +1,56 @@
+# Copyright (c) 2025-2026, The DexVerse Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+import collections
+
+# Adapted from 3D-Diffusion-Policy (https://github.com/YanjieZe/3D-Diffusion-Policy)
+# Original file: diffusion_policy_3d/common/pytorch_util.py
+from typing import Callable, Dict, List
+
+import torch
+import torch.nn as nn
+
+
+def dict_apply(x: Dict[str, torch.Tensor], func: Callable[[torch.Tensor], torch.Tensor]) -> Dict[str, torch.Tensor]:
+    result = dict()
+    for key, value in x.items():
+        if isinstance(value, dict):
+            result[key] = dict_apply(value, func)
+        else:
+            result[key] = func(value)
+    return result
+
+
+def pad_remaining_dims(x, target):
+    assert x.shape == target.shape[: len(x.shape)]
+    return x.reshape(x.shape + (1,) * (len(target.shape) - len(x.shape)))
+
+
+def dict_apply_split(
+    x: Dict[str, torch.Tensor], split_func: Callable[[torch.Tensor], Dict[str, torch.Tensor]]
+) -> Dict[str, torch.Tensor]:
+    results = collections.defaultdict(dict)
+    for key, value in x.items():
+        result = split_func(value)
+        for k, v in result.items():
+            results[k][key] = v
+    return results
+
+
+def dict_apply_reduce(
+    x: List[Dict[str, torch.Tensor]], reduce_func: Callable[[List[torch.Tensor]], torch.Tensor]
+) -> Dict[str, torch.Tensor]:
+    result = dict()
+    for key in x[0].keys():
+        result[key] = reduce_func([x_[key] for x_ in x])
+    return result
+
+
+def optimizer_to(optimizer, device):
+    for state in optimizer.state.values():
+        for k, v in state.items():
+            if isinstance(v, torch.Tensor):
+                state[k] = v.to(device=device)
+    return optimizer

--- a/source/dexverse/dexverse/IL/dp3/model.py
+++ b/source/dexverse/dexverse/IL/dp3/model.py
@@ -1,0 +1,100 @@
+# Copyright (c) 2025-2026, The DexVerse Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""DP3 policy factory for DexVerse."""
+from __future__ import annotations
+
+import copy
+
+from diffusers.schedulers.scheduling_ddim import DDIMScheduler
+from omegaconf import OmegaConf
+
+from .config import DP3PolicyConfig
+from .dp3_core.dp3_policy import DP3
+from .dp3_core.ema_model import EMAModel
+from .dp3_core.normalizer import LinearNormalizer
+
+
+def build_dp3_policy(cfg: DP3PolicyConfig) -> DP3:
+    """Construct a DP3 policy from a DexVerse config.
+
+    Uses OmegaConf wrappers for ``shape_meta`` and ``pointcloud_encoder_cfg``
+    so that DP3's internal ``dict_apply`` does not recurse into them.
+    """
+    shape_meta = OmegaConf.create({
+        "obs": {
+            "point_cloud": {"shape": [cfg.num_points, 3], "type": "point_cloud"},
+            "agent_pos": {"shape": [cfg.proprio_dim], "type": "low_dim"},
+        },
+        "action": {"shape": [cfg.action_dim]},
+    })
+
+    noise_scheduler = DDIMScheduler(
+        num_train_timesteps=cfg.num_train_timesteps,
+        beta_start=0.0001,
+        beta_end=0.02,
+        beta_schedule="squaredcos_cap_v2",
+        clip_sample=True,
+        set_alpha_to_one=True,
+        steps_offset=0,
+        prediction_type="sample",
+    )
+
+    pcd_enc = OmegaConf.create({
+        "in_channels": cfg.pointcloud_encoder_cfg.in_channels,
+        "out_channels": cfg.pointcloud_encoder_cfg.out_channels,
+        "use_layernorm": cfg.pointcloud_encoder_cfg.use_layernorm,
+        "final_norm": cfg.pointcloud_encoder_cfg.final_norm,
+        "normal_channel": cfg.pointcloud_encoder_cfg.normal_channel,
+    })
+
+    return DP3(
+        shape_meta=shape_meta,
+        noise_scheduler=noise_scheduler,
+        horizon=cfg.horizon,
+        n_action_steps=cfg.n_action_steps,
+        n_obs_steps=cfg.n_obs_steps,
+        num_inference_steps=cfg.num_inference_steps,
+        obs_as_global_cond=True,
+        diffusion_step_embed_dim=cfg.diffusion_step_embed_dim,
+        down_dims=cfg.down_dims,
+        kernel_size=cfg.kernel_size,
+        n_groups=cfg.n_groups,
+        condition_type=cfg.condition_type,
+        use_down_condition=cfg.use_down_condition,
+        use_mid_condition=cfg.use_mid_condition,
+        use_up_condition=cfg.use_up_condition,
+        encoder_output_dim=cfg.encoder_output_dim,
+        use_pc_color=cfg.use_pc_color,
+        pointnet_type=cfg.pointnet_type,
+        pointcloud_encoder_cfg=pcd_enc,
+    )
+
+
+def build_ema_model(policy: DP3) -> EMAModel:
+    """Create an EMA copy of the policy."""
+    ema_policy = copy.deepcopy(policy)
+    return EMAModel(
+        model=ema_policy,
+        update_after_step=0,
+        inv_gamma=1.0,
+        power=0.75,
+        min_value=0.0,
+        max_value=0.9999,
+    )
+
+
+def load_dp3_checkpoint(
+    ckpt_path: str,
+    device: str = "cpu",
+) -> dict:
+    """Load a DP3 training checkpoint.
+
+    Returns dict with keys: policy_state, ema_policy_state, normalizer_state,
+    policy_cfg, dataset_cfg, optimizer_state, epoch, metadata.
+    """
+    import torch
+
+    return torch.load(ckpt_path, map_location=device, weights_only=False)

--- a/source/dexverse/dexverse/IL/dp3/online_eval.py
+++ b/source/dexverse/dexverse/IL/dp3/online_eval.py
@@ -1,0 +1,231 @@
+# Copyright (c) 2025-2026, The DexVerse Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Online evaluation of a trained DP3 policy in a DexVerse simulator."""
+from __future__ import annotations
+
+import inspect
+import json
+import os
+import time
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import torch
+from isaaclab.managers.manager_base import ManagerTermBase
+
+from .config import DP3OnlineEvalConfig
+from .runner import load_runner_from_checkpoint
+
+
+def _write_episode_video(frames: list[np.ndarray], output_path: str | Path, fps: int = 30) -> None:
+    """Write a list of ``(H, W, 3)`` uint8 RGB frames to an MP4 file."""
+    import cv2
+
+    if not frames:
+        return
+    h, w = frames[0].shape[:2]
+    fourcc = cv2.VideoWriter_fourcc(*"mp4v")
+    writer = cv2.VideoWriter(str(output_path), fourcc, fps, (w, h))
+    for frame in frames:
+        writer.write(cv2.cvtColor(frame, cv2.COLOR_RGB2BGR))
+    writer.release()
+
+
+def _read_camera_rgb(env, camera_name: str) -> np.ndarray:
+    """Read one ``(H, W, 3)`` uint8 RGB frame from a named scene sensor."""
+    cam = env.unwrapped.scene.sensors[camera_name]
+    rgb = cam.data.output["rgb"][0].cpu().numpy()
+    if rgb.shape[-1] == 4:
+        rgb = rgb[..., :3]
+    if rgb.dtype != np.uint8:
+        if rgb.max() <= 1.0:
+            rgb = (rgb * 255).clip(0, 255)
+        rgb = rgb.clip(0, 255).astype(np.uint8)
+    return rgb
+
+
+class ManualSuccessEvaluator:
+    """Evaluate episode success by directly calling the env's success term.
+
+    A termination term's ``func`` is either a plain callable or a
+    :class:`ManagerTermBase` subclass. Class-based terms must be instantiated
+    once (``func(cfg=term_cfg, env=env)``) and then invoked per step, mirroring
+    what IsaacLab's ``TerminationManager`` does internally. Calling the class
+    directly as ``func(env, **params)`` raises a ``TypeError``.
+    """
+
+    def __init__(self, term_cfg: Any):
+        self.term_cfg = term_cfg
+        self._instance: Any = None
+
+    def __call__(self, env: Any) -> bool:
+        params = dict(getattr(self.term_cfg, "params", {}) or {})
+        func = self.term_cfg.func
+        if inspect.isclass(func) and issubclass(func, ManagerTermBase):
+            if self._instance is None:
+                self._instance = func(cfg=self.term_cfg, env=env)
+            value = self._instance(env, **params)
+        else:
+            value = func(env, **params)
+        if isinstance(value, torch.Tensor):
+            return bool(value.reshape(-1)[0].item())
+        if isinstance(value, np.ndarray):
+            return bool(value.reshape(-1)[0])
+        if isinstance(value, (list, tuple)):
+            return bool(value[0])
+        return bool(value)
+
+
+def _setup_env(
+    task: str,
+    *,
+    device: str,
+    observation_preset: str,
+    json_path: str | None = None,
+):
+    """Create an env with the requested obs preset; extract a success evaluator.
+
+    Pulls ``success`` out of the env cfg so we can score the rollout manually
+    without time-out / failure terms ending the episode early. Other
+    terminations (``time_out``, etc.) are left in place so the rollout still
+    truncates instead of running forever.
+    """
+    import dexverse.tasks  # noqa: F401 — registers all tasks
+    import gymnasium as gym
+    import isaaclab_tasks  # noqa: F401
+    from dexverse.tasks.utils import parse_env_cfg
+
+    env_cfg = parse_env_cfg(task, device=device, num_envs=1, json_path=json_path)
+
+    # Apply the observation preset BEFORE building the env. The preset must
+    # match what the demos were recorded with so train-time and eval-time obs
+    # shapes line up.
+    if observation_preset and hasattr(env_cfg, "_apply_observation_preset"):
+        env_cfg.observation_preset = observation_preset
+        env_cfg._apply_observation_preset(observation_preset)
+
+    success_evaluator = None
+    terminations = getattr(env_cfg, "terminations", None)
+    if terminations is not None and hasattr(terminations, "success"):
+        success_cfg = terminations.success
+        if success_cfg is not None:
+            success_evaluator = ManualSuccessEvaluator(success_cfg)
+            terminations.success = None
+
+    if hasattr(env_cfg, "recorders"):
+        env_cfg.recorders = {}
+
+    env = gym.make(task, cfg=env_cfg)
+    return env, success_evaluator
+
+
+def eval_main(cfg: DP3OnlineEvalConfig) -> dict[str, Any]:
+    """Run closed-loop evaluation of a DP3 policy."""
+    os.makedirs(cfg.output_dir, exist_ok=True)
+    device_str = cfg.device
+    if device_str.startswith("cuda") and not torch.cuda.is_available():
+        device_str = "cpu"
+
+    runner, ckpt = load_runner_from_checkpoint(
+        cfg.ckpt,
+        device=device_str,
+        replan_interval=cfg.replan_interval,
+    )
+    metadata = ckpt.get("metadata", {})
+    print(f"[dp3][eval] Loaded checkpoint from epoch {ckpt.get('epoch', '?')}")
+    print(f"[dp3][eval] Task: {metadata.get('task', cfg.task)}")
+    print(f"[dp3][eval] observation_preset={cfg.observation_preset!r}")
+
+    json_path = getattr(cfg, "json_path", None)
+    env, success_evaluator = _setup_env(
+        cfg.task,
+        device=device_str,
+        observation_preset=cfg.observation_preset,
+        json_path=json_path,
+    )
+
+    returns: list[float] = []
+    lengths: list[int] = []
+    latencies_ms: list[float] = []
+    successes = 0
+
+    video_dir = None
+    if cfg.record_video:
+        video_dir = os.path.join(cfg.output_dir, "videos")
+        os.makedirs(video_dir, exist_ok=True)
+        print(f"[dp3][eval] Recording video from sensor '{cfg.video_camera}' @ {cfg.video_fps} fps -> {video_dir}")
+
+    for ep in range(cfg.num_episodes):
+        obs, _ = env.reset()
+        runner.reset()
+        ep_return = 0.0
+        ep_success = False
+        frames: list[np.ndarray] = []
+
+        if cfg.record_video:
+            frames.append(_read_camera_rgb(env, cfg.video_camera))
+
+        for step in range(cfg.max_steps):
+            start = time.perf_counter()
+            action = runner.act(obs).to(env.unwrapped.device)
+            latencies_ms.append((time.perf_counter() - start) * 1000.0)
+
+            obs, reward, terminated, truncated, _info = env.step(action.unsqueeze(0))
+
+            if cfg.record_video:
+                frames.append(_read_camera_rgb(env, cfg.video_camera))
+
+            if isinstance(reward, torch.Tensor):
+                ep_return += float(reward.reshape(-1)[0].item())
+            else:
+                ep_return += float(np.asarray(reward).reshape(-1)[0])
+
+            if success_evaluator is not None:
+                ep_success = ep_success or bool(success_evaluator(env.unwrapped))
+
+            terminated_flag = bool(torch.as_tensor(terminated).reshape(-1)[0].item())
+            truncated_flag = bool(torch.as_tensor(truncated).reshape(-1)[0].item())
+            done = terminated_flag or truncated_flag or ep_success
+            if done:
+                lengths.append(step + 1)
+                break
+        else:
+            lengths.append(cfg.max_steps)
+
+        if ep_success:
+            successes += 1
+        returns.append(ep_return)
+
+        status = "SUCCESS" if ep_success else "fail"
+        print(f"[dp3][eval] Episode {ep + 1}/{cfg.num_episodes}: return={ep_return:.2f}  len={lengths[-1]}  {status}")
+
+        if cfg.record_video and frames:
+            vid_path = os.path.join(video_dir, f"ep{ep:03d}_{status.lower()}.mp4")
+            _write_episode_video(frames, vid_path, fps=cfg.video_fps)
+            print(f"  -> {vid_path}")
+
+    env.close()
+
+    metrics: dict[str, Any] = {
+        "num_episodes": cfg.num_episodes,
+        "avg_return": float(np.mean(returns)) if returns else 0.0,
+        "avg_ep_len": float(np.mean(lengths)) if lengths else float(cfg.max_steps),
+        "inference_latency_ms": float(np.mean(latencies_ms)) if latencies_ms else 0.0,
+        "success_rate": successes / max(1, cfg.num_episodes) if success_evaluator is not None else None,
+        "successes": successes,
+    }
+
+    results_path = os.path.join(cfg.output_dir, "metrics.json")
+    with open(results_path, "w", encoding="utf-8") as fp:
+        json.dump({"config": asdict(cfg), "metrics": metrics}, fp, ensure_ascii=False, indent=2)
+
+    print(f"\n[dp3][eval] Results:")
+    for k, v in metrics.items():
+        print(f"  {k}: {v}")
+    print(f"\nSaved to {results_path}")
+    return metrics

--- a/source/dexverse/dexverse/IL/dp3/runner.py
+++ b/source/dexverse/dexverse/IL/dp3/runner.py
@@ -1,0 +1,229 @@
+# Copyright (c) 2025-2026, The DexVerse Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""DP3 inference runner for closed-loop evaluation in DexVerse environments."""
+from __future__ import annotations
+
+from collections import deque
+
+import numpy as np
+import torch
+
+from .config import DP3PolicyConfig, PointcloudEncoderConfig
+from .dp3_core.dp3_policy import DP3
+from .dp3_core.normalizer import LinearNormalizer
+from .model import build_dp3_policy, load_dp3_checkpoint
+
+
+def _fps_downsample_torch(points: torch.Tensor, num_points: int) -> torch.Tensor:
+    """Farthest-point-sample a (N, 3) tensor down to (num_points, 3)."""
+    N = points.shape[0]
+    if N <= num_points:
+        if N == 0:
+            return torch.zeros(num_points, 3, device=points.device, dtype=points.dtype)
+        pad_idx = torch.randint(N, (num_points - N,), device=points.device)
+        return torch.cat([points, points[pad_idx]], dim=0)
+
+    try:
+        import pytorch3d.ops as torch3d_ops
+
+        sampled, _ = torch3d_ops.sample_farthest_points(points.unsqueeze(0).float(), K=num_points)
+        return sampled.squeeze(0).to(dtype=points.dtype)
+    except ImportError:
+        pass
+
+    selected = torch.zeros(num_points, dtype=torch.long, device=points.device)
+    dists = torch.full((N,), float("inf"), device=points.device)
+    selected[0] = torch.randint(N, (1,), device=points.device)
+    for i in range(1, num_points):
+        last = points[selected[i - 1]]
+        d = ((points - last) ** 2).sum(dim=-1)
+        dists = torch.minimum(dists, d)
+        selected[i] = dists.argmax()
+    return points[selected]
+
+
+class DexVerseDP3Runner:
+    """Closed-loop DP3 inference for DexVerse environments.
+
+    Reads point clouds from the ``pointcloud`` obs group and proprioception
+    from the ``proprio`` obs group (as produced by the ``pointcloud`` or
+    ``3view_pointcloud`` observation preset), maintains a short obs history
+    window, and returns actions with temporal chunking.
+    """
+
+    def __init__(
+        self,
+        *,
+        policy: DP3,
+        device: torch.device,
+        num_points: int = 512,
+        n_obs_steps: int = 2,
+        n_action_steps: int = 8,
+        replan_interval: int = 8,
+    ):
+        self.policy = policy
+        self.device = device
+        self.num_points = num_points
+        self.n_obs_steps = n_obs_steps
+        self.n_action_steps = n_action_steps
+        self.replan_interval = replan_interval
+
+        self.pcd_history: deque[torch.Tensor] = deque(maxlen=n_obs_steps)
+        self.proprio_history: deque[torch.Tensor] = deque(maxlen=n_obs_steps)
+        self.action_queue: deque[torch.Tensor] = deque()
+        self.replan_tick: int = 0
+
+    def reset(self) -> None:
+        """Clear state between episodes."""
+        self.pcd_history.clear()
+        self.proprio_history.clear()
+        self.action_queue.clear()
+        self.replan_tick = 0
+
+    @torch.no_grad()
+    def act(self, obs: dict) -> torch.Tensor:
+        """Compute an action from one environment observation dict.
+
+        Expects:
+          ``obs["pointcloud"]`` — concatenated point cloud for the active term
+              (``camera_point_cloud_w`` or ``merged_point_cloud_w``). Shape is
+              ``(num_envs, num_points * 3)`` (flat, from ``concatenate_terms``),
+              ``(num_envs, num_points, 3)``, or a dict mapping term-name → tensor.
+          ``obs["proprio"]`` — flat concatenated proprio tensor of shape
+              ``(num_envs, proprio_dim)`` (history is already flattened in by
+              the observation preset).
+
+        Returns an action tensor of shape ``(action_dim,)`` for env_id=0.
+        """
+        pcd = self._extract_point_cloud(obs)
+        pcd_down = _fps_downsample_torch(pcd, self.num_points)
+        self.pcd_history.append(pcd_down.cpu())
+
+        proprio = self._extract_proprio(obs)
+        self.proprio_history.append(proprio.cpu())
+
+        while len(self.pcd_history) < self.n_obs_steps:
+            self.pcd_history.appendleft(self.pcd_history[0])
+        while len(self.proprio_history) < self.n_obs_steps:
+            self.proprio_history.appendleft(self.proprio_history[0])
+
+        should_replan = len(self.action_queue) == 0 or self.replan_tick >= self.replan_interval
+        if should_replan:
+            pcd_window = torch.stack(list(self.pcd_history), dim=0)  # (To, N, 3)
+            proprio_window = torch.stack(list(self.proprio_history), dim=0)  # (To, D)
+            obs_dict = {
+                "point_cloud": pcd_window.unsqueeze(0).to(self.device),
+                "agent_pos": proprio_window.unsqueeze(0).to(self.device),
+            }
+            result = self.policy.predict_action(obs_dict)
+            actions = result["action"][0]  # (n_action_steps, action_dim)
+            self.action_queue = deque(actions.cpu().unbind(dim=0))
+            self.replan_tick = 0
+
+        self.replan_tick += 1
+        return self.action_queue.popleft()
+
+    def _extract_point_cloud(self, obs: dict) -> torch.Tensor:
+        """Return the env_0 point cloud as ``(N, 3)`` on CPU.
+
+        The ``pointcloud`` obs group is configured with ``concatenate_terms=True``
+        and one active term (single- or multi-view), so the runtime tensor is
+        ``(num_envs, num_points * 3)``. We also accept the un-concatenated and
+        nested-dict shapes for robustness.
+        """
+        raw = obs.get("pointcloud")
+        if raw is None:
+            raise ValueError(
+                "No 'pointcloud' group in observation dict. "
+                "Apply the 'pointcloud' or '3view_pointcloud' observation preset "
+                "to the env cfg before gym.make()."
+            )
+        if isinstance(raw, dict):
+            for term in ("camera_point_cloud_w", "merged_point_cloud_w"):
+                if term in raw:
+                    raw = raw[term]
+                    break
+            else:
+                raise ValueError(
+                    "pointcloud dict has none of (camera_point_cloud_w, "
+                    f"merged_point_cloud_w); got keys {list(raw.keys())}"
+                )
+        pcd = torch.as_tensor(raw, dtype=torch.float32)
+        if pcd.ndim == 3 and pcd.shape[-1] == 3:
+            pcd = pcd[0]
+        elif pcd.ndim == 2:
+            pcd = pcd[0].reshape(-1, 3)
+        elif pcd.ndim == 1:
+            pcd = pcd.reshape(-1, 3)
+        else:
+            raise ValueError(f"Unexpected pointcloud tensor shape: {tuple(pcd.shape)}")
+        return pcd.cpu()
+
+    def _extract_proprio(self, obs: dict) -> torch.Tensor:
+        """Return the env_0 proprio vector as ``(D,)`` on CPU.
+
+        With ``concatenate_terms=True`` (and history flattening from the obs
+        preset) the runtime tensor is already flat ``(num_envs, D)``. Nested
+        dicts and per-env tensors are also accepted.
+        """
+        proprio = obs.get("proprio")
+        if proprio is None:
+            raise ValueError(
+                "No 'proprio' group in observation dict. The obs preset must "
+                "keep 'proprio' enabled (the default presets all do)."
+            )
+        if isinstance(proprio, dict):
+            parts = []
+            for key in sorted(proprio.keys()):
+                t = torch.as_tensor(proprio[key], dtype=torch.float32)
+                if t.ndim >= 2:
+                    t = t[0]
+                parts.append(t.flatten())
+            return torch.cat(parts, dim=0).cpu()
+        t = torch.as_tensor(proprio, dtype=torch.float32)
+        if t.ndim >= 2:
+            t = t[0]
+        return t.flatten().cpu()
+
+
+def load_runner_from_checkpoint(
+    ckpt_path: str,
+    *,
+    device: str = "cuda",
+    replan_interval: int = 8,
+) -> tuple[DexVerseDP3Runner, dict]:
+    """Load a trained DP3 policy and create an inference runner."""
+    ckpt = load_dp3_checkpoint(ckpt_path, device=device)
+
+    raw_cfg = ckpt["policy_cfg"]
+    if isinstance(raw_cfg.get("pointcloud_encoder_cfg"), dict):
+        raw_cfg = dict(raw_cfg)
+        raw_cfg["pointcloud_encoder_cfg"] = PointcloudEncoderConfig(**raw_cfg["pointcloud_encoder_cfg"])
+    if isinstance(raw_cfg.get("down_dims"), list):
+        raw_cfg = dict(raw_cfg)
+        raw_cfg["down_dims"] = tuple(raw_cfg["down_dims"])
+    policy_cfg = DP3PolicyConfig(**raw_cfg)
+    policy = build_dp3_policy(policy_cfg)
+
+    state_key = "ema_policy_state" if "ema_policy_state" in ckpt else "policy_state"
+    policy.load_state_dict(ckpt[state_key])
+    policy.to(device)
+    policy.eval()
+
+    normalizer = LinearNormalizer()
+    normalizer.load_state_dict(ckpt["normalizer_state"])
+    policy.set_normalizer(normalizer)
+
+    dev = torch.device(device)
+    runner = DexVerseDP3Runner(
+        policy=policy,
+        device=dev,
+        num_points=policy_cfg.num_points,
+        n_obs_steps=policy_cfg.n_obs_steps,
+        n_action_steps=policy_cfg.n_action_steps,
+        replan_interval=replan_interval,
+    )
+    return runner, ckpt

--- a/source/dexverse/dexverse/IL/dp3/train.py
+++ b/source/dexverse/dexverse/IL/dp3/train.py
@@ -1,0 +1,261 @@
+# Copyright (c) 2025-2026, The DexVerse Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""DP3 training loop for DexVerse."""
+from __future__ import annotations
+
+import copy
+import dataclasses
+import json
+import os
+import random
+import time
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import torch
+from torch.utils.data import DataLoader
+
+from .config import DP3DatasetConfig, DP3PolicyConfig, DP3TrainConfig
+from .dataset import DexVerseDP3Dataset
+from .model import build_dp3_policy, build_ema_model
+
+
+def _seed_everything(seed: int) -> None:
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed_all(seed)
+
+
+def _resolve_device(device: str) -> torch.device:
+    if device.startswith("cuda") and not torch.cuda.is_available():
+        return torch.device("cpu")
+    return torch.device(device)
+
+
+@torch.no_grad()
+def _evaluate(policy, val_loader, device) -> float:
+    """Compute average validation loss."""
+    policy.eval()
+    losses = []
+    for batch in val_loader:
+        batch = _batch_to_device(batch, device)
+        loss, _ = policy.compute_loss(batch)
+        losses.append(loss.item())
+    policy.train()
+    return float(np.mean(losses)) if losses else 0.0
+
+
+def _batch_to_device(batch: dict, device: torch.device) -> dict:
+    """Recursively move batch tensors to device."""
+    result = {}
+    for k, v in batch.items():
+        if isinstance(v, dict):
+            result[k] = _batch_to_device(v, device)
+        elif isinstance(v, torch.Tensor):
+            result[k] = v.to(device)
+        else:
+            result[k] = v
+    return result
+
+
+def _save_checkpoint(
+    path: str,
+    *,
+    policy,
+    ema_model,
+    normalizer,
+    optimizer,
+    policy_cfg: DP3PolicyConfig,
+    dataset_cfg: DP3DatasetConfig,
+    epoch: int,
+    metadata: dict,
+    save_optimizer: bool = True,
+) -> None:
+    """Save a training checkpoint.
+
+    ``save_optimizer`` controls whether the AdamW state (~2x the model size) is
+    written. It is only needed to resume training; inference/eval never reads
+    it, so the sweep skips it to keep checkpoints small and I/O cheap.
+    """
+    Path(path).parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "policy_state": policy.state_dict(),
+        "normalizer_state": normalizer.state_dict(),
+        "policy_cfg": dataclasses.asdict(policy_cfg),
+        "dataset_cfg": dataclasses.asdict(dataset_cfg),
+        "epoch": epoch,
+        "metadata": metadata,
+    }
+    if save_optimizer:
+        payload["optimizer_state"] = optimizer.state_dict()
+    if ema_model is not None:
+        payload["ema_policy_state"] = ema_model.averaged_model.state_dict()
+    torch.save(payload, path)
+
+
+def train_main(cfg: DP3TrainConfig) -> dict[str, Any]:
+    """Run the DP3 training loop.
+
+    Returns a summary dict with final metrics.
+    """
+    os.makedirs(cfg.output_dir, exist_ok=True)
+    _seed_everything(cfg.seed)
+    device = _resolve_device(cfg.device)
+
+    # ---- Dataset ----
+    train_dataset = DexVerseDP3Dataset(cfg.dataset, split="train")
+    val_dataset = train_dataset.get_validation_dataset()
+
+    print(f"[dp3][train] Train: {len(train_dataset)} samples from {len(train_dataset._active_indices)} episodes")
+    print(f"[dp3][train] Val:   {len(val_dataset)} samples from {len(val_dataset._active_indices)} episodes")
+    print(
+        f"[dp3][train] Dims: proprio={train_dataset.proprio_dim}, "
+        f"action={train_dataset.action_dim}, points={train_dataset.num_points}"
+    )
+
+    # ---- Normalizer ----
+    normalizer = train_dataset.get_normalizer()
+
+    # ---- Policy ----
+    policy_cfg = dataclasses.replace(
+        cfg.policy,
+        proprio_dim=train_dataset.proprio_dim,
+        action_dim=train_dataset.action_dim,
+        num_points=train_dataset.num_points,
+    )
+    policy = build_dp3_policy(policy_cfg)
+    policy.set_normalizer(normalizer)
+    policy = policy.to(device)
+
+    # ---- EMA ----
+    ema_model = build_ema_model(policy) if cfg.use_ema else None
+
+    # ---- Optimizer ----
+    optimizer = torch.optim.AdamW(
+        policy.parameters(),
+        lr=cfg.lr,
+        betas=cfg.betas,
+        eps=1e-8,
+        weight_decay=cfg.weight_decay,
+    )
+
+    # ---- DataLoaders ----
+    train_loader = DataLoader(
+        train_dataset,
+        batch_size=cfg.batch_size,
+        shuffle=True,
+        num_workers=cfg.num_workers,
+        pin_memory=True,
+        drop_last=len(train_dataset) >= cfg.batch_size,
+    )
+    val_loader = DataLoader(
+        val_dataset,
+        batch_size=cfg.batch_size,
+        shuffle=False,
+        num_workers=cfg.num_workers,
+        pin_memory=True,
+        drop_last=False,
+    )
+
+    # ---- Training loop ----
+    best_val_loss = float("inf")
+    best_epoch = -1
+    history: list[dict[str, float]] = []
+    start_time = time.time()
+
+    metadata = {
+        "task": train_dataset.metadata.get("task", "unknown"),
+        "bbox_min": train_dataset.bbox_min.tolist() if train_dataset.bbox_min is not None else None,
+        "bbox_max": train_dataset.bbox_max.tolist() if train_dataset.bbox_max is not None else None,
+    }
+
+    for epoch in range(1, cfg.num_epochs + 1):
+        policy.train()
+        epoch_losses = []
+
+        for batch in train_loader:
+            batch = _batch_to_device(batch, device)
+
+            loss, loss_dict = policy.compute_loss(batch)
+
+            optimizer.zero_grad(set_to_none=True)
+            loss.backward()
+            if cfg.grad_clip_norm > 0:
+                torch.nn.utils.clip_grad_norm_(policy.parameters(), max_norm=cfg.grad_clip_norm)
+            optimizer.step()
+
+            if ema_model is not None:
+                ema_model.step(policy)
+
+            epoch_losses.append(loss.item())
+
+        train_loss = float(np.mean(epoch_losses)) if epoch_losses else 0.0
+
+        # ---- Validation ----
+        val_loss = 0.0
+        if epoch % cfg.val_every == 0:
+            eval_policy = ema_model.averaged_model if ema_model is not None else policy
+            val_loss = _evaluate(eval_policy, val_loader, device)
+
+        history.append({"epoch": epoch, "train_loss": train_loss, "val_loss": val_loss})
+
+        if epoch % cfg.log_every == 0 or epoch == 1:
+            print(f"[dp3][train] epoch={epoch:04d}  train_loss={train_loss:.6f}  val_loss={val_loss:.6f}")
+
+        # ---- Checkpointing ----
+        # Checkpoints are written without optimizer state (inference-only) and
+        # ``last.pt`` only every ``save_every_epochs`` (plus the final epoch).
+        # A 255M-param model produces multi-GB checkpoints; writing one every
+        # epoch saturates disk I/O and serializes parallel training jobs.
+        ckpt_kwargs = dict(
+            policy=policy,
+            ema_model=ema_model,
+            normalizer=normalizer,
+            optimizer=optimizer,
+            policy_cfg=policy_cfg,
+            dataset_cfg=cfg.dataset,
+            metadata=metadata,
+            save_optimizer=False,
+        )
+
+        if epoch % cfg.save_every_epochs == 0 or epoch == cfg.num_epochs:
+            _save_checkpoint(os.path.join(cfg.output_dir, "last.pt"), epoch=epoch, **ckpt_kwargs)
+
+        if val_loss < best_val_loss and val_loss > 0:
+            best_val_loss = val_loss
+            best_epoch = epoch
+            _save_checkpoint(os.path.join(cfg.output_dir, "best.pt"), epoch=epoch, **ckpt_kwargs)
+
+    elapsed = time.time() - start_time
+    summary = {
+        "task": metadata["task"],
+        "train_samples": len(train_dataset),
+        "val_samples": len(val_dataset),
+        "best_val_loss": best_val_loss,
+        "best_epoch": best_epoch,
+        "final_train_loss": history[-1]["train_loss"] if history else 0.0,
+        "elapsed_s": elapsed,
+    }
+
+    # Save metrics
+    metrics_path = os.path.join(cfg.output_dir, "metrics.json")
+    Path(metrics_path).parent.mkdir(parents=True, exist_ok=True)
+    with open(metrics_path, "w") as f:
+        json.dump(
+            {
+                "config": dataclasses.asdict(cfg),
+                "history": history,
+                "summary": summary,
+            },
+            f,
+            indent=2,
+        )
+
+    print(f"[dp3][train] Done. best_epoch={best_epoch} best_val_loss={best_val_loss:.6f} elapsed={elapsed:.1f}s")
+    return summary

--- a/source/dexverse/setup.py
+++ b/source/dexverse/setup.py
@@ -26,6 +26,18 @@ INSTALL_REQUIRES = [
     "psutil",
 ]
 
+# Optional dependencies for the imitation-learning baselines
+EXTRAS_REQUIRE = {
+    # 3D Diffusion Policy baseline (dexverse.IL.dp3 + scripts/dp3)
+    "dp3": [
+        "diffusers",
+        "einops",
+        "h5py",
+        "omegaconf",
+        "termcolor",
+    ],
+}
+
 # Installation operation
 setup(
     name="dexverse",
@@ -37,6 +49,7 @@ setup(
     description=EXTENSION_TOML_DATA["package"]["description"],
     keywords=EXTENSION_TOML_DATA["package"]["keywords"],
     install_requires=INSTALL_REQUIRES,
+    extras_require=EXTRAS_REQUIRE,
     license="BSD-3-Clause",
     include_package_data=True,
     python_requires=">=3.10",


### PR DESCRIPTION
## Summary

Adds a point-cloud imitation-learning baseline based on 3D Diffusion Policy (DP3):

- `source/dexverse/dexverse/IL/dp3/` — configs, HDF5 dataset loader, policy factory,
  training loop, closed-loop inference runner, online sim evaluation, and vendored
  `dp3_core/` components (adapted from
  [3D-Diffusion-Policy](https://github.com/YanjieZe/3D-Diffusion-Policy); no upstream
  install needed)
- `scripts/dp3/` — dataset converter, training / online-eval / dataset-visualization CLIs
- `setup.py` — optional `dp3` extra: `pip install -e "source/dexverse[dp3]"`
- Full walkthrough in `source/dexverse/dexverse/IL/dp3/README.md`
  (replay demos with the `pointcloud` preset → convert → train → `eval_online`)

The converter consumes the H5 files written by
`scripts/demo_tools/create_demo_files_sequential.py`; no changes to existing code
besides the `setup.py` extra. The top-level README is left untouched (baselines
section / roadmap update to follow separately).

## Testing

- All `dexverse.IL.dp3` modules import; `list_envs.py` still registers all 100 tasks
- Offline pipeline through the CLIs: synthetic replay-format H5 → converter → 2-epoch
  training (default architecture) → checkpoint load → runner inference with correct
  action dims
- Closed-loop `eval_online.py` rollout on `Dexverse-GraspPan-v0` with the `pointcloud`
  preset (core + shadow-hand assets from HF): env creation, camera-driven point-cloud
  obs, success evaluator, and `metrics.json` all working

🤖 Generated with [Claude Code](https://claude.com/claude-code)