### PR TITLE
Feat/task upgrades

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,9 +77,14 @@ tests/
 
 # Asset binaries are hosted on Hugging Face (dexverse/DexVerse_Dataset) and
 # fetched via scripts/asset_tools/download_assets.py. Keep only the package's
-# path-constants module (assets/__init__.py) in git.
+# path-constants module and procedural asset generators in git.
 /source/dexverse/dexverse/assets/*
 !/source/dexverse/dexverse/assets/__init__.py
+!/source/dexverse/dexverse/assets/rack_builder.py
+!/source/dexverse/dexverse/assets/shelf_builder.py
+!/source/dexverse/dexverse/assets/small_table_builder.py
+!/source/dexverse/dexverse/assets/cut_props_builder.py
+!/source/dexverse/dexverse/assets/desk_props_builder.py
 
 # robot_agents binary assets (USD/URDF/meshes) are hosted on Hugging Face and
 # fetched via scripts/asset_tools/download_robot_agents.py. Small text sources
@@ -99,11 +104,18 @@ tests/
 
 # Demonstration recordings are hosted on Hugging Face (demonstrations/ prefix)
 # and fetched via scripts/demo_tools/download_demos.py. Keep only docs (*.md)
-# and the baseline manifest (read by download_demos.py / upload_demos.py).
+# and the baseline manifests (read by the offline release tools and downloader).
 /source/dexverse/demonstrations/**
 !/source/dexverse/demonstrations/**/
 !/source/dexverse/demonstrations/**/*.md
 !/source/dexverse/demonstrations/baseline_manifest.txt
+!/source/dexverse/demonstrations/baseline_manifest_v1.txt
+# Imported private data and provenance must never enter the public source diff.
+/source/dexverse/demonstrations/v0/**
+/source/dexverse/demonstrations/v1/**
+/source/dexverse/demonstrations/_review/**
+# User-created backup of the private collection tree (including provenance docs).
+/source/dexverse/demonstrations copy/
 
 # Legacy/orphaned demo data (superseded by demonstrations/, hosted on HF).
 /demos/
@@ -113,3 +125,4 @@ tests/
 
 AGENTS.md
 env.sh
+/.worktrees/

--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@
 
 This repository is the official codebase for **DexVerse**, a benchmark for tabletop dexterous
 manipulation built on [Isaac Lab](https://github.com/isaac-sim/IsaacLab). 
-**Docs:** `source/dexverse/docs/envdocs.md` lists the registered tasks.
+See [demo download and H5 conversion](docs/demo_conversion.md), or run
+`python scripts/list_envs.py` for the registered task catalog.
 
 ## Repository Structure
 
@@ -44,13 +45,13 @@ DexVerse/
 ├── source/dexverse/                 # Installable Python package (the Isaac Lab extension)
 │   ├── dexverse/                        # Core package
 │   │   ├── tasks/                           # Task/environment definitions and configs
+│   │   ├── baseline_v1/                     # Upgraded versions of the 20 baseline tasks
 │   │   ├── assets/                          # Asset configs (objects, scenes, background HDRIs, ...)
 │   │   ├── devices/                         # Teleop input devices (OpenXR, retargeters)
 │   │   ├── robot_agents/                    # Per-robot-hand configs
 │   │   └── utils/                           # Shared utilities
 │   ├── demonstrations/                  # Demonstration data (populated by download_demos.py)
-│   ├── docker_utils/                    # Docker Compose patch for IsaacLab. 
-│   └── docs/                            # Extension docs; envdocs.md lists all registered tasks
+│   └── docker_utils/                    # Docker Compose patch for IsaacLab
 ├── scripts/                         # Entry points and tooling (not installed as a package)
 │   ├── list_envs.py                     # List registered tasks
 │   ├── zero_agent.py / random_agent.py  # Dummy agents for sanity checks
@@ -60,7 +61,7 @@ DexVerse/
 │   ├── asset_tools/                     # Asset download utilities
 │   └── demo_tools/                      # Demo download / conversion / inspection utilities
 ├── datastorage/                     # Host-mounted demo output (Docker; gitignored contents)
-└── docs/                            # Repo-level docs (observation space, known hand issues)
+└── docs/                            # Demo conversion guide and project images
 ```
 
 
@@ -182,8 +183,8 @@ The bundles extract into `source/dexverse/dexverse/assets/`. Note that `--all` p
 (core assets ~410 MB, ManiTwin object pool ~2.2 GB, HDRIs ~1.8 GB, plus long-horizon task meshes),
 so expect a few GB of downloads.
 
-With both downloads in place, every registered environment is functional. If you only need a
-subset (a single hand, or just the core assets), both scripts support finer-grained flags — run
+Some tasks require additional generated assets; see [baseline task versions](#baseline-task-versions).
+If you only need a subset (a single hand, or just the core assets), both scripts support finer-grained flags — run
 them with `--help`, or `download_robot_agents.py --list` to see the available hand bundles.
 
 ## Quick Start
@@ -205,9 +206,8 @@ python scripts/random_agent.py --task=<TASK_NAME> --enable_cameras --num_envs=1
 ```
 
 If the simulator window opens and the scene steps without errors, the core installation is complete.
-Pick any `<TASK_NAME>` from the `list_envs.py` output (the full catalog is documented in
-`source/dexverse/docs/envdocs.md`), and use `--num_envs=<N>` to control how many parallel
-environments are spawned.
+Pick any `<TASK_NAME>` from the `list_envs.py` output, and use `--num_envs=<N>`
+to control how many parallel environments are spawned.
 
 ## Teleoperation and Data Collection
 
@@ -267,6 +267,35 @@ When finished, stop the containers from the Isaac Lab root:
 
 
 
+### Baseline task versions
+
+The 20 baseline task families have paired `-v0` (original) and `-v1` (upgraded)
+environments. Select the version in the task ID, for example
+`Dexverse-PushT-v0` or `Dexverse-PushT-v1`.
+Original tasks remain in `dexverse/tasks/`; their baseline upgrades live beside
+them in `dexverse/baseline_v1/`. This is task versioning, not a separate benchmark release.
+
+**Control compatibility:** v1 reuses the shared robot definitions but keeps its
+collection/control differences in `baseline_v1/control_profile.py`: floating
+Shadow wrist simulation/command limits are ±2π, and vector retargeting uses
+`low_pass_alpha=0.2` and `scaling_factor=1.125` for both hands (v0: alpha 0.8,
+left scale 1.3, right scale 1.125). The filter/scale affect teleop collection;
+wrist limits also affect policy execution. These explicit overrides preserve
+the v1 setup without duplicating robots or changing v0. Matching action shapes
+do not make a v0-trained policy compatible with v1; validate the task and control
+settings before transferring policies.
+
+```bash
+python scripts/list_envs.py --baseline --version all --names_only
+```
+
+Both versions use the same benchmark prerequisites. Before running the cutaway
+door v1 task, generate its USD from the supplied URDF:
+
+```bash
+python scripts/asset_tools/convert_cutaway_door.py --headless
+```
+
 ### Debug teleoperation (`teleop_agent.py`)
 
 Use `scripts/teleop_agent.py` to test VR teleop, retargeting, and task setup **without** writing demos to disk.  
@@ -285,6 +314,11 @@ Common optional flags:
 - `--teleop_retargeter relative|absolute` — wrist retargeting mode (default: `relative`). `relative` takes the pose of the operator's wrist when the teleoperation process is started. `absolute` directly take the pose of the operator's wrist in the simulator's frame and match the robot's wrist link to that.  
 - `--retargeting_scheme dexpilot|vector` — finger retargeting optimizer (default: `dexpilot`)
 - `--enable_debug_vis` — show zone / reference-point markers in the viewport
+
+The debug switch also controls v1 hand-tracking dots and current-object frames.
+The same controls are available in zero-agent and recording; use
+`--cues_in_rgb` / `--no-cues_in_rgb` to choose camera visibility separately.
+Task-defining goals remain visible.
 
 Use START / STOP / RESET from the XR client to control the session (more details see the official IsaacLab CloudXR guide).
 
@@ -310,15 +344,26 @@ cd /workspace/dexverse
 
 By default, output path on the host: `DexVerse/datastorage/grasping/Dexverse-PickUpStick-v0/<TASK>_<timestamp>.pkl`. File names can also be specified. See output of `--help` for other argument options. 
 
-Each pickle includes per-step scene states (`record_state` is always on). Use START to begin
-recording an episode; a demo is saved after `--num_success_steps` consecutive successful steps. To see other arguments, use `--help`. Smooth teleoperation also depends on CPU, GPU, and network condition. 
+New recordings include the selected `task_version`, `benchmark_revision`, and `action_layout`.
+Use `--device cpu` for consistent collection/replay device selection and
+`--seed N` to seed collection randomness; this does not guarantee identical physics
+across machines. The resolved seed is saved in each session. Teleop and zero-agent
+also accept `--seed`.
+
+Each pickle includes per-step scene states (`record_state` is always on), plus per-episode
+command and task-buffer state used to reconstruct randomized goals and their visual markers.
+Use START to begin recording an episode; a demo is saved after `--num_success_steps`
+consecutive successful steps. To see other arguments, use `--help`. Smooth teleoperation also
+depends on CPU, GPU, and network condition.
 
 ### Basic replaying and converting demos (`--set-state`)
 
 Isaac Sim / PhysX dynamics can differ slightly across GPUs and driver versions, so replaying
 recorded **actions** step-by-step on another machine may drift from the original trajectory.
 
-When converting pickles to HDF5 for training, it is recommended to use `scripts/demo_tools/create_demo_files_sequential.py` with `--set-state` (the default). This flag directly set the recorded scene state at each timestep instead of using environment steps from actions. This keeps observations consistent across machines.
+When converting pickles to HDF5, use `scripts/demo_tools/create_demo_files_sequential.py`
+with `--set-state` (the default) to restore recorded scene states at each timestep.
+This is not a guarantee of identical contact observations or successful action-driven replay.
 
 ```bash
 python scripts/demo_tools/create_demo_files_sequential.py \
@@ -327,6 +372,30 @@ python scripts/demo_tools/create_demo_files_sequential.py \
 ```
 
 Pass `--no-set-state` only if you explicitly want true action replay. See `create_demo_files_sequential.py --help` for the full set of output and selection options.
+
+For curated baseline demos, select the task **including its version**. Once the
+versioned release is available in the dataset repository:
+
+```bash
+# Download all available v0 AND v1 baselines (reports missing sets).
+python scripts/demo_tools/download_demos.py --repo dexverse/DexVerse_release --baseline
+
+# Or download one exact task/version.
+python scripts/demo_tools/download_demos.py --repo dexverse/DexVerse_release --task Dexverse-PushT-v1
+
+# Convert that task's curated demos.pkl; change -v1 to -v0 for the original task.
+python scripts/demo_tools/create_demo_files_sequential.py \
+    --task Dexverse-PushT-v1 --obs-groups state --device cpu \
+    --set-state --output-dir outputs/h5
+```
+
+Output is `outputs/h5/v1/non_prehensile/Dexverse-PushT-v1/Dexverse-PushT-v1.state.seq.demo.h5`.
+All 50 trajectories in a complete set are converted by default. Task selection
+never recursively merges collection sessions or substitutes another version.
+Use `--dry-run` to inspect selection without starting the simulator; use
+`--demos-root PATH` for a different download directory or prepared local release.
+Raw-session conversion remains available through `--file PATH` or the explicit
+`--legacy-collections` option. See [versioned H5 conversion](docs/demo_conversion.md).
 
 #### Observation modes (`--obs-groups`)
 
@@ -401,7 +470,9 @@ See also `source/dexverse/docker_utils/README.md` for Docker mount details.
 
 ## Demonstrations
 
-> 🚧 **Data and Instructions Coming soon.** 
+See [demo download and H5 conversion](docs/demo_conversion.md) for versioned task
+selection. The dataset manifest lists available recordings; the dataset card
+specifies their license. Demonstrations are distributed separately from the code.
 
 
 

--- a/README.md
+++ b/README.md
@@ -142,15 +142,16 @@ python -m pip install matplotlib "opencv-python<4.12" open3d imageio-ffmpeg "num
 
 ## Downloading Assets
 
-The robot hand and object/scene assets are not stored in the git repository. They are hosted on the gated
+The robot hand and object/scene assets are not stored in the git repository. They are hosted on the public
 Hugging Face dataset [`dexverse/DexVerse_release`](https://huggingface.co/datasets/dexverse/DexVerse_release)
-and must be downloaded before any environment can run. Log in once and accept the dataset terms:
+and must be downloaded before any environment can run. No Hugging Face login is required:
 
 ```bash
 pip install huggingface_hub
-hf auth login   # and follow the prompt to login to hugging face
-# alternatively, you can create hugging face tokens and set the environmetn HF_TOKEN=<your-token> 
 ```
+
+Robot, asset, and demo downloaders default to this release. Use `--repo OWNER/DATASET`
+to override it; `hf auth login` is only needed if that dataset requires authentication.
 
 
 

--- a/docs/demo_conversion.md
+++ b/docs/demo_conversion.md
@@ -1,0 +1,50 @@
+# Download demonstrations and convert to H5
+
+Run from the DexVerse checkout installed in your `dexverse` environment, using
+NumPy 1.26 and the task's assets. Only load trusted pickles. Isaac Sim requires a
+supported NVIDIA GPU for startup/rendering even when physics uses CPU.
+
+## Download
+
+Once the versioned release is available in the dataset repository:
+
+```bash
+conda activate dexverse
+python scripts/demo_tools/download_demos.py \
+  --repo dexverse/DexVerse_release --baseline
+```
+
+`--baseline` selects available v0 and v1 sets. Use `--version v0` or `--version v1`
+to narrow selection, or `--task Dexverse-PushT-v1` for one set. Follow the dataset's
+access requirements if authentication is requested. Files are checksum-verified;
+different local files are not overwritten. Use `--dest PATH` for another location.
+
+Downloads use `source/dexverse/demonstrations/v0|v1/<category>/<task>/demos.pkl`.
+Consult the dataset card for the demonstration license.
+
+## Convert by task and version
+
+```bash
+python scripts/demo_tools/create_demo_files_sequential.py \
+  --task Dexverse-PushT-v1 --obs-groups state --device cpu \
+  --set-state --output-dir outputs/h5
+```
+
+Change `-v1` to `-v0` to select the original task. Output goes under
+`outputs/h5/v1/non_prehensile/Dexverse-PushT-v1/`; v0 uses a separate directory.
+All trajectories are converted by default (50 in a complete set).
+
+- Add `--select-episodes 0 1 2` for a small test, or `--dry-run` to inspect selection
+  without launching the simulator.
+- Use `--demos-root PATH` for a different download directory.
+- Use `--obs-groups rgb` for image observations. Groups depend on the task:
+  Push-T v0 needs `--obs-groups privileged policy proprio` for object/goal state.
+- Task selection uses only the curated `demos.pkl`, not raw sessions or backups.
+  Use `--file PATH` explicitly for a raw recording.
+- Existing H5s are reused only when inputs, selection, settings and completeness
+  match. Otherwise choose a new output directory; `--overwrite` deliberately
+  replaces existing output.
+
+CPU physics and set-state replay are defaults. Set-state restores recorded
+states; it does not verify action-driven success or identical contact physics.
+Run the scripts with `--help` for additional options.

--- a/docs/demo_conversion.md
+++ b/docs/demo_conversion.md
@@ -6,12 +6,11 @@ supported NVIDIA GPU for startup/rendering even when physics uses CPU.
 
 ## Download
 
-Once the versioned release is available in the dataset repository:
+The downloader defaults to the public `dexverse/DexVerse_release` dataset; no login is required:
 
 ```bash
 conda activate dexverse
-python scripts/demo_tools/download_demos.py \
-  --repo dexverse/DexVerse_release --baseline
+python scripts/demo_tools/download_demos.py --baseline
 ```
 
 `--baseline` selects available v0 and v1 sets. Use `--version v0` or `--version v1`

--- a/scripts/asset_tools/build_rack_usd.py
+++ b/scripts/asset_tools/build_rack_usd.py
@@ -1,0 +1,59 @@
+# Copyright (c) 2025-2026, The DexVerse Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Generate a parametric multi-level rack (shelf unit) as a single rigid USD.
+
+Thin CLI around :func:`dexverse.assets.rack_builder.build_rack` (see that
+module for the geometry / frame conventions and the manifest layout).
+
+    python scripts/asset_tools/build_rack_usd.py                 # default 3-level rack
+    python scripts/asset_tools/build_rack_usd.py --levels 4 --spacing 0.16 --name rack_4level
+
+Requires ``pxr`` (ships with Isaac Sim's python). No simulator launch needed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+REPO_SRC = Path(__file__).resolve().parents[2] / "source" / "dexverse"
+if str(REPO_SRC) not in sys.path:
+    sys.path.insert(0, str(REPO_SRC))
+
+from dexverse.assets.rack_builder import RACK_ASSET_DIR, build_rack  # noqa: E402
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--out_dir", type=Path, default=RACK_ASSET_DIR)
+    ap.add_argument("--name", type=str, default="rack_3level")
+    ap.add_argument("--levels", type=int, default=3)
+    ap.add_argument("--spacing", type=float, default=0.18, help="Vertical distance between shelf tops (m).")
+    ap.add_argument("--depth", type=float, default=0.40, help="Rack extent along x (m).")
+    ap.add_argument("--width", type=float, default=0.55, help="Rack extent along y (m).")
+    ap.add_argument("--board_thickness", type=float, default=0.02)
+    ap.add_argument("--post_size", type=float, default=0.03)
+    ap.add_argument("--bottom_gap", type=float, default=0.10, help="Height of the lowest shelf top above the rack base (m).")
+    ap.add_argument("--top_margin", type=float, default=0.03, help="Post height above the top shelf (m).")
+    args = ap.parse_args()
+    usd, manifest = build_rack(
+        args.out_dir,
+        name=args.name,
+        levels=args.levels,
+        spacing=args.spacing,
+        depth=args.depth,
+        width=args.width,
+        board_thickness=args.board_thickness,
+        post_size=args.post_size,
+        bottom_gap=args.bottom_gap,
+        top_margin=args.top_margin,
+    )
+    print(f"wrote {usd}\nwrote {manifest}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/asset_tools/convert_cutaway_door.py
+++ b/scripts/asset_tools/convert_cutaway_door.py
@@ -1,0 +1,54 @@
+"""Convert the source-only cutaway door URDF using Isaac Sim's importer.
+
+Run: python scripts/run_local.py scripts/asset_tools/convert_cutaway_door.py --headless
+No downloads. Output is an ignored generated asset; original door is untouched.
+"""
+
+import argparse
+import math
+from pathlib import Path
+
+from isaaclab.app import AppLauncher
+
+ROOT = Path(__file__).resolve().parents[2]
+OUTPUT = ROOT / "source/dexverse/dexverse/assets/core_assets/dexverse_authored/cutaway_door"
+parser = argparse.ArgumentParser(description=__doc__)
+parser.add_argument("--output-dir", type=Path, default=OUTPUT)
+AppLauncher.add_app_launcher_args(parser)
+args = parser.parse_args()
+app = AppLauncher(args).app
+
+from isaaclab.sim.converters import UrdfConverter, UrdfConverterCfg  # noqa: E402
+
+try:
+    cfg = UrdfConverterCfg(
+        asset_path=str(ROOT / "scripts/asset_tools/urdf/cutaway_door.urdf"),
+        usd_dir=str(args.output_dir.resolve()),
+        usd_file_name="cutaway_door.usd",
+        fix_base=True,
+        merge_fixed_joints=False,
+        self_collision=True,
+        make_instanceable=False,
+        collision_from_visuals=False,
+        collider_type="convex_hull",  # Separate panel boxes and one convex bevel; never hull the whole panel.
+        force_usd_conversion=True,
+        joint_drive=UrdfConverterCfg.JointDriveCfg(
+            target_type="position",
+            gains=UrdfConverterCfg.JointDriveCfg.PDGainsCfg(
+                stiffness={"door_hinge": 0.20, "latch_slide": 12.0},
+                damping={"door_hinge": 0.12, "latch_slide": 1.0},
+            ),
+        ),
+    )
+    converter = UrdfConverter(cfg)
+    from pxr import Usd, UsdPhysics
+
+    stage = Usd.Stage.Open(converter.usd_path)
+    joint = stage.GetPrimAtPath("/cutaway_door/joints/door_hinge")
+    # URDF has no portable spring preload; preserve it in the standalone USD
+    # as well as in the task's reset-time targets. USD angles use degrees.
+    UsdPhysics.DriveAPI.Get(joint, "angular").GetTargetPositionAttr().Set(math.degrees(-0.20))
+    stage.GetRootLayer().Save()
+    print(f"CUTAWAY_DOOR_USD: {converter.usd_path}", flush=True)
+finally:
+    app.close()

--- a/scripts/asset_tools/urdf/cutaway_door.urdf
+++ b/scripts/asset_tools/urdf/cutaway_door.urdf
@@ -1,0 +1,72 @@
+<?xml version="1.0"?>
+<robot name="cutaway_door">
+  <!-- SI units; root at the hinge foot. Door opens +Z, from +X toward +Y.
+       Near 90 degrees the lower window lip cams the beveled spring catch up.
+       After passing its vertical retaining face, the spring drops it into
+       the window and the closing spring seats the door against the catch.
+       Keep separate box colliders: a single convex hull would fill the hole.
+       Spring drives are configured in Isaac Lab, not portable URDF dynamics.
+       Required: fixed base, self collision ON, no fixed-joint merging. -->
+  <material name="frame_grey"><color rgba="0.32 0.32 0.34 1"/></material>
+  <material name="panel_grey"><color rgba="0.60 0.60 0.62 1"/></material>
+  <material name="catch_orange"><color rgba="0.90 0.48 0.12 1"/></material>
+  <link name="frame">
+    <inertial><origin xyz="0 0 0.10"/><mass value="3"/><inertia ixx="0.06" iyy="0.06" izz="0.06" ixy="0" ixz="0" iyz="0"/></inertial>
+    <visual><origin xyz="0.12 0.13 0.006"/><geometry><box size="0.46 0.34 0.012"/></geometry><material name="frame_grey"/></visual>
+    <collision><origin xyz="0.12 0.13 0.006"/><geometry><box size="0.46 0.34 0.012"/></geometry></collision>
+    <!-- Full, 10 cm deep surround. Top, sill and free jamb leave 5 mm
+         running gaps: too narrow to hook a finger around the closed panel.
+         The hinge jamb has a rear rebate to block rear finger access while
+         relieving the opening side for the panel's entire 0-96 degree sweep. -->
+    <visual name="frame_header"><origin xyz="0.1635 0 0.4425"/><geometry><box size="0.433 0.100 0.035"/></geometry><material name="frame_grey"/></visual>
+    <collision name="frame_header"><origin xyz="0.1635 0 0.4425"/><geometry><box size="0.433 0.100 0.035"/></geometry></collision>
+    <visual name="frame_sill"><origin xyz="0.1635 0 0.0075"/><geometry><box size="0.433 0.100 0.015"/></geometry><material name="frame_grey"/></visual>
+    <collision name="frame_sill"><origin xyz="0.1635 0 0.0075"/><geometry><box size="0.433 0.100 0.015"/></geometry></collision>
+    <visual name="frame_free_jamb"><origin xyz="0.3625 0 0.22"/><geometry><box size="0.035 0.100 0.410"/></geometry><material name="frame_grey"/></visual>
+    <collision name="frame_free_jamb"><origin xyz="0.3625 0 0.22"/><geometry><box size="0.035 0.100 0.410"/></geometry></collision>
+    <visual name="frame_hinge_jamb"><origin xyz="-0.0365 0 0.22"/><geometry><box size="0.033 0.100 0.410"/></geometry><material name="frame_grey"/></visual>
+    <collision name="frame_hinge_jamb"><origin xyz="-0.0365 0 0.22"/><geometry><box size="0.033 0.100 0.410"/></geometry></collision>
+    <visual name="frame_hinge_rebate"><origin xyz="-0.0105 -0.032 0.22"/><geometry><box size="0.019 0.036 0.410"/></geometry><material name="frame_grey"/></visual>
+    <collision name="frame_hinge_rebate"><origin xyz="-0.0105 -0.032 0.22"/><geometry><box size="0.019 0.036 0.410"/></geometry></collision>
+    <!-- Latch support is outside the door's sweep through 96 degrees. -->
+    <visual><origin xyz="-0.074 0.255 0.088"/><geometry><box size="0.030 0.055 0.150"/></geometry><material name="frame_grey"/></visual>
+    <collision><origin xyz="-0.074 0.255 0.088"/><geometry><box size="0.030 0.055 0.150"/></geometry></collision>
+  </link>
+  <link name="door">
+    <inertial><origin xyz="0.160 0 0.214"/><mass value="0.65"/><inertia ixx="0.010" iyy="0.016" izz="0.006" ixy="0" ixz="0" iyz="0"/></inertial>
+    <!-- Four boxes form a REAL 14 x 8 cm window: x=[.18,.32], z=[.21,.29].
+         Panel spans x=[.004,.34], z=[.020,.42], thickness 18 mm. -->
+    <visual><origin xyz="0.092 0 0.22"/><geometry><box size="0.176 0.018 0.40"/></geometry><material name="panel_grey"/></visual>
+    <collision><origin xyz="0.092 0 0.22"/><geometry><box size="0.176 0.018 0.40"/></geometry></collision>
+    <visual><origin xyz="0.260 0 0.115"/><geometry><box size="0.16 0.018 0.19"/></geometry><material name="panel_grey"/></visual>
+    <collision><origin xyz="0.260 0 0.115"/><geometry><box size="0.16 0.018 0.19"/></geometry></collision>
+    <visual><origin xyz="0.260 0 0.355"/><geometry><box size="0.16 0.018 0.13"/></geometry><material name="panel_grey"/></visual>
+    <collision><origin xyz="0.260 0 0.355"/><geometry><box size="0.16 0.018 0.13"/></geometry></collision>
+    <visual><origin xyz="0.330 0 0.25"/><geometry><box size="0.020 0.018 0.08"/></geometry><material name="panel_grey"/></visual>
+    <collision><origin xyz="0.330 0 0.25"/><geometry><box size="0.020 0.018 0.08"/></geometry></collision>
+  </link>
+  <joint name="door_hinge" type="revolute">
+    <parent link="frame"/><child link="door"/><origin xyz="0 0 0"/><axis xyz="0 0 1"/>
+    <limit lower="0" upper="1.675516082" effort="3" velocity="2"/>
+    <dynamics damping="0.12" friction="0.0"/>
+  </joint>
+  <link name="latch">
+    <inertial><origin xyz="-0.005 0.25 0.215"/><mass value="0.06"/><inertia ixx="0.00009" iyy="0.00010" izz="0.00015" ixy="0" ixz="0" iyz="0"/></inertial>
+    <!-- 12 x 6 cm retaining face, slightly smaller than the 14 x 8 cm hole.
+         The opening-side bevel rises toward +X; the approaching door cams
+         the catch up ~35 mm, then its spring returns it behind the lower lip.
+         The vertical -X face resists closing, without a software joint lock.
+         Mesh is a local, source-authored convex triangular prism (SI units). -->
+    <visual name="latch_bevel"><origin xyz="0.015 0.19 0.18"/><geometry><mesh filename="latch_wedge.obj"/></geometry><material name="catch_orange"/></visual>
+    <collision name="latch_bevel"><origin xyz="0.015 0.19 0.18"/><geometry><mesh filename="latch_wedge.obj"/></geometry></collision>
+    <visual name="latch_bridge"><origin xyz="-0.030 0.25 0.234"/><geometry><box size="0.090 0.120 0.012"/></geometry><material name="catch_orange"/></visual>
+    <collision name="latch_bridge"><origin xyz="-0.030 0.25 0.234"/><geometry><box size="0.090 0.120 0.012"/></geometry></collision>
+    <visual><origin xyz="-0.074 0.25 0.190"/><geometry><box size="0.025 0.055 0.080"/></geometry><material name="catch_orange"/></visual>
+    <collision><origin xyz="-0.074 0.25 0.190"/><geometry><box size="0.025 0.055 0.080"/></geometry></collision>
+  </link>
+  <joint name="latch_slide" type="prismatic">
+    <parent link="frame"/><child link="latch"/><origin xyz="0 0 0"/><axis xyz="0 0 1"/>
+    <limit lower="0" upper="0.055" effort="5" velocity="0.5"/>
+    <dynamics damping="1.0" friction="0.0"/>
+  </joint>
+</robot>

--- a/scripts/asset_tools/urdf/latch_wedge.obj
+++ b/scripts/asset_tools/urdf/latch_wedge.obj
@@ -1,0 +1,17 @@
+# Convex spring-latch nose, meters. Width Y=.12, height Z=.06, ramp run X=.05.
+# The X=0 face retains the door; the sloped underside cams upward on approach.
+o latch_wedge
+v 0 0 0
+v 0 0 0.06
+v 0.05 0 0.06
+v 0 0.12 0
+v 0 0.12 0.06
+v 0.05 0.12 0.06
+f 1 3 2
+f 4 5 6
+f 1 5 4
+f 1 2 5
+f 2 6 5
+f 2 3 6
+f 1 6 3
+f 1 4 6

--- a/scripts/demo_tools/audit_demos.py
+++ b/scripts/demo_tools/audit_demos.py
@@ -1,0 +1,326 @@
+#!/usr/bin/env python3
+# Copyright (c) 2025-2026, The DexVerse Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Audit teleop demo sets for validity, coverage, horizon slack and signal quality.
+
+Reads the session pickles (``record_demos.py`` output) and, when available, the
+replayed HDF5 (``create_demo_files_sequential.py`` output) of one or more
+``<category>/<Task>/<session>`` demo sets and prints, per set:
+
+  A1 criterion replay   -- does the task's success term fire when the demo is replayed,
+                           and how late (should be ~end of episode);
+  A2 rule violations    -- failure terminations tripped by any demo;
+  A3 post-success tail  -- steps recorded after the first success;
+  B5 reset coverage     -- initial-pose spread per scene entity, quartile occupancy
+                           (against ``--range`` when given, else the demos' own span);
+  B6 goal balance       -- counts of discrete per-episode goals (``task_state`` buffers);
+  B8 horizon slack      -- episode lengths vs the eval horizon;
+  C13 signal quality    -- idle lead/trail, idle fraction, action jerk, per session.
+
+Requires NO Isaac; runs on the raw files. Examples::
+
+    python scripts/demo_tools/audit_demos.py \\
+        --task functional/Dexverse-FunctionalPourMug-v0/0823_zhuxiu --horizon 1200 \\
+        --range PourMug:object:-0.10,0.20,-0.35,0.35
+
+    python scripts/demo_tools/audit_demos.py --task bimanual/Dexverse-BimanualCartonRegrasp-v0/0823_zhuxiu \\
+        --task articulation/Dexverse-CutStripScissors-v0/0824_zhuxiu_final50 --json audit.json
+
+NOTE: A1-A3 need an H5 replayed with a replayer that advances ``episode_length_buf``
+during set-state replay (fixed 2026-08-25). Older H5s report 0 fires for stage-machine /
+cut-sweep tasks -- re-replay before trusting A1 for those.
+"""
+from __future__ import annotations
+
+import argparse
+import glob
+import json
+import os
+import pickle
+import sys
+
+import numpy as np
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+DEFAULT_DEMOS_ROOT = os.path.join(REPO_ROOT, "source", "dexverse", "demonstrations")
+DEFAULT_H5_ROOT = os.path.join(REPO_ROOT, "outputs", "demos_h5")
+
+
+def _yaw_deg(q: np.ndarray) -> np.ndarray:
+    w, x, y, z = q[:, 0], q[:, 1], q[:, 2], q[:, 3]
+    return np.degrees(np.arctan2(2 * (w * z + x * y), 1 - 2 * (y * y + z * z)))
+
+
+def _quartiles(u: np.ndarray) -> list[int]:
+    return np.histogram(np.clip(u, 0, 1), bins=4, range=(0, 1))[0].tolist()
+
+
+def _idle(actions: np.ndarray, thr: float = 1e-3) -> tuple[int, int, float]:
+    if len(actions) < 2:
+        return 0, 0, 0.0
+    still = np.abs(np.diff(actions, axis=0)).max(axis=1) < thr
+    moving = ~still
+    lead = int(np.argmax(moving)) if moving.any() else len(still)
+    trail = int(np.argmax(moving[::-1])) if moving.any() else len(still)
+    return lead, trail, float(still.mean())
+
+
+def load_set(demos_root: str, rel: str) -> dict:
+    session_dir = os.path.join(demos_root, rel)
+    pkls = sorted(glob.glob(os.path.join(session_dir, "*.pkl")))
+    if not pkls:
+        raise SystemExit(f"no pickles under {session_dir}")
+    episodes, sessions, meta = [], [], None
+    for p in pkls:
+        with open(p, "rb") as fp:
+            d = pickle.load(fp)
+        if d.get("format") != "dexverse_trajectory":
+            print(f"  [skip] {os.path.basename(p)}: format={d.get('format')!r}")
+            continue
+        meta = meta or {k: d.get(k) for k in ("task", "robot_type", "schema_version")}
+        for e in d.get("episodes", []):
+            episodes.append(e)
+            sessions.append(os.path.basename(p))
+    return {"rel": rel, "episodes": episodes, "sessions": sessions, "meta": meta or {}, "session_dir": session_dir}
+
+
+def find_h5(h5_root: str, rel: str) -> str | None:
+    session = rel.rstrip("/").split("/")[-1]
+    cand = os.path.join(h5_root, rel, f"{session}.pointcloud.seq.demo.h5")
+    if os.path.isfile(cand):
+        return cand
+    hits = sorted(glob.glob(os.path.join(h5_root, rel, "*.seq.demo.h5")))
+    return hits[0] if hits else None
+
+
+def audit_replay(h5_path: str | None) -> dict:
+    out = {"h5": h5_path}
+    if h5_path is None:
+        return out
+    import h5py
+
+    with h5py.File(h5_path, "r") as hf:
+        demos = list(hf["data"].keys())
+        fires, first_frac, tails, no_attr, violations = [], [], [], [], {}
+        for k in demos:
+            g = hf["data"][k]
+            if not bool(g.attrs.get("success", False)):
+                no_attr.append(k)
+            terms = g["terminations"] if "terminations" in g else {}
+            if "success" in terms:
+                s = terms["success"][...].astype(bool)
+                if s.any():
+                    f = int(np.argmax(s))
+                    fires.append(k)
+                    first_frac.append(f / max(1, len(s)))
+                    tails.append(len(s) - f)
+            for t in terms:
+                if t in ("success", "time_out"):
+                    continue
+                if terms[t][...].astype(bool).any():
+                    violations.setdefault(t, []).append(k)
+        out.update(
+            demos=len(demos),
+            attr_success=len(demos) - len(no_attr),
+            fires=len(fires),
+            first_success_pct_median=float(np.median(first_frac) * 100) if first_frac else None,
+            tail_median=float(np.median(tails)) if tails else None,
+            tail_max=int(max(tails)) if tails else None,
+            no_fire=[k for k in demos if k not in fires],
+            violations={t: len(v) for t, v in violations.items()},
+        )
+    return out
+
+
+def audit_coverage(episodes: list, ranges: dict[str, tuple[float, float, float, float]]) -> dict:
+    st0 = episodes[0].get("initial_state", {})
+    entities = [("rigid_object", k) for k in st0.get("rigid_object", {}) if "table" not in k] + [
+        ("articulation", k) for k in st0.get("articulation", {}) if k != "robot"
+    ]
+    out = {}
+    for grp, name in entities:
+        try:
+            P = np.array([np.asarray(e["initial_state"][grp][name]["root_pose"]).reshape(-1)[:7] for e in episodes])
+        except Exception:
+            continue
+        yaw = _yaw_deg(P[:, 3:7])
+        rec = {
+            "x": [float(P[:, 0].min()), float(P[:, 0].max()), float(P[:, 0].std())],
+            "y": [float(P[:, 1].min()), float(P[:, 1].max()), float(P[:, 1].std())],
+            "yaw_deg": [float(yaw.min()), float(yaw.max()), float(yaw.std())],
+        }
+        if name in ranges:
+            x0, x1, y0, y1 = ranges[name]
+            rec["range"] = ranges[name]
+            rec["quartiles_x"] = _quartiles((P[:, 0] - x0) / max(1e-9, x1 - x0))
+            rec["quartiles_y"] = _quartiles((P[:, 1] - y0) / max(1e-9, y1 - y0))
+            rec["outside_range"] = int(((P[:, 0] < x0) | (P[:, 0] > x1) | (P[:, 1] < y0) | (P[:, 1] > y1)).sum())
+        elif P[:, 0].std() > 1e-4 or P[:, 1].std() > 1e-4:
+            rec["quartiles_x"] = _quartiles((P[:, 0] - P[:, 0].min()) / max(1e-9, np.ptp(P[:, 0])))
+            rec["quartiles_y"] = _quartiles((P[:, 1] - P[:, 1].min()) / max(1e-9, np.ptp(P[:, 1])))
+        out[f"{grp}/{name}"] = rec
+    return out
+
+
+def audit_goals(episodes: list) -> dict:
+    counts: dict[str, dict] = {}
+    for e in episodes:
+        ts = e.get("task_state") or {}
+        for bname, val in (ts.get("env_buffers") or {}).items():
+            v = np.asarray(val)
+            if v.size == 1 and float(v).is_integer():
+                counts.setdefault(bname, {})
+                counts[bname][int(v)] = counts[bname].get(int(v), 0) + 1
+    return {b: dict(sorted(c.items())) for b, c in counts.items()}
+
+
+def audit_horizon(episodes: list, horizon: int) -> dict:
+    L = np.array([len(e.get("actions", [])) for e in episodes])
+    return {
+        "horizon": horizon,
+        "len_min": int(L.min()), "len_median": float(np.median(L)), "len_mean": float(L.mean()), "len_max": int(L.max()),
+        "over_60pct": int((L > 0.6 * horizon).sum()), "over_80pct": int((L > 0.8 * horizon).sum()), "over_horizon": int((L > horizon).sum()),
+    }
+
+
+def audit_signal(episodes: list, sessions: list) -> dict:
+    per = {}
+    for e, s in zip(episodes, sessions):
+        a = np.asarray(e.get("actions", []), dtype=np.float32)
+        if a.ndim != 2 or len(a) < 3:
+            continue
+        lead, trail, frac = _idle(a)
+        jerk = float(np.abs(np.diff(a, n=2, axis=0)).mean())
+        per.setdefault(s, []).append((lead, trail, frac, jerk, len(a)))
+    out = {}
+    for s, rows in per.items():
+        r = np.array(rows, dtype=np.float64)
+        out[s] = {"episodes": len(rows), "idle_lead_med": float(np.median(r[:, 0])), "idle_trail_med": float(np.median(r[:, 1])),
+                  "idle_frac_mean": float(r[:, 2].mean()), "jerk_mean": float(r[:, 3].mean()), "len_mean": float(r[:, 4].mean())}
+    allr = np.array([row for rows in per.values() for row in rows], dtype=np.float64)
+    out["_all"] = {"episodes": int(len(allr)), "idle_frac_mean": float(allr[:, 2].mean()), "jerk_mean": float(allr[:, 3].mean()),
+                   "jerk_p90": float(np.percentile(allr[:, 3], 90))} if len(allr) else {}
+    return out
+
+
+def flags_for(rep: dict) -> list[str]:
+    f = []
+    r = rep["replay"]
+    if r.get("h5") is None:
+        f.append("A1: no replay H5 found -> criterion/violation audits skipped")
+    else:
+        if r["fires"] < r["demos"]:
+            f.append(f"A1: success term fired in only {r['fires']}/{r['demos']} replayed demos"
+                     + (" (0 fires: if this H5 predates the step-counter replay fix of 2026-08-25, re-replay)" if r["fires"] == 0 else ""))
+        if r.get("first_success_pct_median") is not None and r["first_success_pct_median"] < 85:
+            f.append(f"A1: success fires early (median {r['first_success_pct_median']:.0f}% of episode) -> criterion may be too loose or demos overrun")
+        if r.get("tail_max") and r["tail_max"] > 60:
+            f.append(f"A3: up to {r['tail_max']} steps recorded after success -> trim demos at first success (+margin)")
+        for t, n in r.get("violations", {}).items():
+            f.append(f"A2: {n} demos trip failure rule '{t}'")
+    for ent, c in rep["coverage"].items():
+        if "range" in c:
+            exp = rep["n"] / 4
+            for ax in ("x", "y"):
+                q = c[f"quartiles_{ax}"]
+                if min(q) < 0.5 * exp:
+                    f.append(f"B5: {ent} {ax}-quartiles {q} uneven vs configured range (expect ~{exp:.0f} each)")
+            if c.get("outside_range"):
+                f.append(f"B5: {ent}: {c['outside_range']} demos start outside the configured range")
+    for b, counts in rep["goals"].items():
+        exp = rep["n"] / max(1, len(counts))
+        low = {k: v for k, v in counts.items() if v < 0.6 * exp}
+        if low:
+            f.append(f"B6: goal '{b}' imbalanced: {counts} (under-represented: {low})")
+    h = rep["horizon"]
+    if h["over_horizon"]:
+        f.append(f"B8: {h['over_horizon']} demos LONGER than the {h['horizon']}-step horizon (unfinishable at eval)")
+    if h["len_median"] > 0.6 * h["horizon"] or h["over_80pct"] > 0.1 * rep["n"]:
+        f.append(f"B8: little horizon slack (median {h['len_median']:.0f}, {h['over_80pct']} demos > 80% of horizon)")
+    sig = rep["signal"]
+    allj = sig.get("_all", {}).get("jerk_mean")
+    for s, v in sig.items():
+        if s == "_all":
+            continue
+        if allj and v["jerk_mean"] > 1.8 * allj:
+            f.append(f"C13: session {s} is jerky (jerk {v['jerk_mean']:.4f} vs set mean {allj:.4f})")
+        if v["idle_frac_mean"] > 0.15:
+            f.append(f"C13: session {s} idle {v['idle_frac_mean']*100:.0f}% of steps")
+    return f
+
+
+def print_report(rep: dict) -> None:
+    print(f"\n=== {rep['rel']}  ({rep['n']} episodes, {rep['meta'].get('robot_type')}, {len(rep['signal']) - 1} session file(s)) ===")
+    r = rep["replay"]
+    if r.get("h5"):
+        print(f"A1 criterion replay : success fires in {r['fires']}/{r['demos']} demos"
+              + (f", median at {r['first_success_pct_median']:.0f}% of episode" if r["first_success_pct_median"] is not None else "")
+              + f" | teleop success attr: {r['attr_success']}/{r['demos']}")
+        print(f"A2 rule violations  : {r['violations'] or 'none'}")
+        print(f"A3 post-success tail: median {r['tail_median']} / max {r['tail_max']} steps" if r["tail_max"] is not None else "A3 post-success tail: n/a")
+    else:
+        print("A1-A3: no replay H5 found")
+    print("B5 reset coverage   :")
+    for ent, c in rep["coverage"].items():
+        line = f"   {ent:32s} x[{c['x'][0]:+.3f},{c['x'][1]:+.3f}] y[{c['y'][0]:+.3f},{c['y'][1]:+.3f}] yaw[{c['yaw_deg'][0]:+.0f},{c['yaw_deg'][1]:+.0f}]deg"
+        if "quartiles_x" in c:
+            line += f"  quartiles x{c['quartiles_x']} y{c['quartiles_y']}" + (" (vs configured range)" if "range" in c else " (own span)")
+        print(line)
+    print(f"B6 goal balance     : {rep['goals'] or 'no discrete goals recorded'}")
+    h = rep["horizon"]
+    print(f"B8 horizon slack    : len min/med/max {h['len_min']}/{h['len_median']:.0f}/{h['len_max']} vs horizon {h['horizon']} | >60%: {h['over_60pct']}  >80%: {h['over_80pct']}  >100%: {h['over_horizon']}")
+    print("C13 signal quality  :")
+    for s, v in rep["signal"].items():
+        if s == "_all":
+            continue
+        print(f"   {s[-40:]:40s} n={v['episodes']:3d} idle lead/trail {v['idle_lead_med']:.0f}/{v['idle_trail_med']:.0f} idle {v['idle_frac_mean']*100:4.1f}% jerk {v['jerk_mean']:.4f} len {v['len_mean']:.0f}")
+    print("FLAGS:" if rep["flags"] else "FLAGS: none")
+    for fl in rep["flags"]:
+        print(f"   ! {fl}")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--task", action="append", required=True, help="<category>/<Task>/<session> (repeatable)")
+    ap.add_argument("--demos-root", default=DEFAULT_DEMOS_ROOT)
+    ap.add_argument("--h5-root", default=DEFAULT_H5_ROOT)
+    ap.add_argument("--h5", action="append", default=[], help="Explicit replay H5 for the task at the same position (optional).")
+    ap.add_argument("--horizon", type=int, default=1200, help="Eval horizon in env steps (default 1200).")
+    ap.add_argument(
+        "--range",
+        action="append",
+        default=[],
+        help="Configured reset range 'TASKSUBSTR:entity:x0,x1,y0,y1' (world frame, init offsets applied); "
+        "TASKSUBSTR selects which --task it applies to (substring match). Repeatable.",
+    )
+    ap.add_argument("--json", default=None, help="Write the full report to this JSON file.")
+    args = ap.parse_args()
+
+    range_specs = []
+    for r in args.range:
+        task_sub, name, vals = r.split(":", 2)
+        range_specs.append((task_sub, name, tuple(float(v) for v in vals.split(","))))
+    reports = []
+    for i, rel in enumerate(args.task):
+        ds = load_set(args.demos_root, rel)
+        h5 = args.h5[i] if i < len(args.h5) else find_h5(args.h5_root, rel)
+        ranges = {name: vals for task_sub, name, vals in range_specs if task_sub in rel}
+        rep = {"rel": rel, "n": len(ds["episodes"]), "meta": ds["meta"],
+               "replay": audit_replay(h5), "coverage": audit_coverage(ds["episodes"], ranges),
+               "goals": audit_goals(ds["episodes"]), "horizon": audit_horizon(ds["episodes"], args.horizon),
+               "signal": audit_signal(ds["episodes"], ds["sessions"])}
+        rep["flags"] = flags_for(rep)
+        reports.append(rep)
+        print_report(rep)
+    if args.json:
+        with open(args.json, "w") as fp:
+            json.dump(reports, fp, indent=2, default=lambda o: o.tolist() if hasattr(o, "tolist") else str(o))
+        print(f"\nwrote {args.json}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/demo_tools/conversion_output.py
+++ b/scripts/demo_tools/conversion_output.py
@@ -1,0 +1,114 @@
+# Copyright (c) 2025-2026, The DexVerse Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Evidence required to reuse a completed sequential conversion, without Isaac."""
+
+from functools import lru_cache
+import hashlib
+import json
+from pathlib import Path
+
+import h5py
+
+from demo_release import ROOT, sha256
+
+
+@lru_cache(maxsize=1)
+def implementation_digest():
+    """Include local source edits as well as the declared release version."""
+    paths = [ROOT / "source/dexverse/config/extension.toml"]
+    for directory in (ROOT / "source/dexverse/dexverse", ROOT / "scripts/demo_tools"):
+        paths.extend(p for p in directory.rglob("*") if p.suffix in {".py", ".yml", ".yaml"})
+    digest = hashlib.sha256()
+    for path in sorted(paths):
+        digest.update(path.relative_to(ROOT).as_posix().encode() + b"\0")
+        digest.update(sha256(path).encode() + b"\0")
+    return digest.hexdigest()
+
+
+def conversion_request(*, task, identity, pickles, episodes, options):
+    """Describe the exact requested inputs and replay/output settings."""
+    return {
+        "schema": 1,
+        "implementation_sha256": implementation_digest(),
+        "task": task,
+        "identity": identity,
+        "sources": [{"sha256": sha256(p), "bytes": Path(p).stat().st_size} for p in pickles],
+        "episodes": [{"index": int(ep["episode_index"]), "steps": len(ep["actions"])} for ep in episodes],
+        "options": options,
+    }
+
+
+def request_json(request):
+    return json.dumps(request, sort_keys=True, separators=(",", ":"))
+
+
+def validate_existing_output(path, request):
+    """Refuse stale, partial, legacy or mismatched H5 instead of silently skipping."""
+    try:
+        with h5py.File(path, "r") as existing:
+            if not existing.attrs.get("conversion_complete", False):
+                raise ValueError("completion marker is missing or false")
+            if existing.attrs.get("conversion_request") != request_json(request):
+                raise ValueError("sources, episodes, implementation, revision or conversion settings differ")
+            if existing.attrs.get("task") != request["task"]:
+                raise ValueError("task identity differs")
+            if existing.attrs.get("replay_benchmark_revision") != request["identity"]["benchmark_revision"]:
+                raise ValueError("replay revision differs")
+            expected = {ep["index"]: ep["steps"] for ep in request["episodes"]}
+            data = existing["data"]
+            if (len(expected) != len(request["episodes"]) or len(data) != len(expected)
+                    or existing.attrs.get("requested_episodes") != len(expected)
+                    or existing.attrs.get("num_episodes") != len(expected)):
+                raise ValueError("episode count differs")
+            seen = set()
+            for episode in data.values():
+                index = int(episode.attrs["episode_index"])
+                if index not in expected or index in seen:
+                    raise ValueError("episode indices differ")
+                seen.add(index)
+                steps = expected[index]
+                if episode.attrs.get("num_samples") != steps:
+                    raise ValueError("episode length differs")
+                for name in ("actions", "source_actions"):
+                    if episode[name].shape[0] != steps:
+                        raise ValueError(f"truncated {name}")
+                for name in ("obs", "next_obs", "terminations"):
+                    if name == "terminations" and name not in episode:
+                        continue
+
+                    def check_length(_, dataset):
+                        if isinstance(dataset, h5py.Dataset) and (not dataset.shape or dataset.shape[0] != steps):
+                            raise ValueError(f"truncated {name}")
+
+                    episode[name].visititems(check_length)
+    except (OSError, KeyError, TypeError, ValueError) as exc:
+        raise ValueError(
+            f"Cannot reuse {path}: {exc}. Choose a new output directory or pass --overwrite."
+        ) from exc
+
+
+def exit_conversion(run):
+    """Flush finalized outputs/logs and exit without Kit replacing our exit code.
+
+    Each converter process owns one scene. Its run function closes H5/video
+    writers before returning or raising; process exit releases the simulator.
+    """
+    import os
+    import sys
+    import traceback
+
+    code = 1
+    try:
+        code = run()
+    except KeyboardInterrupt:
+        code = 130
+        traceback.print_exc()
+    except BaseException:
+        traceback.print_exc()
+    finally:
+        sys.stdout.flush()
+        sys.stderr.flush()
+        os._exit(code)

--- a/scripts/demo_tools/create_demo_files_sequential.py
+++ b/scripts/demo_tools/create_demo_files_sequential.py
@@ -38,9 +38,12 @@ Example::
 
 import argparse
 import json
+import os
 import pickle
+import sys
 from pathlib import Path
-from typing import NamedTuple
+from demo_selection import discover_groups, normalize_demo_root, validate_selected_identity, worker_arguments, PickleGroup
+from conversion_output import conversion_request, exit_conversion, request_json, validate_existing_output
 
 import torch
 from _active_object_masks import apply_recorded_active_masks
@@ -56,13 +59,13 @@ parser.add_argument(
     "--demos-root",
     type=Path,
     default=Path(__file__).resolve().parents[2] / "source" / "dexverse" / "demonstrations",
-    help="Root that holds task/<env>/<pickle>.pkl trees (default: %(default)s).",
+    help="Versioned download directory or prepared release root (default: %(default)s).",
 )
 parser.add_argument(
     "--task",
     action="append",
     default=[],
-    help="Task subdirectory to convert (relative to --demos-root). Repeatable.",
+    help="Versioned task ID, e.g. Dexverse-PushT-v0 or Dexverse-PushT-v1. Also accepts version/category/task paths. Repeatable.",
 )
 parser.add_argument(
     "--file",
@@ -73,8 +76,16 @@ parser.add_argument(
 parser.add_argument(
     "--all",
     action="store_true",
-    help="Convert every pickle found under --demos-root.",
+    help="Convert available curated baseline demos; report missing tasks. Never scans raw sessions by default.",
 )
+parser.add_argument("--version", choices=("all", "v0", "v1"), default="all",
+                    help="Filter --all or check the version in --task (never substitute versions).")
+parser.add_argument("--legacy-collections", action="store_true",
+                    help="Explicit raw-directory discovery/merging instead of curated demos.pkl selection.")
+parser.add_argument("--dry-run", action="store_true", help="List selected pickles without launching Isaac Sim or loading pickles.")
+parser.add_argument("--worker-group", help=argparse.SUPPRESS)
+parser.add_argument("--task-timeout", type=int, default=3600,
+                    help="Timeout in seconds per isolated task when selecting multiple tasks (default: 3600).")
 parser.add_argument(
     "--output-dir",
     type=Path,
@@ -132,12 +143,23 @@ parser.add_argument(
         "the simulator instead."
     ),
 )
+parser.add_argument(
+    "--strip-cameras",
+    action=argparse.BooleanOptionalAction,
+    default=True,
+    help=(
+        "For camera-free captures (e.g. --obs-groups state without --record-video) "
+        "remove the scene's camera sensors before building the env, so no RTX frame "
+        "is rendered per step. Pass --no-strip-cameras to keep them."
+    ),
+)
 
 # --- Environment-level options -------------------------------------------
 parser.add_argument("--task-override", default=None)
 parser.add_argument("--robot-type-override", default=None)
 parser.add_argument("--json-path", default=None)
 parser.add_argument("--enable-pinocchio", action="store_true")
+parser.add_argument("--seed", type=int, default=None, help="Replay reset/randomization seed; recorded state still takes precedence.")
 
 # --- Video recording ------------------------------------------------------
 parser.add_argument(
@@ -148,9 +170,62 @@ parser.add_argument(
 parser.add_argument("--video-camera", default="third_person_camera")
 parser.add_argument("--video-fps", type=int, default=30)
 parser.add_argument("--video-dir", type=Path, default=None)
+parser.add_argument("--video-only-camera", action="store_true", help="Keep only --video-camera (for low-cost video review with state observations).")
+parser.add_argument("--video-size", type=int, default=None, help="Optional square resolution for the review camera.")
 
 AppLauncher.add_app_launcher_args(parser)
+parser.set_defaults(device="cpu")
 args_cli = parser.parse_args()
+
+args_cli.demos_root = normalize_demo_root(args_cli.demos_root)
+if (args_cli.task or args_cli.all) and args_cli.task_override:
+    parser.error("--task selects the exact replay task; use --file with --task-override for deliberate remapping.")
+if args_cli.seed is not None and not 0 <= args_cli.seed < 2**32:
+    parser.error("--seed must be in [0, 2**32)")
+if any(i < 0 for i in args_cli.select_episodes) or len(set(args_cli.select_episodes)) != len(args_cli.select_episodes):
+    parser.error("--select-episodes must contain distinct nonnegative indices")
+try:
+    if args_cli.worker_group:
+        _worker = json.loads(args_cli.worker_group)
+        _worker["anchor_dir"] = Path(_worker["anchor_dir"])
+        _worker["pickles"] = [Path(p) for p in _worker["pickles"]]
+        _selected_groups, _selection_warnings = [PickleGroup(**_worker)], []
+    else:
+        _selected_groups, _selection_warnings = discover_groups(
+            args_cli.demos_root, tasks=args_cli.task, files=args_cli.file, all_tasks=args_cli.all,
+            version=args_cli.version, legacy_collections=args_cli.legacy_collections,
+        )
+except (ValueError, FileNotFoundError) as exc:
+    parser.error(str(exc))
+for _warning in _selection_warnings:
+    print(f"[coverage] {_warning}", flush=True)
+if args_cli.dry_run:
+    for _group in _selected_groups:
+        print(f"{_group.label}: " + ", ".join(str(p) for p in _group.pickles))
+    raise SystemExit(0)
+
+if args_cli.task_timeout < 1:
+    parser.error("--task-timeout must be positive")
+if len(_selected_groups) > 1:
+    # Isaac scene teardown/reinitialization can hang. Isolate each task process;
+    # this parent never launches Kit, and still reports a nonzero status on failure.
+    import subprocess
+
+    _failures = []
+    for _group in _selected_groups:
+        print(f"[task worker] {_group.label}", flush=True)
+        _command = [sys.executable, "-u", str(Path(__file__).resolve()),
+                    *worker_arguments(_group, sys.argv[1:]), "--demos-root", str(args_cli.demos_root)]
+        try:
+            _completed = subprocess.run(_command, timeout=args_cli.task_timeout, check=False)
+            if _completed.returncode:
+                _failures.append(_group.label)
+        except subprocess.TimeoutExpired:
+            print(f"[error] {_group.label} exceeded --task-timeout", flush=True)
+            _failures.append(_group.label)
+    if _failures:
+        print(f"Failed task groups: {_failures}", flush=True)
+    raise SystemExit(1 if _failures else 0)
 
 args_cli.headless = True
 
@@ -184,8 +259,12 @@ _preset_has_camera = _obs_preset_arg in {
     "3view_rgb_depth",
     "3view_pointcloud",
 }
-if args_cli.record_video or _capture_all_groups or _preset_has_camera or (_obs_groups_lower & _CAMERA_OBS_GROUPS):
+_NEEDS_CAMERAS = bool(
+    args_cli.record_video or _capture_all_groups or _preset_has_camera or (_obs_groups_lower & _CAMERA_OBS_GROUPS)
+)
+if _NEEDS_CAMERAS or not args_cli.strip_cameras:
     args_cli.enable_cameras = True
+# Camera-free replay strips sensor configs before scene construction below.
 
 if args_cli.enable_pinocchio:
     import pinocchio  # noqa: F401
@@ -203,7 +282,9 @@ import gymnasium as gym  # noqa: E402
 import h5py  # noqa: E402
 import isaaclab_tasks  # noqa: F401, E402
 import numpy as np  # noqa: E402
-from dexverse.tasks.utils import parse_env_cfg  # noqa: E402
+from dexverse.tasks.utils import parse_env_cfg, prune_stale_obs_refs, strip_camera_cfgs  # noqa: E402
+from dexverse.teleop_utils.episode_task_state import restore_episode_task_state  # noqa: E402
+from dexverse.benchmark import task_identity, validate_replay_identity  # noqa: E402
 from isaaclab.managers import TerminationTermCfg as DoneTerm  # noqa: E402
 from isaaclab.managers.manager_base import ManagerTermBase  # noqa: E402
 
@@ -347,24 +428,6 @@ def _evaluate_termination_term(term_cfg, env, instance_cache: dict):
     return func(env, **params)
 
 
-def _force_clear_sim_context() -> None:
-    try:
-        from isaaclab.sim import SimulationContext
-    except Exception:
-        return
-    try:
-        instance = SimulationContext.instance()
-    except Exception:
-        instance = None
-    if instance is None:
-        return
-    for method_name in ("clear_instance", "clear_all_callbacks", "stop", "close"):
-        method = getattr(instance, method_name, None)
-        if callable(method):
-            with contextlib.suppress(Exception):
-                method()
-
-
 def _get_runtime_obs(env, *, update_history: bool = False):
     # update_history must be True on the per-step set-state path: history-enabled
     # obs terms (e.g. proprio/policy with history_length>0) only advance their
@@ -398,6 +461,28 @@ def _refresh_after_set_state(env):
     else:
         env.sim.render()
     env.scene.update(dt=env.physics_dt)
+
+
+def _set_last_action(env, action: torch.Tensor) -> None:
+    """Write a recorded action into the action manager's buffers.
+
+    The ``--set-state`` path never calls ``env.step``, so the action manager's
+    ``_action`` / ``_prev_action`` buffers stay at their zero reset value, and any
+    observation term reading them -- notably ``mdp.last_action``, which is the
+    whole ``policy`` group -- gets recorded as all-zeros for the entire episode.
+    Policies trained on such a recording see zeros there but their own previous
+    action at evaluation time, and fail. (DP3 ignores the ``policy`` group, which
+    is why the point-cloud replays never surfaced this; the state-based diffusion
+    policy consumes it.)
+
+    The buffers are set directly rather than through ``process_action`` so no
+    action term applies side effects to the scene we just restored.
+    """
+    manager = getattr(env, "action_manager", None)
+    if manager is None:
+        return
+    manager._prev_action[:] = manager._action
+    manager._action[:] = action.to(manager.device)
 
 
 def _has_multi_asset_or_usd(scene_cfg) -> bool:
@@ -444,6 +529,16 @@ class ObsGroupCapture:
     @property
     def group_names(self) -> list[str]:
         return list(self._group_names)
+
+    @property
+    def term_names_by_group(self) -> dict[str, list[str]]:
+        """Per-group term order as declared on the ObservationManager.
+
+        This is the order a ``concatenate_terms=True`` group uses internally, so
+        writers persist it and readers that re-concatenate the per-term datasets
+        can reproduce the env's own layout instead of guessing.
+        """
+        return {g: list(self._term_names[g]) for g in self._group_names}
 
     def capture(self, env_id: int = 0) -> dict[str, np.ndarray]:
         flat: dict[str, np.ndarray] = {}
@@ -502,6 +597,11 @@ class PerPickleH5Writer:
         compression: str,
         compression_opts: int,
         observation_preset: str | None = None,
+        term_order_by_group: dict[str, list[str]] | None = None,
+        source_benchmark_revision: str | None = None,
+        source_action_layout: dict | None = None,
+        source_task: str | None = None,
+        source_sim_device: str | None = None,
     ):
         output_file.parent.mkdir(parents=True, exist_ok=True)
         self._output_file = output_file
@@ -519,6 +619,13 @@ class PerPickleH5Writer:
         self._h5 = h5py.File(self._output_file, "w")
         self._data = self._h5.create_group("data")
         self._h5.attrs["task"] = str(task_name)
+        self._h5.attrs["source_task"] = source_task or str(task_name)
+        self._h5.attrs["source_sim_device"] = source_sim_device or "unspecified"
+        self._h5.attrs["source_benchmark_revision"] = source_benchmark_revision or "unspecified"
+        self._h5.attrs["replay_benchmark_revision"] = task_identity(task_name)["benchmark_revision"]
+        self._h5.attrs["replay_task_version"] = task_identity(task_name)["task_version"]
+        if source_action_layout is not None:
+            self._h5.attrs["source_action_layout"] = json.dumps(source_action_layout)
         self._h5.attrs["source_pickles"] = json.dumps([str(p.resolve()) for p in source_pickles])
         self._h5.attrs["schema_version"] = self.SCHEMA_VERSION
         self._h5.attrs["obs_groups"] = json.dumps(list(obs_groups))
@@ -527,6 +634,12 @@ class PerPickleH5Writer:
         self._h5.attrs["observation_preset"] = observation_preset or ""
         # Marker so readers can tell sequential outputs from parallel ones.
         self._h5.attrs["replay_mode"] = "sequential"
+        # ObservationManager term order per group. Readers that rebuild a flat
+        # observation vector from the per-term datasets (e.g.
+        # scripts/diffusion/build_dataset.py) need this; alphabetical key order
+        # silently produces a different layout than the live environment.
+        if term_order_by_group:
+            self._h5.attrs["term_order"] = json.dumps({g: list(terms) for g, terms in term_order_by_group.items()})
         self._counter = 0
 
     def write_episode(
@@ -705,60 +818,8 @@ class VideoRecorder:
 # ============================================================================
 
 
-class PickleGroup(NamedTuple):
-    label: str
-    output_stem: str
-    anchor_dir: Path
-    pickles: list[Path]
-
-
 def _discover_source_pickle_groups() -> list[PickleGroup]:
-    groups: list[PickleGroup] = []
-    demos_root = args_cli.demos_root.expanduser().resolve()
-
-    for f in args_cli.file:
-        p = Path(f).expanduser().resolve()
-        if not p.is_file():
-            raise FileNotFoundError(f"--file path does not exist: {p}")
-        groups.append(
-            PickleGroup(
-                label=p.name,
-                output_stem=p.stem,
-                anchor_dir=p.parent,
-                pickles=[p],
-            )
-        )
-
-    task_dirs: set[Path] = set()
-    for task in args_cli.task:
-        sub = (demos_root / task).resolve()
-        if not sub.is_dir():
-            raise FileNotFoundError(f"--task dir not found under {demos_root}: {task}")
-        for pkl in sub.rglob("*.pkl"):
-            task_dirs.add(pkl.parent.resolve())
-
-    if args_cli.all:
-        if not demos_root.is_dir():
-            raise FileNotFoundError(f"--demos-root not found: {demos_root}")
-        for pkl in demos_root.rglob("*.pkl"):
-            task_dirs.add(pkl.parent.resolve())
-
-    for task_dir in sorted(task_dirs):
-        pkls = sorted(p.resolve() for p in task_dir.glob("*.pkl"))
-        if not pkls:
-            continue
-        groups.append(
-            PickleGroup(
-                label=task_dir.name,
-                output_stem=task_dir.name,
-                anchor_dir=task_dir,
-                pickles=pkls,
-            )
-        )
-
-    if not groups:
-        raise SystemExit("Nothing selected. Pass --all, --task <name>, or --file <path>.")
-    return groups
+    return _selected_groups
 
 
 def _merge_trajectory_payloads(pickles: list[Path]) -> dict:
@@ -769,6 +830,9 @@ def _merge_trajectory_payloads(pickles: list[Path]) -> dict:
     merged_episodes = list(base.get("episodes") or [])
     for extra in pickles[1:]:
         payload = _load_trajectory_pickle(str(extra))
+        for key in ("robot_type", "benchmark_revision", "action_layout", "sim_device"):
+            if payload.get(key) != base.get(key):
+                raise ValueError(f"{key} mismatch when merging {extra.name} with {pickles[0].name}")
         env = payload.get("env_name") or payload.get("task")
         if env != base_env:
             raise ValueError(
@@ -780,6 +844,7 @@ def _merge_trajectory_payloads(pickles: list[Path]) -> dict:
         ep["episode_index"] = i
     merged = dict(base)
     merged["episodes"] = merged_episodes
+    merged["num_episodes"] = len(merged_episodes)
     return merged
 
 
@@ -834,6 +899,7 @@ def _build_env_for_pickle(payload: dict):
     if env_name is None:
         raise ValueError("Task/env name was not found in the pickle and was not overridden.")
     task_name = args_cli.task_override if args_cli.task_override is not None else env_name
+    validate_replay_identity(payload, env_name, explicit_override=args_cli.task_override is not None)
 
     json_path = args_cli.json_path if args_cli.json_path is not None else payload.get("json_path")
     env_cfg = parse_env_cfg(env_name, device=args_cli.device, num_envs=1, json_path=json_path)
@@ -854,6 +920,8 @@ def _build_env_for_pickle(payload: dict):
         env_cfg.sim.device = args_cli.device if args_cli.device is not None else env_cfg.sim.device
         env_cfg.scene.num_envs = 1
     env_cfg.env_name = env_name
+    if args_cli.seed is not None:
+        env_cfg.seed = args_cli.seed
 
     if _has_multi_asset_or_usd(env_cfg.scene):
         print(
@@ -883,11 +951,38 @@ def _build_env_for_pickle(payload: dict):
         env_cfg.observation_preset = _obs_preset_arg
         env_cfg._apply_observation_preset(_obs_preset_arg)
 
-    # IsaacLab default is 0 — without it, the RTX camera buffer is stale after
-    # reset, so per-episode lighting/texture randomizers won't appear in the
-    # first captured frame. In sequential mode every episode is a fresh reset,
-    # so we always want a few extra renders to let RTX settle.
-    env_cfg.num_rerenders_on_reset = 4
+    if args_cli.record_video and (args_cli.video_only_camera or args_cli.video_size is not None):
+        from isaaclab.sensors import CameraCfg
+
+        selected_camera = getattr(env_cfg.scene, args_cli.video_camera, None)
+        if not isinstance(selected_camera, CameraCfg):
+            raise ValueError(f"Video camera {args_cli.video_camera!r} is not configured")
+        if args_cli.video_size is not None:
+            if args_cli.video_size < 16 or args_cli.video_size % 2:
+                raise ValueError("--video-size must be an even integer >= 16")
+            selected_camera.width = selected_camera.height = args_cli.video_size
+        if args_cli.video_only_camera:
+            for name in dir(env_cfg.scene):
+                if name != args_cli.video_camera and isinstance(getattr(env_cfg.scene, name, None), CameraCfg):
+                    setattr(env_cfg.scene, name, None)
+            prune_stale_obs_refs(env_cfg)
+
+    if _NEEDS_CAMERAS or not args_cli.strip_cameras:
+        # IsaacLab default is 0 — without it, the RTX camera buffer is stale after
+        # reset, so per-episode lighting/texture randomizers won't appear in the
+        # first captured frame. In sequential mode every episode is a fresh reset,
+        # so we always want a few extra renders to let RTX settle.
+        env_cfg.num_rerenders_on_reset = 4
+    else:
+        # Camera-free capture (e.g. the ``state`` preset): drop the scene's camera
+        # sensors and any obs term that referenced them. Nothing reads the frames,
+        # and without RTX sensors the per-step refresh no longer renders (nor
+        # re-renders 4x per set-state step). Physics, joint and object state are
+        # unaffected. ``--no-strip-cameras`` keeps the sensors.
+        strip_camera_cfgs(env_cfg)
+        prune_stale_obs_refs(env_cfg)
+        env_cfg.num_rerenders_on_reset = 0
+        print("  [info] camera-free capture: scene camera sensors stripped (--no-strip-cameras keeps them).")
 
     env = gym.make(task_name, cfg=env_cfg).unwrapped
     return env, env_cfg, env_name, task_name, termination_cfgs
@@ -951,6 +1046,14 @@ def _replay_one_episode(
         )
         env.reset_to(initial_state, env_ids_one, is_relative=True)
         apply_recorded_active_masks(env, episode, env_ids_one)
+        skipped_task_state = restore_episode_task_state(
+            env,
+            episode.get("task_state"),
+            env_index=0,
+            legacy_goal_pose=episode.get("goal_pose"),
+        )
+        if skipped_task_state:
+            print(f"  [warn] could not restore task state: {', '.join(skipped_task_state)}")
         if args_cli.set_state:
             _refresh_after_set_state(env)
         _get_runtime_obs(env)
@@ -964,6 +1067,15 @@ def _replay_one_episode(
         last_flat = initial_flat
         terminations_buf: dict[str, list[bool]] = {n: [] for n in termination_cfgs}
         termination_instance_cache: dict = {}
+        # Reset pass: evaluate every termination term once while
+        # ``episode_length_buf == 0`` (just after ``reset_to``) so env-resident,
+        # step-keyed state -- stage-machine / cut-sweep *persistent* success
+        # latches, hold counters -- is cleared before the episode is scored.
+        # Without this, a success latched in the previous episode is reported
+        # at step 0 of the next one (seen on CutStripScissors, Aug 2026).
+        for _term_cfg in termination_cfgs.values():
+            with contextlib.suppress(Exception):
+                _evaluate_termination_term(_term_cfg, env, termination_instance_cache)
 
         if video is not None:
             video.start_episode(ep_index)
@@ -997,6 +1109,15 @@ def _replay_one_episode(
                 )
                 env.scene.reset_to(step_state, env_ids_one, is_relative=True)
                 _refresh_after_set_state(env)
+                # Mirror ManagerBasedRLEnv.step: advance the per-env step counter.
+                # Step-keyed runtime logic (stage-machine / cut-sweep reset detection
+                # via ``episode_length_buf == 0``, per-step memoization, hold
+                # counters) otherwise sees step 0 forever and never accumulates
+                # progress -- e.g. the cut tasks' success term fired in 0/50
+                # replayed demos before this (Aug 2026).
+                if isinstance(getattr(env, "episode_length_buf", None), torch.Tensor):
+                    env.episode_length_buf[env_ids_one] += 1
+                _set_last_action(env, action_batched)
                 _get_runtime_obs(env, update_history=True)
             else:
                 env.step(action_batched)
@@ -1014,6 +1135,29 @@ def _replay_one_episode(
             if video is not None:
                 video.capture()
 
+            # Debug trace of the cut-sweep internals (DEXVERSE_CUTSWEEP_TRACE=<csv path>).
+            _trace_path = os.environ.get("DEXVERSE_CUTSWEEP_TRACE")
+            if _trace_path and "success" in termination_cfgs:
+                _tk = (termination_cfgs["success"].params or {}).get("task_key")
+                if _tk:
+                    from dexverse.baseline_v1.mdp.cut_sweep import evaluate_cut_sweep as _ecs
+
+                    _o = _ecs(env, _tk)
+                    _buf = getattr(env, "episode_length_buf", None)
+                    from dexverse.baseline_v1.mdp.stage_machine import evaluate_stage_graph as _esg, get_stage_graph as _gsg
+
+                    _fl = _esg(env, task_key=_tk, persistent=True, ordering_mode="strict")
+                    _st = getattr(env, "_stage_graph_runtime_cache", {}).get(_tk)
+                    _latched = getattr(_st, "latched_flags", None) or {}
+                    _names = [st.name for st in _gsg(_tk).stages]
+                    with open(_trace_path, "a") as _fp:
+                        _fp.write(
+                            f"{ep_index},{step_idx},{int(_buf[0]) if _buf is not None else -1},"
+                            f"{float(_o['frontier_frac'][0]):.4f},{int(_o['ext_ok'][0])},{int(_o['gates_ok'][0])},"
+                            + ",".join(f"{int(_fl[n][0])}" for n in _names) + ","
+                            + ",".join(f"{int(_latched[n][0]) if n in _latched else -1}" for n in _names)
+                            + f",{int(getattr(_st, 'latched_step_buf', torch.tensor([-1]))[0])}\n"
+                        )
             if termination_cfgs:
                 for term_name, term_cfg in termination_cfgs.items():
                     try:
@@ -1032,6 +1176,8 @@ def _replay_one_episode(
                     else:
                         terminations_buf[term_name].append(bool(term_value[0].item()))
 
+        if len(actions_buf) != T:
+            raise RuntimeError(f"Episode {ep_index} interrupted: captured {len(actions_buf)}/{T} steps")
         writer.write_episode(
             episode_index=ep_index,
             episode_name=str(ep_name),
@@ -1052,9 +1198,6 @@ def _replay_one_episode(
 
 def _convert_one_group(group: PickleGroup) -> tuple[int, int, int]:
     output_path = _output_path_for_group(group)
-    if output_path.is_file() and not args_cli.overwrite:
-        print(f"[skip] {output_path} exists (pass --overwrite to replace).")
-        return (0, 0, 0)
 
     if len(group.pickles) == 1:
         print(f"[load] {group.pickles[0]}")
@@ -1064,24 +1207,48 @@ def _convert_one_group(group: PickleGroup) -> tuple[int, int, int]:
             print(f"  + {p.name}")
 
     payload = _merge_trajectory_payloads(group.pickles)
+    validate_selected_identity(payload, group.expected_task)
     episodes = payload["episodes"]
     if not episodes:
-        print(f"  (no episodes in {group.label}; skipping)")
-        return (0, 0, 0)
+        raise ValueError(f"No episodes in {group.label}")
     if args_cli.select_episodes:
         wanted = set(args_cli.select_episodes)
         selected = [ep for ep in episodes if int(ep.get("episode_index", -1)) in wanted]
-        if not selected:
-            selected = [episodes[i] for i in args_cli.select_episodes if 0 <= i < len(episodes)]
+        if {int(ep.get("episode_index", -1)) for ep in selected} != wanted:
+            raise ValueError(f"Some --select-episodes indices are absent from {group.label}: {sorted(wanted)}")
         episodes = selected
-        if not episodes:
-            print("  (no episodes matched --select-episodes; skipping)")
-            return (0, 0, 0)
+
+    task = (args_cli.task_override or payload.get("env_name") or payload.get("task") or "").split(":")[-1]
+    validate_replay_identity(payload, task, explicit_override=args_cli.task_override is not None)
+    option_names = (
+        "task_override", "robot_type_override", "device", "seed", "set_state", "strip_cameras",
+        "obs_groups", "rgb_dtype", "depth_dtype", "compression", "compression_opts",
+        "record_video", "video_camera", "video_fps", "video_only_camera", "video_size", "rendering_mode",
+    )
+    options = {name: getattr(args_cli, name, None) for name in option_names}
+    options["observation_preset"] = _obs_preset_arg
+    json_path = args_cli.json_path if args_cli.json_path is not None else payload.get("json_path")
+    if json_path is not None:
+        from demo_release import sha256
+
+        options["json_sha256"] = sha256(json_path)
+    request = conversion_request(
+        task=task, identity=task_identity(task), pickles=group.pickles, episodes=episodes, options=options,
+    )
+    if output_path.exists() and not args_cli.overwrite:
+        validate_existing_output(output_path, request)
+        # An H5 completion marker does not establish that external MP4s still
+        # exist or finalized correctly. Require a deliberate rebuild for videos.
+        if args_cli.record_video:
+            raise ValueError(f"Video output reuse is not verified: {output_path}; use a new directory or --overwrite")
+        print(f"[skip] {output_path}: matching sources, episodes and conversion settings.")
+        return (0, 0, 0)
 
     succeeded = 0
     failed = 0
     env = None
     video = None
+    writer = None
     try:
         env, env_cfg, env_name, task_name, termination_cfgs = _build_env_for_pickle(payload)
         print(f"  [info] sequential replay of {len(episodes)} episode(s) in {env.num_envs} env")
@@ -1102,7 +1269,19 @@ def _convert_one_group(group: PickleGroup) -> tuple[int, int, int]:
             compression=args_cli.compression,
             compression_opts=args_cli.compression_opts,
             observation_preset=_obs_preset_arg,
+            term_order_by_group=capture.term_names_by_group,
+            source_benchmark_revision=payload.get("benchmark_revision"),
+            source_action_layout=payload.get("action_layout"),
+            source_task=payload.get("env_name") or payload.get("task"),
+            source_sim_device=payload.get("sim_device"),
         )
+        writer._h5.attrs["set_state"] = bool(args_cli.set_state)
+        writer._h5.attrs["replay_sim_device"] = str(env.device)
+        writer._h5.attrs["replay_seed"] = int(env.cfg.seed)
+        writer._h5.attrs["step_dt"] = float(env.step_dt)
+        writer._h5.attrs["conversion_complete"] = False
+        writer._h5.attrs["requested_episodes"] = len(episodes)
+        writer._h5.attrs["conversion_request"] = request_json(request)
         if args_cli.record_video:
             video = VideoRecorder(
                 env,
@@ -1140,16 +1319,17 @@ def _convert_one_group(group: PickleGroup) -> tuple[int, int, int]:
             elif ep_success is False:
                 failed += 1
 
+        if writer._counter != len(episodes):
+            raise RuntimeError(f"Conversion interrupted: wrote {writer._counter}/{len(episodes)} episodes")
+        writer._h5.attrs["conversion_complete"] = True
         writer.flush()
     finally:
-        if env is not None:
-            try:
-                env.close()
-            except Exception as exc:  # noqa: BLE001
-                print(f"  [warn] env.close() failed: {exc}")
-                _force_clear_sim_context()
-        else:
-            _force_clear_sim_context()
+        if video is not None:
+            video.finalize_episode()
+        if writer is not None and writer._h5.id.valid:
+            writer._h5.close()
+        # This worker owns one scene. Release it at process exit after closing
+        # files: env/Kit teardown can hang or terminate with an incorrect code.
 
     total = len(episodes)
     unknown = total - succeeded - failed
@@ -1176,8 +1356,7 @@ def main() -> int:
     grand_succ = grand_fail = grand_total = 0
     for group in groups:
         if not simulation_app.is_running() or simulation_app.is_exiting():
-            print("  [info] simulation app exiting; stopping early.")
-            break
+            raise RuntimeError("Simulation app exited before conversion completed")
         s, f, t = _convert_one_group(group)
         grand_succ += s
         grand_fail += f
@@ -1191,8 +1370,4 @@ def main() -> int:
 
 
 if __name__ == "__main__":
-    try:
-        rc = main()
-    finally:
-        simulation_app.close()
-    raise SystemExit(rc)
+    exit_conversion(main)

--- a/scripts/demo_tools/demo_release.py
+++ b/scripts/demo_tools/demo_release.py
@@ -1,0 +1,179 @@
+"""Simulator-free manifest and safe file operations for versioned demo releases."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from pathlib import Path, PurePosixPath
+import shutil
+import tempfile
+
+ROOT = Path(__file__).resolve().parents[2]
+DEMOS = ROOT / "source/dexverse/demonstrations"
+MANIFEST = "demonstrations/release_manifest.json"
+SCHEMA = "dexverse-demo-release-v1"
+
+
+def sha256(path):
+    with Path(path).open("rb") as stream:
+        return hashlib.file_digest(stream, "sha256").hexdigest()
+
+
+def safe_relative(value):
+    if not isinstance(value, str) or "\\" in value:
+        raise ValueError(f"Invalid relative path: {value!r}")
+    path = PurePosixPath(value)
+    if path.is_absolute() or not path.parts or any(p in {"..", "."} for p in value.split("/")):
+        raise ValueError(f"Unsafe relative path: {value!r}")
+    if str(path) != value:
+        raise ValueError(f"Noncanonical relative path: {value!r}")
+    return path
+
+
+def contained_path(root, relative):
+    root = Path(root).resolve()
+    path = root / str(safe_relative(relative))
+    if not path.resolve().is_relative_to(root):
+        raise ValueError(f"Path escapes root through symlink: {relative}")
+    return path
+
+
+def baseline_entries(version="all"):
+    result = []
+    for ver in ("v0", "v1") if version == "all" else (version,):
+        if ver not in {"v0", "v1"}:
+            raise ValueError(f"Unknown version {ver}")
+        name = "baseline_manifest.txt" if ver == "v0" else "baseline_manifest_v1.txt"
+        for line in (DEMOS / name).read_text().splitlines():
+            entry = line.strip()
+            if entry and not entry.startswith("#"):
+                safe_relative(entry)
+                result.append(f"{ver}/{entry}")
+    return result
+
+
+def baseline_key(selector, version="all"):
+    """Resolve a versioned task ID or category path; never guess a version."""
+    safe_relative(selector)
+    keys = baseline_entries()
+    matches = [key for key in keys if selector in (key, key.split("/", 1)[1], key.split("/")[-1])]
+    if len(matches) != 1:
+        raise ValueError(f"Unknown baseline task {selector!r}. Use an explicit ID such as Dexverse-PushT-v0 or Dexverse-PushT-v1.")
+    key = matches[0]
+    if version not in {"all", "v0", "v1"} or version not in ("all", key.split("/")[0]):
+        raise ValueError(f"Task {selector!r} conflicts with --version {version}")
+    return key
+
+
+def validate_manifest(data):
+    if data.get("schema") != SCHEMA:
+        raise ValueError("Unsupported demo release manifest schema")
+    expected = set(baseline_entries())
+    tasks, paths = set(), set()
+    for task in data["tasks"]:
+        key = task["key"]
+        if key not in expected or key in tasks:
+            raise ValueError(f"Unknown/duplicate baseline: {key}")
+        tasks.add(key)
+        if task["task"] != key.split("/")[-1]:
+            raise ValueError(f"Task identity mismatch: {key}")
+        count = task["episodes"]
+        if type(count) is not int or count < 0:
+            raise ValueError("Invalid episode count")
+        files = task["files"]
+        if task["status"] not in {"complete", "partial", "missing", "skipped"}:
+            raise ValueError("Invalid coverage status")
+        if (count > 0) != bool(files) or (task["status"] == "complete" and count != 50):
+            raise ValueError(f"Inconsistent coverage: {key}")
+        if task["status"] in {"missing", "skipped"} and (count or files):
+            raise ValueError(f"Unavailable task has data: {key}")
+        total = 0
+        for entry in files:
+            path = str(safe_relative(entry["path"]))
+            if path != f"demonstrations/{key}/demos.pkl" or path in paths:
+                raise ValueError(f"Unexpected/duplicate release path: {path}")
+            paths.add(path)
+            digest = entry["sha256"]
+            if not isinstance(digest, str) or len(digest) != 64 or any(c not in "0123456789abcdef" for c in digest):
+                raise ValueError("Invalid SHA256")
+            if type(entry["bytes"]) is not int or entry["bytes"] <= 0:
+                raise ValueError("Invalid file size")
+            if type(entry["episodes"]) is not int or entry["episodes"] <= 0:
+                raise ValueError("Invalid file episode count")
+            total += entry["episodes"]
+        if total != count:
+            raise ValueError(f"File counts disagree: {key}")
+    if tasks != expected:
+        raise ValueError(f"Manifest must account for all baseline versions; missing {sorted(expected - tasks)}")
+    return data
+
+
+def read_manifest(path):
+    return validate_manifest(json.loads(Path(path).read_text()))
+
+
+def verify_release(root):
+    root = Path(root).resolve()
+    manifest = read_manifest(contained_path(root, MANIFEST))
+    allowed = {MANIFEST, "README.md"}
+    for task in manifest["tasks"]:
+        for entry in task["files"]:
+            path = contained_path(root, entry["path"])
+            if path.is_symlink() or path.stat().st_size != entry["bytes"] or sha256(path) != entry["sha256"]:
+                raise ValueError(f"Release checksum/size mismatch: {path}")
+            allowed.add(entry["path"])
+    actual = set()
+    for path in root.rglob("*"):
+        if path.is_symlink():
+            raise ValueError(f"Symlinks not allowed in a release: {path}")
+        if path.is_file():
+            actual.add(path.relative_to(root).as_posix())
+    if actual != allowed:
+        raise ValueError(f"Release files differ from allow-list: extra={actual-allowed}, missing={allowed-actual}")
+    return manifest, sorted(allowed)
+
+
+def install_file(source, destination, digest=None):
+    """Atomic copy, no replacement of differing data; identical files are no-ops."""
+    source, destination = Path(source), Path(destination)
+    digest = digest or sha256(source)
+    if sha256(source) != digest:
+        raise ValueError(f"Source checksum mismatch: {source}")
+    if destination.exists() or destination.is_symlink():
+        if destination.is_symlink() or not destination.is_file() or sha256(destination) != digest:
+            raise FileExistsError(f"Refusing to overwrite different local data: {destination}")
+        return False
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    fd, temp = tempfile.mkstemp(prefix=".demo-download-", dir=destination.parent)
+    try:
+        with os.fdopen(fd, "wb") as out, source.open("rb") as stream:
+            shutil.copyfileobj(stream, out)
+            out.flush()
+            os.fsync(out.fileno())
+        if sha256(temp) != digest:
+            raise ValueError("Copy checksum mismatch")
+        os.link(temp, destination)
+    finally:
+        os.unlink(temp)
+    return True
+
+
+def main():
+    """Offline release validation; no HF dependency, unpickling or network calls."""
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Verify a prepared demo release locally (no uploads).")
+    parser.add_argument("--release-dir", type=Path, required=True)
+    args = parser.parse_args()
+    manifest, files = verify_release(args.release_dir)
+    total = sum((args.release_dir / name).stat().st_size for name in files)
+    episodes = sum(task["episodes"] for task in manifest["tasks"])
+    print(f"Verified {len(files)} allow-listed files ({total:,} bytes), {episodes:,} trajectories.")
+    for task in manifest["tasks"]:
+        print(f"  {task['key']}: {task['status']} ({task['episodes']})")
+    print("Local validation only: nothing uploaded.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/demo_tools/demo_selection.py
+++ b/scripts/demo_tools/demo_selection.py
@@ -1,0 +1,133 @@
+"""Simulator-free selection of curated versioned demos or explicit raw sessions."""
+
+import json
+from pathlib import Path
+from typing import NamedTuple
+
+from demo_release import baseline_entries, baseline_key, contained_path, read_manifest, sha256
+
+
+class PickleGroup(NamedTuple):
+    label: str
+    output_stem: str
+    anchor_dir: Path
+    pickles: list[Path]
+    expected_task: str | None = None
+
+
+def normalize_demo_root(root):
+    """Accept a download root, prepared release root, or explicit v0/v1 root."""
+    root = Path(root).expanduser().resolve()
+    if (root / "demonstrations/release_manifest.json").is_file():
+        root /= "demonstrations"
+    return root
+
+
+def discover_groups(root, *, tasks=(), files=(), all_tasks=False, version="all", legacy_collections=False):
+    """Curated selection never descends into local_collection, backups or _review.
+
+    Return groups plus explicit coverage warnings for --all. Individual missing
+    tasks fail with download guidance. File overrides are deliberate, not fallback.
+    """
+    root = normalize_demo_root(root)
+    if version not in {"all", "v0", "v1"}:
+        raise ValueError(f"Invalid version {version}")
+    if not (tasks or files or all_tasks):
+        raise ValueError("Nothing selected. Pass --task Dexverse-PushT-v1, --all, or --file PATH.")
+    if files and (tasks or all_tasks or version != "all" or legacy_collections):
+        raise ValueError("Use --file separately from --task/--all/--version/--legacy-collections.")
+    if tasks and all_tasks:
+        raise ValueError("Choose --task or --all, not both.")
+    groups, warnings = [], []
+    if files:
+        for filename in dict.fromkeys(files):
+            path = Path(filename).expanduser().resolve()
+            if not path.is_file() or path.suffix != ".pkl":
+                raise FileNotFoundError(f"Expected a pickle file: {path}")
+            groups.append(PickleGroup(path.name, path.stem, path.parent, [path]))
+        return groups, warnings
+    if legacy_collections:
+        if version != "all":
+            raise ValueError("--version is for curated datasets; raw collections use explicit directory paths.")
+        directories = [root] if all_tasks else [contained_path(root, task) for task in tasks]
+        parents = set()
+        for directory in directories:
+            if not directory.is_dir():
+                raise FileNotFoundError(f"Collection directory not found: {directory}")
+            for path in directory.rglob("*.pkl"):
+                relative = path.relative_to(root)
+                if any(p == "_review" or "backup" in p.lower() or "copy" in p.lower() for p in relative.parts):
+                    continue
+                contained_path(root, relative.as_posix())
+                parents.add(path.parent)
+        for directory in sorted(parents):
+            groups.append(PickleGroup(directory.name, directory.name, directory, sorted(directory.glob("*.pkl"))))
+        if not groups:
+            raise FileNotFoundError("No raw collection pickles selected; use --file for an explicit recording.")
+        return groups, warnings
+
+    root_version = root.name if root.name in {"v0", "v1"} else None
+    if root_version and version not in ("all", root_version):
+        raise ValueError("--demos-root version conflicts with --version")
+    selected_version = root_version or version
+    keys = baseline_entries(selected_version) if all_tasks else list(dict.fromkeys(baseline_key(t, selected_version) for t in tasks))
+    manifest_path = root.parent / "release_manifest.json" if root_version else root / "release_manifest.json"
+    records = {r["key"]: r for r in read_manifest(manifest_path)["tasks"]} if manifest_path.is_file() else None
+    for key in keys:
+        relative = key.split("/", 1)[1] if root_version else key
+        path = contained_path(root, relative + "/demos.pkl")
+        task = key.split("/")[-1]
+        record = records[key] if records is not None else None
+        if record is not None and not record["files"]:
+            message = f"{task}: {record['status']}. {record['reason']}"
+        elif not path.is_file():
+            message = (f"{task}: curated demo not found: {path}. Download with "
+                       f"python scripts/demo_tools/download_demos.py --repo OWNER/DATASET --task {task}; "
+                       "or point --demos-root at a prepared release. Raw sessions require --file or --legacy-collections.")
+        else:
+            if record is not None:
+                entry = record["files"][0]
+                if path.stat().st_size != entry["bytes"] or sha256(path) != entry["sha256"]:
+                    raise ValueError(f"Release checksum/size mismatch: {path}")
+            groups.append(PickleGroup(key, task, path.parent, [path], task))
+            if record is not None and record["status"] != "complete":
+                warnings.append(f"{task}: {record['status']} ({record['episodes']}/50)")
+            continue
+        if not all_tasks:
+            raise FileNotFoundError(message)
+        warnings.append(message)
+    if not groups:
+        raise FileNotFoundError("No curated demos available. " + "\n".join(warnings))
+    return groups, warnings
+
+
+def validate_selected_identity(payload, expected_task):
+    """Reject misplaced files before constructing an environment, even with overrides."""
+    if expected_task is None:
+        return
+    identities = [payload.get(k) for k in ("task", "env_name") if payload.get(k) is not None]
+    if not identities or any(task != expected_task for task in identities):
+        raise ValueError(f"Selected {expected_task}, but the curated pickle identifies {identities!r}")
+    version = int(expected_task[-1])
+    if payload.get("task_version", version) != version:
+        raise ValueError(f"Curated pickle task_version does not match {expected_task}")
+
+
+def worker_arguments(group, arguments):
+    """Retain render/output options, replacing all selection with one exact group."""
+    values = {"--task", "--file", "--version", "--demos-root", "--worker-group"}
+    switches = {"--all", "--legacy-collections", "--dry-run"}
+    retained, skip = [], False
+    for arg in arguments:
+        if skip:
+            skip = False
+            continue
+        name = arg.split("=", 1)[0]
+        if name in values:
+            skip = "=" not in arg
+        elif name not in switches:
+            retained.append(arg)
+    data = group._asdict()
+    data["anchor_dir"] = str(group.anchor_dir)
+    data["pickles"] = [str(p) for p in group.pickles]
+    return retained + ["--worker-group", json.dumps(data)]

--- a/scripts/demo_tools/download_demos.py
+++ b/scripts/demo_tools/download_demos.py
@@ -1,217 +1,182 @@
 # Copyright (c) 2025-2026, The DexVerse Project Developers.
 # All rights reserved.
-#
 # SPDX-License-Identifier: BSD-3-Clause
 
-"""Sync teleoperation demonstrations from the DexVerse Hugging Face
-dataset into the in-repo ``demonstrations/`` directory.
+"""Download versioned demos without overwriting differing local recordings.
 
-The HF repo ``dexverse/DexVerse_Dataset`` keeps demos under
-``demonstrations/<category>/<task>/...``. This script mirrors that tree
-into ``source/dexverse/demonstrations/`` (or a path of your choosing).
+  python scripts/demo_tools/download_demos.py --repo OWNER/DATASET --baseline
+  python scripts/demo_tools/download_demos.py --baseline --version v1 --dry-run
+  python scripts/demo_tools/download_demos.py --category functional --version v0
 
-Examples
---------
-    # Download everything under demonstrations/
-    python scripts/demo_tools/download_demos.py --all
-
-    # Only the rigid category
-    python scripts/demo_tools/download_demos.py --category rigid
-
-    # A specific task
-    python scripts/demo_tools/download_demos.py --task contact_rich/Dexverse-PlugCharger-v0
-
-    # The curated baseline demo set (tasks listed in baseline_manifest.txt,
-    # each fetched from its own real <category>/<task> location -- no
-    # separate "baseline" category, so a later --all won't re-download them)
-    python scripts/demo_tools/download_demos.py --baseline
-
-    # Just list what is available on the remote
-    python scripts/demo_tools/download_demos.py --list
-
-The dataset is gated. Run ``huggingface-cli login`` once (and accept the
-terms on the dataset page in your browser) before using this script.
+--baseline selects BOTH v0 and v1 by default, using the remote release manifest.
+Absent/skipped tasks are reported, never silently substituted with another version.
+For older unversioned datasets, use --legacy explicitly (v0 only). No pickle is
+unpickled during download. Authenticate with `hf auth login` for gated/private repos.
 """
 
 from __future__ import annotations
 
 import argparse
+import fnmatch
 from pathlib import Path
+
+from demo_release import DEMOS, MANIFEST, baseline_entries, baseline_key, contained_path, install_file, read_manifest, safe_relative, sha256
 
 DEFAULT_REPO = "dexverse/DexVerse_Dataset"
 DEFAULT_REPO_TYPE = "dataset"
+DEFAULT_DEST = DEMOS
 REMOTE_ROOT = "demonstrations"
-
-REPO_ROOT = Path(__file__).resolve().parents[2]
-DEFAULT_DEST = REPO_ROOT / "source" / "dexverse" / "demonstrations"
-# The curated baseline set is a list of <category>/<task> entries (see the
-# file for details), each a real category/task location -- not a separate
-# flat "baseline" category. Keeps the remote free of duplicate copies and
-# lets a later --all skip files --baseline already fetched.
-BASELINE_MANIFEST = DEFAULT_DEST / "baseline_manifest.txt"
+BASELINE_MANIFEST = DEMOS / "baseline_manifest.txt"
 
 
-def _load_baseline_manifest() -> list[str]:
-    if not BASELINE_MANIFEST.is_file():
-        raise SystemExit(f"--baseline manifest not found: {BASELINE_MANIFEST}")
-    entries = []
-    for line in BASELINE_MANIFEST.read_text().splitlines():
-        line = line.strip()
-        if line and not line.startswith("#"):
-            entries.append(line.strip("/"))
-    return entries
+def _load_baseline_manifest(version="all"):
+    return baseline_entries(version)
 
 
-def _load_hf():
-    try:
-        from huggingface_hub import HfApi, snapshot_download
-    except ImportError as exc:
-        raise SystemExit("huggingface_hub not installed. Run `pip install huggingface_hub`.") from exc
-    return HfApi, snapshot_download
-
-
-def _list_remote(repo: str, repo_type: str) -> list[str]:
-    HfApi, _ = _load_hf()
-    api = HfApi()
-    files = api.list_repo_files(repo_id=repo, repo_type=repo_type)
-    return [f for f in files if f.startswith(REMOTE_ROOT + "/")]
-
-
-def _print_listing(files: list[str]) -> None:
-    if not files:
-        print(f"No files found under {REMOTE_ROOT}/ on the remote.")
-        return
-
-    categories: dict[str, dict[str, int]] = {}
-    for f in files:
-        parts = f.split("/")
-        if len(parts) < 3:
-            continue
-        category = parts[1]
-        task = parts[2] if len(parts) >= 4 else "<root>"
-        categories.setdefault(category, {}).setdefault(task, 0)
-        categories[category][task] += 1
-
-    print(f"Available demos under {REMOTE_ROOT}/ in remote repo:")
-    for category in sorted(categories):
-        print(f"  {category}/")
-        for task, count in sorted(categories[category].items()):
-            print(f"    {task}/  ({count} file{'s' if count != 1 else ''})")
-
-
-def _build_patterns(args) -> list[str]:
-    patterns: list[str] = []
+def _build_patterns(args):
+    """Unversioned selectors expand into both directories; explicit ones stay explicit."""
+    version = getattr(args, "version", "all")
+    legacy = getattr(args, "legacy", False)
+    versions = ("v0", "v1") if version == "all" else (version,)
+    patterns = []
+    if legacy and version == "v1":
+        raise ValueError("Legacy layout has no v1 demos")
     if args.all:
-        patterns.append(f"{REMOTE_ROOT}/**")
+        patterns.extend(["demonstrations/**"] if legacy else [f"demonstrations/{v}/**" for v in versions])
     if args.baseline:
-        for entry in _load_baseline_manifest():
-            patterns.append(f"{REMOTE_ROOT}/{entry}/**")
-    for cat in args.category or []:
-        patterns.append(f"{REMOTE_ROOT}/{cat.strip('/')}/**")
-    for task in args.task or []:
-        patterns.append(f"{REMOTE_ROOT}/{task.strip('/')}/**")
-    for pat in args.pattern or []:
-        patterns.append(pat)
-    return patterns
+        for entry in baseline_entries("v0" if legacy else version):
+            patterns.append(f"demonstrations/{entry.split('/', 1)[1] if legacy else entry}/**")
+    for selector in args.task or []:
+        if not legacy:
+            key = baseline_key(selector, version)
+            patterns.append(f"demonstrations/{key}/**")
+        else:
+            safe_relative(selector)
+            if selector.endswith("-v1") or selector.split("/")[0] in {"v0", "v1"}:
+                raise ValueError("Legacy layout only supports unversioned v0 paths")
+            if "/" not in selector:
+                selector = baseline_key(selector, "v0").split("/", 1)[1]
+            patterns.append(f"demonstrations/{selector}/**")
+    for selector in args.category or []:
+        safe_relative(selector)
+        if selector.split("/")[0] in {"v0", "v1"}:
+            if legacy:
+                raise ValueError("Do not use a version prefix with --legacy")
+            if selector.split("/")[0] not in versions:
+                raise ValueError("Explicit task version conflicts with --version")
+            patterns.append(f"demonstrations/{selector}/**")
+        else:
+            selected_versions = versions
+            if selector.endswith(("-v0", "-v1")):
+                selected_versions = tuple(v for v in versions if selector.endswith("-" + v))
+            patterns.extend([f"demonstrations/{selector}/**"] if legacy else
+                            [f"demonstrations/{v}/{selector}/**" for v in selected_versions])
+    for pattern in args.pattern or []:
+        if not pattern.startswith("demonstrations/") or ".." in pattern.split("/") or "\\" in pattern:
+            raise ValueError("Patterns must stay under demonstrations/")
+        patterns.append(pattern)
+    return list(dict.fromkeys(patterns))
 
 
-def main() -> int:
-    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
-    parser.add_argument("--repo", default=DEFAULT_REPO, help="HF repo id (default: %(default)s)")
-    parser.add_argument("--repo-type", default=DEFAULT_REPO_TYPE, choices=("dataset", "model", "space"))
-    parser.add_argument(
-        "--dest",
-        type=Path,
-        default=DEFAULT_DEST,
-        help="Local destination directory (default: source/dexverse/demonstrations)",
-    )
-    parser.add_argument("--cache-dir", type=Path, default=None, help="HF cache dir override.")
-    parser.add_argument("--all", action="store_true", help=f"Download everything under {REMOTE_ROOT}/.")
-    parser.add_argument(
-        "--baseline",
-        action="store_true",
-        help=(
-            "Download the curated baseline demo set (the tasks "
-            f"listed in {BASELINE_MANIFEST.name}), each from its "
-            "own real <category>/<task> location."
-        ),
-    )
-    parser.add_argument(
-        "--category",
-        action="append",
-        help="Download a category subdir, e.g. `--category rigid` or `--category articulation`. Repeatable.",
-    )
-    parser.add_argument(
-        "--task",
-        action="append",
-        help="Download a specific task, e.g. `--task contact_rich/Dexverse-PlugCharger-v0`. Repeatable.",
-    )
-    parser.add_argument("--pattern", action="append", help="Extra HF allow_patterns glob (advanced). Repeatable.")
-    parser.add_argument(
-        "--list", dest="list_only", action="store_true", help="List what's available on the remote and exit."
-    )
-    parser.add_argument("--dry-run", action="store_true", help="Show what would be downloaded without fetching.")
-    args = parser.parse_args()
+def select_release(manifest, patterns):
+    files, unavailable = [], []
+    for task in manifest["tasks"]:
+        probe = f"demonstrations/{task['key']}/demos.pkl"
+        if not any(fnmatch.fnmatchcase(probe, pattern) for pattern in patterns):
+            continue
+        files.extend(task["files"])
+        if task["status"] != "complete":
+            unavailable.append(task)
+    return files, unavailable
 
-    if args.list_only:
-        files = _list_remote(args.repo, args.repo_type)
-        _print_listing(files)
-        return 0
 
-    patterns = _build_patterns(args)
-    if not patterns:
-        parser.error(
-            "Nothing selected. Use --all, --baseline, --category <name>, "
-            "--task <cat/name>, --pattern <glob>, or --list."
-        )
-
-    print(f"Repo:        {args.repo} ({args.repo_type})")
-    print(f"Destination: {args.dest}")
-    print("Patterns:")
-    for p in patterns:
-        print(f"  {p}")
-
-    if args.dry_run:
-        files = _list_remote(args.repo, args.repo_type)
-        import fnmatch
-
-        matched = sorted({f for f in files for p in patterns if fnmatch.fnmatch(f, p)})
-        print(f"\n[dry-run] {len(matched)} file(s) would be downloaded:")
-        for f in matched:
-            print(f"  {f}")
-        return 0
-
-    _, snapshot_download = _load_hf()
-    args.dest.mkdir(parents=True, exist_ok=True)
-    snapshot_download(
-        repo_id=args.repo,
-        repo_type=args.repo_type,
-        allow_patterns=patterns,
-        local_dir=str(args.dest),
-        cache_dir=str(args.cache_dir) if args.cache_dir else None,
-    )
-
-    # snapshot_download mirrors the repo paths, so files arrive at
-    # `<dest>/demonstrations/...`. Promote them up to `<dest>/...` so the
-    # caller's dest contains the categories directly. Promote per-file so
-    # newly fetched tasks merge into pre-existing category dirs instead of
-    # being silently stranded under `<dest>/demonstrations/`.
-    import shutil
-
-    nested = args.dest / REMOTE_ROOT
-    if nested.is_dir():
-        for src_file in nested.rglob("*"):
-            if not src_file.is_file():
+def fetch_selected(entries, dest, fetch):
+    """Checksum validate cached downloads and atomically install without clobbering."""
+    for entry in entries:
+        rel = safe_relative(entry["path"])
+        if rel.parts[0] != REMOTE_ROOT:
+            raise ValueError("Remote entry outside demonstrations/")
+        target = contained_path(dest, str(rel.relative_to(REMOTE_ROOT)))
+        if target.exists() or target.is_symlink():
+            if target.is_symlink() or not target.is_file():
+                raise FileExistsError(f"Refusing to replace {target}")
+            if entry.get("sha256"):
+                if target.stat().st_size != entry["bytes"] or sha256(target) != entry["sha256"]:
+                    raise FileExistsError(f"Different local file exists: {target}; choose another --dest")
+                print(f"Already verified: {target}")
                 continue
-            rel = src_file.relative_to(nested)
-            dst_file = args.dest / rel
-            dst_file.parent.mkdir(parents=True, exist_ok=True)
-            if dst_file.exists() or dst_file.is_symlink():
-                dst_file.unlink()
-            src_file.rename(dst_file)
-        shutil.rmtree(nested, ignore_errors=True)
+        cached = Path(fetch(entry["path"]))
+        if entry.get("bytes") is not None and cached.stat().st_size != entry["bytes"]:
+            raise ValueError(f"Downloaded size mismatch: {entry['path']}")
+        install_file(cached, target, entry.get("sha256"))
+        print(f"Installed: {target}")
 
-    print(f"\nDone. Demos at: {args.dest}")
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--repo", default=DEFAULT_REPO)
+    parser.add_argument("--repo-type", default=DEFAULT_REPO_TYPE, choices=("dataset", "model", "space"))
+    parser.add_argument("--revision", default="main", help="Branch, tag, or pinned commit")
+    parser.add_argument("--dest", type=Path, default=DEFAULT_DEST)
+    parser.add_argument("--cache-dir", type=Path)
+    parser.add_argument("--baseline", action="store_true", help="Both baseline versions by default")
+    parser.add_argument("--version", choices=("all", "v0", "v1"), default="all")
+    parser.add_argument("--all", action="store_true")
+    parser.add_argument("--category", action="append")
+    parser.add_argument("--task", action="append", help="Versioned ID (Dexverse-PushT-v1) or [v0|v1/]<category>/<task>; repeatable")
+    parser.add_argument("--pattern", action="append", help="demonstrations/ glob; restricted to manifest files")
+    parser.add_argument("--list", dest="list_only", action="store_true")
+    parser.add_argument("--dry-run", action="store_true", help="Read remote inventory, no demo downloads")
+    parser.add_argument("--legacy", action="store_true", help="Explicit old unversioned v0 dataset layout")
+    parser.add_argument("--require-complete", action="store_true", help="Fail before fetching if selected tasks are missing/partial/skipped")
+    args = parser.parse_args()
+    try:
+        patterns = _build_patterns(args)
+    except ValueError as exc:
+        parser.error(str(exc))
+    if not patterns and not args.list_only:
+        parser.error("Select --baseline, --all, --category, --task, --pattern, or --list")
+    from huggingface_hub import HfApi, hf_hub_download
+    api = HfApi()
+    # Pin inventory and downloads to the same commit even when a branch advances.
+    revision = api.repo_info(repo_id=args.repo, repo_type=args.repo_type, revision=args.revision).sha
+    def fetch(name):
+        return hf_hub_download(repo_id=args.repo, repo_type=args.repo_type, revision=revision,
+                               filename=name, cache_dir=str(args.cache_dir) if args.cache_dir else None)
+    if args.legacy:
+        if args.require_complete:
+            parser.error("--require-complete needs the versioned release manifest")
+        paths = api.list_repo_files(repo_id=args.repo, repo_type=args.repo_type, revision=revision)
+        paths = [p for p in paths if p.startswith("demonstrations/") and p.split("/")[1] not in {"v0", "v1", "_review"}]
+        if args.list_only:
+            print("\n".join(paths))
+            return 0
+        entries = [{"path": p} for p in paths if any(fnmatch.fnmatchcase(p, pat) for pat in patterns)]
+        unavailable = []
+        print("Legacy layout: only unversioned v0; release hashes and v1 coverage unavailable.")
+    else:
+        from huggingface_hub.errors import EntryNotFoundError
+        try:
+            manifest = read_manifest(fetch(MANIFEST))
+        except EntryNotFoundError as exc:
+            raise SystemExit("Remote has no versioned release manifest. Upload a prepared release first, or use --legacy for the old v0-only dataset.") from exc
+        if args.list_only:
+            for task in manifest["tasks"]:
+                print(f"{task['key']}: {task['status']} ({task['episodes']})")
+            return 0
+        entries, unavailable = select_release(manifest, patterns)
+    print(f"Dataset {args.repo}@{revision}: {len(entries)} selected files")
+    for task in unavailable:
+        print(f"Unavailable/incomplete: {task['key']} ({task['status']}, {task['episodes']}/50). {task['reason']}")
+    if unavailable and args.require_complete:
+        raise SystemExit("Selected baseline set is incomplete; nothing downloaded")
+    if not entries:
+        raise SystemExit("No demo files match this selection")
+    if args.dry_run:
+        print("\n".join(entry["path"] for entry in entries))
+        return 0
+    fetch_selected(entries, args.dest, fetch)
+    # A remote manifest is not installed as local coverage: selection may be partial.
     return 0
 
 

--- a/scripts/demo_tools/download_demos.py
+++ b/scripts/demo_tools/download_demos.py
@@ -11,7 +11,8 @@
 --baseline selects BOTH v0 and v1 by default, using the remote release manifest.
 Absent/skipped tasks are reported, never silently substituted with another version.
 For older unversioned datasets, use --legacy explicitly (v0 only). No pickle is
-unpickled during download. Authenticate with `hf auth login` for gated/private repos.
+unpickled during download. The default release is public and needs no login.
+Authenticate with `hf auth login` only when using a gated/private --repo override.
 """
 
 from __future__ import annotations
@@ -22,7 +23,7 @@ from pathlib import Path
 
 from demo_release import DEMOS, MANIFEST, baseline_entries, baseline_key, contained_path, install_file, read_manifest, safe_relative, sha256
 
-DEFAULT_REPO = "dexverse/DexVerse_Dataset"
+DEFAULT_REPO = "dexverse/DexVerse_release"
 DEFAULT_REPO_TYPE = "dataset"
 DEFAULT_DEST = DEMOS
 REMOTE_ROOT = "demonstrations"
@@ -114,7 +115,7 @@ def fetch_selected(entries, dest, fetch):
 
 def main():
     parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
-    parser.add_argument("--repo", default=DEFAULT_REPO)
+    parser.add_argument("--repo", default=DEFAULT_REPO, help="HF repo id (default: %(default)s)")
     parser.add_argument("--repo-type", default=DEFAULT_REPO_TYPE, choices=("dataset", "model", "space"))
     parser.add_argument("--revision", default="main", help="Branch, tag, or pinned commit")
     parser.add_argument("--dest", type=Path, default=DEFAULT_DEST)

--- a/scripts/demo_tools/import_versioned_demos.py
+++ b/scripts/demo_tools/import_versioned_demos.py
@@ -1,0 +1,430 @@
+"""Copy trusted NumPy trajectory pickles into version-separated local task folders.
+
+Planning is read-only except for the JSON inventory under outputs/. Apply never
+overwrites inputs or existing different outputs. Remote access is download-only;
+credentials are supplied by the user's existing Hugging Face login, never saved.
+"""
+
+from __future__ import annotations
+
+import argparse
+import builtins
+import collections
+import hashlib
+import json
+import os
+import pickle
+import sys
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+import numpy as np
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "source/dexverse"))
+from dexverse.benchmark import BASELINE_PAIRS, LEGACY_UPGRADE_TASKS, task_identity  # noqa: E402
+
+DEST = ROOT / "source/dexverse/demonstrations"
+IDENTITY_KEYS = (
+    "task",
+    "env_name",
+    "format",
+    "benchmark_revision",
+    "task_version",
+    "task_source_revision",
+    "action_layout",
+)
+
+
+class NumpyCompatUnpickler(pickle.Unpickler):
+    """Allow only the NumPy/container constructors used by these recordings.
+
+    NumPy 2 pickles refer to numpy._core, unavailable in NumPy 1.26. Remapping
+    GLOBAL references at unpickle time preserves values; byte substitution would
+    corrupt pickle FRAME lengths. Re-serialization uses the active NumPy version.
+    This is a narrow compatibility loader, not a general untrusted-pickle sandbox.
+    """
+
+    def __init__(self, stream):
+        super().__init__(stream)
+        self.remapped = set()
+
+    def find_class(self, module, name):
+        original = module
+        if module == "numpy._core" or module.startswith("numpy._core."):
+            module = "numpy.core" + module[len("numpy._core") :]
+            self.remapped.add((original, module, name))
+        allowed = {
+            ("numpy", "ndarray"),
+            ("numpy", "dtype"),
+            ("numpy.core.multiarray", "_reconstruct"),
+            ("numpy.core.multiarray", "scalar"),
+            ("numpy.core.numeric", "_frombuffer"),
+        }
+        if (module, name) in allowed:
+            return super().find_class(module, name)
+        if module == "builtins" and name in {"set", "frozenset", "slice", "complex", "bytearray"}:
+            return getattr(builtins, name)
+        if module == "collections" and name == "OrderedDict":
+            return collections.OrderedDict
+        if module == "_codecs" and name == "encode":
+            return _latin1_encode
+        raise pickle.UnpicklingError(f"Unsupported pickle constructor: {module}.{name}")
+
+
+def _latin1_encode(value, encoding="latin1", errors="strict"):
+    """Old pickle protocols represent byte arrays through this constructor."""
+    if encoding not in {"latin1", "latin-1"} or errors != "strict":
+        raise pickle.UnpicklingError("Only strict latin1 byte reconstruction is supported")
+    return value.encode("latin1")
+
+
+def load_compatible(path):
+    with Path(path).open("rb") as stream:
+        loader = NumpyCompatUnpickler(stream)
+        payload = loader.load()
+    if not isinstance(payload, dict) or not isinstance(payload.get("episodes"), list):
+        raise ValueError("Expected a trajectory dict with episodes")
+    return payload, sorted(loader.remapped)
+
+
+def canonical_v0(task):
+    return task.replace("Dexbench-FixateThenManipulate-", "Dexverse-").replace("Dexbench-", "Dexverse-")
+
+
+def category(task):
+    for line in (DEST / "baseline_manifest.txt").read_text().splitlines():
+        if (
+            line
+            and not line.startswith("#")
+            and line.split("/")[-1].removesuffix("-v0") == task.removesuffix("-v1").removesuffix("-v0")
+        ):
+            return line.split("/")[0]
+    raise ValueError(f"Task is not in the baseline manifest: {task}")
+
+
+def sha256(path):
+    with Path(path).open("rb") as stream:
+        return hashlib.file_digest(stream, "sha256").hexdigest()
+
+
+def array_digest(value):
+    """Digest numerical contents, dtype, shape, and container structure."""
+    h = hashlib.sha256()
+
+    def visit(obj):
+        if isinstance(obj, np.ndarray):
+            if obj.dtype.hasobject:
+                raise ValueError("Object arrays need manual review")
+            h.update(str((obj.dtype.str, obj.shape)).encode())
+            h.update(np.ascontiguousarray(obj).tobytes())
+        elif isinstance(obj, dict):
+            for key in sorted(obj, key=str):
+                h.update(str(key).encode())
+                visit(obj[key])
+        elif isinstance(obj, (list, tuple)):
+            h.update(str((type(obj).__name__, len(obj))).encode())
+            for child in obj:
+                visit(child)
+        elif isinstance(obj, np.generic):
+            visit(np.asarray(obj))
+        else:
+            h.update(repr(obj).encode())
+
+    visit(value)
+    return h.hexdigest()
+
+
+def inspect_payload(payload):
+    episodes = payload["episodes"]
+    dims, entities, issues = set(), set(), set()
+    for ep in episodes:
+        actions = np.asarray(ep.get("actions", []))
+        if actions.ndim != 2 or not len(actions):
+            issues.add("empty_or_invalid_actions")
+            continue
+        dims.add(actions.shape[-1])
+        if not np.isfinite(actions).all():
+            issues.add("nonfinite_actions")
+        states = ep.get("states")
+        if states is None or len(states) != len(actions) + 1:
+            issues.add("missing_or_misaligned_recorded_states")
+        for values in ep.get("initial_state", {}).values():
+            if isinstance(values, dict):
+                entities.update(values)
+    if len(dims) != 1:
+        issues.add("mixed_action_dimensions")
+    if not episodes:
+        issues.add("empty_recording")
+    robot = payload.get("robot_type", "")
+    expected = {"floating_shadow_right": 28, "floating_shadow_left": 28, "floating_shadow_bimanual": 56}.get(robot)
+    if expected is None or dims != {expected}:
+        issues.add("unsupported_or_mismatched_robot_layout")
+    return {
+        "episodes": len(episodes),
+        "recorded_successes": sum(bool(e.get("success")) for e in episodes),
+        "action_dims": sorted(dims),
+        "scene_entities": sorted(entities),
+        "issues": sorted(issues),
+        "task_state_episodes": sum(bool(e.get("task_state")) for e in episodes),
+    }
+
+
+def write_json(path, value):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value, indent=2) + "\n")
+
+
+def plan_local(private_root):
+    # Prefer the latest collection per task. Tests, backups, renders and robot
+    # experiments are not demonstration sources. Keep dated session filenames.
+    collections_by_task = collections.defaultdict(list)
+    allowed = {
+        "0821_yunchao_hammer_withta_table",
+        "0823_zhuxiu_teleop",
+        "0824_yunchao_actual",
+        "0829_yunchao",
+        "0905_zhuxiu",
+    }
+    for directory in sorted(private_root.iterdir()):
+        if directory.name not in allowed:
+            continue
+        for task_dir in sorted(directory.iterdir()):
+            if task_dir.is_dir() and list(task_dir.glob("*.pkl")):
+                collections_by_task[task_dir.name].append(task_dir)
+    items, excluded = [], []
+    for source_task, directories in sorted(collections_by_task.items()):
+        target = LEGACY_UPGRADE_TASKS.get(source_task, BASELINE_PAIRS.get(source_task))
+        if target is None:
+            continue
+        latest = directories[-1]
+        excluded.extend(str(p) for directory in directories[:-1] for p in directory.glob("*.pkl"))
+        for path in sorted(latest.glob("*.pkl")):
+            payload, remaps = load_compatible(path)
+            if payload.get("task") != source_task:
+                raise ValueError(f"Task/path disagreement: {path}")
+            summary = inspect_payload(payload)
+            reasons = list(summary["issues"])
+            if target == "Dexverse-OpenDoor-v1":
+                reasons.append("retired_tilted_door_not_cutaway_latch_v1")
+            if target == "Dexverse-OpenLaptop-v1" and any(
+                n in summary["scene_entities"] for n in ("laptop_goal", "laptop_open_region")
+            ):
+                reasons.append("older_laptop_placement_goal_not_current_v1")
+            if target == "Dexverse-BimanualLiftCarton-v1" and summary["task_state_episodes"] != summary["episodes"]:
+                reasons.append("missing_recorded_carton_target_face")
+            items.append(
+                {
+                    "source": str(path),
+                    "source_task": source_task,
+                    "target_task": target,
+                    "version": 1,
+                    "collection": latest.parent.name,
+                    "sha256": sha256(path),
+                    "bytes": path.stat().st_size,
+                    "summary": summary,
+                    "numpy_remaps": remaps,
+                    "review_reasons": reasons,
+                }
+            )
+    return items, excluded
+
+
+def plan_remote(repo):
+    from huggingface_hub import HfApi
+
+    info = HfApi().dataset_info(repo, files_metadata=True, timeout=30)
+    reruns, state = collections.defaultdict(list), collections.defaultdict(list)
+    for entry in info.siblings:
+        name = entry.rfilename
+        if not name.endswith(".pkl"):
+            continue
+        parts = name.split("/")
+        task = canonical_v0(parts[-2])
+        if task not in BASELINE_PAIRS:
+            continue
+        if name.startswith("baseline_rerun/"):
+            reruns[task].append(entry)
+        elif name.startswith(("pkl/state/floating_shadow_right/", "pkl/state/floating_shadow_bimanual/")):
+            state[task].append(entry)
+    items = []
+    for task in BASELINE_PAIRS:
+        for entry in sorted(reruns.get(task) or state.get(task, []), key=lambda x: x.rfilename):
+            items.append(
+                {
+                    "remote_file": entry.rfilename,
+                    "repo": repo,
+                    "revision": info.sha,
+                    "target_task": task,
+                    "version": 0,
+                    "collection": "baseline_rerun" if entry.rfilename.startswith("baseline_rerun/") else "state_shadow",
+                    "bytes": entry.size,
+                    "remote_sha256": entry.lfs.sha256 if entry.lfs else None,
+                }
+            )
+    return items, info.sha
+
+
+def convert(item, source, dest):
+    payload, remaps = load_compatible(source)
+    summary = inspect_payload(payload)
+    reasons = sorted(set(item.get("review_reasons", []) + summary["issues"]))
+    source_task = payload.get("env_name") or payload.get("task")
+    if item["version"] == 0 and canonical_v0(source_task) != item["target_task"]:
+        raise ValueError(f"Unexpected task in remote file: {source_task}")
+    source_hash = sha256(source)
+    if item.get("sha256") and source_hash != item["sha256"]:
+        raise ValueError("Source changed since planning")
+    if item.get("remote_sha256") and source_hash != item["remote_sha256"]:
+        raise ValueError("Remote hash mismatch")
+    original_identity = {key: payload.get(key) for key in IDENTITY_KEYS}
+    data_digest = array_digest({k: v for k, v in payload.items() if k not in IDENTITY_KEYS})
+    target = item["target_task"]
+    version = item["version"]
+    identity = task_identity(target)
+    payload.update(
+        task=target,
+        env_name=target,
+        format="dexverse_trajectory",
+        task_version=version,
+        benchmark_revision=identity["benchmark_revision"],
+    )
+    # Do not invent recording-time source revisions or joint ordering.
+    payload["task_source_revision"] = original_identity["task_source_revision"]
+    provenance = {
+        "source": item.get("source") or item["remote_file"],
+        "source_sha256": source_hash,
+        "original_identity": original_identity,
+        "numpy_module_remaps": remaps,
+        "normalized_with_numpy": np.__version__,
+        "target_task_source_revision": identity["task_source_revision"],
+        "compatibility": "needs_review" if reasons else "not_simulation_verified",
+        "review_reasons": reasons,
+        "array_and_episode_digest": data_digest,
+        "imported_at_utc": datetime.now(timezone.utc).isoformat(),
+    }
+    if "repo" in item:
+        provenance.update(remote_repo=item["repo"], remote_revision=item["revision"])
+    payload["demo_import"] = provenance
+    directory = dest / ("_review" if reasons else f"v{version}")
+    if reasons:
+        directory = directory / f"v{version}"
+    directory = directory / category(target) / target / item["collection"]
+    filename = Path(source).name.replace(source_task, target)
+    if not filename.startswith(target):
+        filename = target + "__" + filename
+    output = directory / filename
+    output.parent.mkdir(parents=True, exist_ok=True)
+    if output.exists():
+        existing, _ = load_compatible(output)
+        if existing.get("demo_import", {}).get("source_sha256") != source_hash:
+            raise FileExistsError(f"Refusing to overwrite {output}")
+        status = "already_imported"
+    else:
+        # Publish only a complete file. Hard-link creation is atomic and refuses
+        # to replace an existing destination, including a concurrent import.
+        temporary = None
+        try:
+            with tempfile.NamedTemporaryFile(dir=directory, suffix=".tmp", delete=False) as stream:
+                temporary = Path(stream.name)
+                pickle.dump(payload, stream, protocol=4)
+                stream.flush()
+                os.fsync(stream.fileno())
+            os.link(temporary, output)
+        finally:
+            if temporary is not None:
+                temporary.unlink(missing_ok=True)
+        status = "imported"
+    with output.open("rb") as stream:
+        restored = pickle.load(stream)
+    assert restored["task"] == target and restored["task_version"] == version
+    assert (
+        array_digest({k: v for k, v in restored.items() if k not in IDENTITY_KEYS and k != "demo_import"})
+        == data_digest
+    )
+    return {
+        "output": str(output.relative_to(dest)),
+        "status": status,
+        "source_sha256": source_hash,
+        "output_sha256": sha256(output),
+        "target_task": target,
+        "version": version,
+        "summary": summary,
+        "numpy_remaps": remaps,
+        "review_reasons": reasons,
+    }
+
+
+def apply_plan(plan, dest, workspace):
+    from huggingface_hub import hf_hub_download
+
+    results, hashes = [], {}
+    report = workspace / "import_report.json"
+    for item in plan["items"]:
+        try:
+            if "remote_file" in item:
+                source = Path(
+                    hf_hub_download(
+                        repo_id=item["repo"],
+                        repo_type="dataset",
+                        revision=item["revision"],
+                        filename=item["remote_file"],
+                        local_dir=workspace / "remote_raw",
+                    )
+                )
+            else:
+                source = Path(item["source"])
+            digest = sha256(source)
+            key = (item["version"], item["target_task"], digest)
+            if key in hashes:
+                results.append({"status": "duplicate_source", "source": str(source), "duplicate_of": hashes[key]})
+            else:
+                result = convert(item, source, dest)
+                hashes[key] = result["output"]
+                results.append(result)
+                print(
+                    json.dumps({k: result[k] for k in ("status", "target_task", "output", "review_reasons")}),
+                    flush=True,
+                )
+        except Exception as exc:
+            results.append({"status": "failed", "item": item, "error": f"{type(exc).__name__}: {exc}"})
+            print(f"FAILED {item['target_task']}: {type(exc).__name__}: {exc}", flush=True)
+        write_json(report, {"destination": str(dest), "results": results})
+    return int(any(r["status"] == "failed" for r in results))
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--private-root", type=Path)
+    parser.add_argument("--hf-repo", help="Optional private HF dataset to download; no default or upload path.")
+    parser.add_argument("--workspace", type=Path, default=ROOT / "outputs/demo_import")
+    parser.add_argument("--dest", type=Path, default=DEST)
+    parser.add_argument("--apply", action="store_true", help="Apply an existing reviewed plan.json")
+    args = parser.parse_args()
+    path = args.workspace / "plan.json"
+    if args.apply:
+        return apply_plan(json.loads(path.read_text()), args.dest, args.workspace)
+    items, excluded = plan_local(args.private_root) if args.private_root else ([], [])
+    revision = None
+    if args.hf_repo:
+        remote, revision = plan_remote(args.hf_repo)
+        items.extend(remote)
+    write_json(path, {"items": items, "excluded_older_local_sessions": excluded, "remote_revision": revision})
+    print(
+        json.dumps(
+            {
+                "plan": str(path),
+                "files": len(items),
+                "bytes": sum(i["bytes"] for i in items),
+                "tasks_v1": sorted({i["target_task"] for i in items if i["version"] == 1}),
+                "tasks_v0": sorted({i["target_task"] for i in items if i["version"] == 0}),
+            },
+            indent=2,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/demo_tools/merge_demos.py
+++ b/scripts/demo_tools/merge_demos.py
@@ -24,6 +24,7 @@ The resulting pickle stores:
     - ``usd_paths``        : list[str]               length num_envs
     - ``initial_states``   : list[dict]              length num_envs
     - ``goal_poses``       : list[np.ndarray|None]   length num_envs
+    - ``task_states``      : list[dict|None]         length num_envs
     - ``multi_assets``     : list[list[dict]]        length num_envs
     - ``multi_usds``       : list[list[dict]]        length num_envs
     - ``actions``          : np.ndarray (T, N, D)    zero-padded per env
@@ -61,14 +62,20 @@ import numpy as np
 
 TRAJECTORY_FORMAT = "dexverse_trajectory"
 BATCH_FORMAT = "dexverse_trajectory_batch"
-BATCH_SCHEMA_VERSION = 3
+BATCH_SCHEMA_VERSION = 5
 
 # Per-episode active-object-subset field recorded by randomized-pool tasks
 # (e.g. TrashDrawerSort, GraspTwoItems). Preserved through the merge so batch
 # replay can restore each episode's recorded object subset. Mirrors
 # _active_object_masks.ACTIVE_EPISODE_FIELDS (kept local: this tool must not
 # import torch).
-_ACTIVE_EPISODE_FIELDS: tuple[str, ...] = ("active_object_metadata",)
+_ACTIVE_EPISODE_FIELDS: tuple[str, ...] = (
+    "active_object_metadata",
+    "reset_id",
+    "source_reset_id",
+    "reset_source_session",
+    "reset_source_seed",
+)
 
 
 def load_trajectory_pickle(path: str) -> dict:
@@ -191,7 +198,16 @@ def merge_trajectory_pickles(
     env_name = payloads[0].get("env_name")
     robot_type = payloads[0].get("robot_type")
     json_path = payloads[0].get("json_path")
+    benchmark_revision = payloads[0].get("benchmark_revision")
+    action_layout = payloads[0].get("action_layout")
+    sim_device = payloads[0].get("sim_device")
     for path, payload in zip(input_paths[1:], payloads[1:]):
+        if payload.get("sim_device") != sim_device:
+            raise ValueError(f"Simulation device mismatch in {path!r}; do not mix CPU, GPU, or unknown collection devices")
+        if payload.get("benchmark_revision") != benchmark_revision:
+            raise ValueError(f"Benchmark revision mismatch in {path!r}")
+        if not allow_mixed_robot and payload.get("action_layout") != action_layout:
+            raise ValueError(f"Action layout mismatch in {path!r}")
         if not allow_mixed_task and payload.get("task") != task:
             raise ValueError(
                 f"Task mismatch in {path!r}: {payload.get('task')!r} != {task!r} (pass --allow_mixed_task to override)."
@@ -244,6 +260,7 @@ def merge_trajectory_pickles(
                 "usd_path": usd_path,
                 "initial_state": copy.deepcopy(ep.get("initial_state")),
                 "goal_pose": copy.deepcopy(ep.get("goal_pose")),
+                "task_state": copy.deepcopy(ep.get("task_state")),
                 "multi_assets": _normalize_episode_binding_list(ep.get("multi_assets")),
                 "multi_usds": _normalize_episode_binding_list(ep.get("multi_usds")),
                 "actions": actions.astype(np.float32, copy=False),
@@ -269,6 +286,11 @@ def merge_trajectory_pickles(
     batch_payload = {
         "format": BATCH_FORMAT,
         "schema_version": BATCH_SCHEMA_VERSION,
+        "benchmark_revision": benchmark_revision,
+        "sim_device": sim_device,
+        "task_version": payloads[0].get("task_version"),
+        "task_source_revision": payloads[0].get("task_source_revision"),
+        "action_layout": action_layout if not allow_mixed_robot else None,
         "task": task,
         "env_name": env_name,
         "robot_type": robot_type,
@@ -279,6 +301,7 @@ def merge_trajectory_pickles(
         "usd_paths": [entry["usd_path"] for entry in entries],
         "initial_states": [entry["initial_state"] for entry in entries],
         "goal_poses": [entry["goal_pose"] for entry in entries],
+        "task_states": [entry["task_state"] for entry in entries],
         "multi_assets": [entry["multi_assets"] for entry in entries],
         "multi_usds": [entry["multi_usds"] for entry in entries],
         "actions": action_tensor,

--- a/scripts/demo_tools/merge_session_pickles.py
+++ b/scripts/demo_tools/merge_session_pickles.py
@@ -49,6 +49,9 @@ DEFAULT_DEMOS_ROOT = REPO_ROOT / "source" / "dexverse" / "demonstrations"
 # These keys describe the env / asset / robot identity of the recording; if
 # they disagree, the demos are logically different datasets.
 _REQUIRED_MATCH_KEYS: tuple[str, ...] = (
+    "sim_device",
+    "benchmark_revision",
+    "action_layout",
     "format",
     "env_name",
     "task",
@@ -61,6 +64,11 @@ _REQUIRED_MATCH_KEYS: tuple[str, ...] = (
 # ``record_demos.py``. We intentionally keep only these keys in merged output
 # so ad-hoc metadata (e.g. ``augmented*`` markers) does not leak through.
 _CANONICAL_TOP_LEVEL_KEYS: tuple[str, ...] = (
+    "sim_device",
+    "task_version",
+    "benchmark_revision",
+    "task_source_revision",
+    "action_layout",
     "format",
     "schema_version",
     "task",
@@ -69,8 +77,11 @@ _CANONICAL_TOP_LEVEL_KEYS: tuple[str, ...] = (
     "usd_path",
     "robot_type",
     "json_path",
+    "arm_joint_names",
     "num_episodes",
     "episodes",
+    "num_reset_attempts",
+    "reset_attempts",
 )
 
 
@@ -194,13 +205,17 @@ def _merge_one_task(
 
     base_payload: dict | None = None
     base_path: Path | None = None
+    binding_payload: dict | None = None
+    binding_path: Path | None = None
     merged_episodes: list = []
+    merged_reset_attempts: list = []
 
     for src in sources:
         payload = _load_pickle(src)
         _validate_intra_pickle_bindings(payload, src)
         eps = payload.get("episodes") or []
-        if not eps:
+        attempts = payload.get("reset_attempts") or []
+        if not eps and not attempts:
             continue
         if base_payload is None:
             base_payload = payload
@@ -211,15 +226,48 @@ def _merge_one_task(
                     f"{task_dir.name}: incompatible top-level metadata between {base_path.name} and {src.name}:\n"
                     + _format_mismatch(base_payload, payload, base_path, src)
                 )
-            if _first_episode_bindings(payload) != _first_episode_bindings(base_payload):
-                raise ValueError(
-                    f"{task_dir.name}: per-episode multi_assets/multi_usds bindings "
-                    f"differ between {base_path.name} and {src.name}. These sessions "
-                    "used different object pools and cannot be merged into one pickle."
-                )
-        merged_episodes.extend(eps)
+        if eps and binding_payload is None:
+            binding_payload = payload
+            binding_path = src
+        elif eps and _first_episode_bindings(payload) != _first_episode_bindings(binding_payload):
+            assert binding_path is not None
+            raise ValueError(
+                f"{task_dir.name}: per-episode multi_assets/multi_usds bindings "
+                f"differ between {binding_path.name} and {src.name}. These sessions "
+                "used different object pools and cannot be merged into one pickle."
+            )
+        episode_index_offset = len(merged_episodes)
+        source_episode_indices = {
+            int(ep.get("episode_index", local_idx)): episode_index_offset + local_idx
+            for local_idx, ep in enumerate(eps)
+        }
+        reset_id_map: dict[int, int] = {}
+        for attempt in attempts:
+            attempt_copy = dict(attempt)
+            old_reset_id = int(attempt_copy.get("reset_id", len(reset_id_map)))
+            new_reset_id = len(merged_reset_attempts)
+            reset_id_map[old_reset_id] = new_reset_id
+            attempt_copy["reset_id"] = new_reset_id
+            attempt_copy["source_session"] = src.name
+            attempt_copy["source_reset_id"] = old_reset_id
+            attempt_copy["source_seed"] = payload.get("seed")
+            if attempt_copy.get("successful_episode_index") is not None:
+                old_episode_idx = int(attempt_copy["successful_episode_index"])
+                if old_episode_idx in source_episode_indices:
+                    attempt_copy["successful_episode_index"] = source_episode_indices[old_episode_idx]
+            merged_reset_attempts.append(attempt_copy)
+        for ep in eps:
+            ep_copy = dict(ep)
+            if ep_copy.get("reset_id") is not None:
+                old_reset_id = int(ep_copy["reset_id"])
+                if old_reset_id in reset_id_map:
+                    ep_copy["source_reset_id"] = old_reset_id
+                    ep_copy["reset_id"] = reset_id_map[old_reset_id]
+                    ep_copy["reset_source_session"] = src.name
+                    ep_copy["reset_source_seed"] = payload.get("seed")
+            merged_episodes.append(ep_copy)
 
-    if base_payload is None or not merged_episodes:
+    if base_payload is None:
         return (None, 0, "no_episodes")
 
     merged_payload = {k: copy.copy(base_payload.get(k)) for k in _CANONICAL_TOP_LEVEL_KEYS if k in base_payload}
@@ -232,6 +280,10 @@ def _merge_one_task(
         new_episodes.append(ep_copy)
     merged_payload["episodes"] = new_episodes
     merged_payload["num_episodes"] = len(new_episodes)
+    if merged_reset_attempts:
+        merged_payload["reset_attempts"] = merged_reset_attempts
+        merged_payload["num_reset_attempts"] = len(merged_reset_attempts)
+        merged_payload["schema_version"] = max(int(merged_payload.get("schema_version", 0)), 5)
 
     out_path.parent.mkdir(parents=True, exist_ok=True)
     with open(out_path, "wb") as fp:

--- a/scripts/demo_tools/plot_workspace_coverage.py
+++ b/scripts/demo_tools/plot_workspace_coverage.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+# Copyright (c) 2025-2026, The DexVerse Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Workspace-coverage figures: where can objects/goals start (the env's reset
+distribution) vs where the demos actually started.
+
+Inputs (simulator-free):
+  * ``outputs/reset_audit/<Task>/samples.npz`` from
+    ``scripts/env_tools/sample_reset_distributions.py`` (N sampled resets;
+    ``rigid_object/<name>/root_pose`` / ``articulation/<name>/root_pose`` (N,7)),
+  * the session pickles' ``initial_state`` (same layout) for the demo starts.
+
+For every scene entity that actually moves between resets, one top-down panel:
+reset density (2-D histogram, sequential blue) with demo starts overlaid
+(orange), a yaw histogram when the entity's yaw is randomized, and a coverage
+number: the fraction of the reset distribution's occupied area that lies within
+``--radius`` metres of at least one demo start. Discrete per-episode goals found
+in ``task_state`` (e.g. the carton's target face) get a bar panel.
+
+    python scripts/demo_tools/plot_workspace_coverage.py \\
+        --task Dexverse-FunctionalPourMug-v0:functional/Dexverse-FunctionalPourMug-v0/0823_zhuxiu \\
+        --out-dir outputs/demo_audit/coverage
+"""
+from __future__ import annotations
+
+import argparse
+import glob
+import json
+import os
+import pickle
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt  # noqa: E402
+import numpy as np  # noqa: E402
+from matplotlib.colors import LinearSegmentedColormap  # noqa: E402
+
+REPO = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+# Reference palette (dataviz skill): categorical slot 1/2, sequential blue ramp, chrome.
+BLUE, ORANGE = "#2a78d6", "#eb6834"
+SEQ = ["#fcfcfb", "#cde2fb", "#9ec5f4", "#6da7ec", "#3987e5", "#256abf", "#184f95", "#0d366b"]
+INK, INK2, MUTED, GRID, AXIS, SURFACE = "#0b0b0b", "#52514e", "#898781", "#e1e0d9", "#c3c2b7", "#fcfcfb"
+CMAP = LinearSegmentedColormap.from_list("seqblue", SEQ)
+# Human-readable class labels for known discrete goal buffers.
+GOAL_LABELS = {"carton_grasp_face": ["+x", "-x", "+y", "-y", "+z", "-z"]}
+
+
+def yaw_deg(q):  # (N,4) wxyz
+    w, x, y, z = q.T
+    return np.degrees(np.arctan2(2 * (w * z + x * y), 1 - 2 * (y * y + z * z)))
+
+
+def load_samples(task):
+    p = os.path.join(REPO, "outputs", "reset_audit", task, "samples.npz")
+    with np.load(p) as d:
+        return {k: d[k] for k in d.files if k.endswith("root_pose") and not k.startswith("settled/")}
+
+
+def load_demo_starts(rel):
+    eps = [e for p in sorted(glob.glob(os.path.join(REPO, "source/dexverse/demonstrations", rel, "*.pkl")))
+           for e in pickle.load(open(p, "rb"))["episodes"]]
+    poses, goals = {}, {}
+    for e in eps:
+        st = e["initial_state"]
+        for kind in ("rigid_object", "articulation"):
+            for name, entry in st.get(kind, {}).items():
+                poses.setdefault(f"{kind}/{name}/root_pose", []).append(np.asarray(entry["root_pose"]).reshape(-1)[:7])
+        for b, v in ((e.get("task_state") or {}).get("env_buffers") or {}).items():
+            v = np.asarray(v)
+            if v.size == 1:
+                goals.setdefault(b, []).append(int(v))
+    return {k: np.stack(v) for k, v in poses.items()}, goals, len(eps)
+
+
+def coverage(samples_xy, demo_xy, radius, cell=0.02):
+    """Fraction of occupied reset cells (cell m grid) within `radius` of a demo start."""
+    cells = np.unique(np.floor(samples_xy / cell).astype(int), axis=0)
+    centers = (cells + 0.5) * cell
+    d = np.sqrt(((centers[:, None, :] - demo_xy[None, :, :]) ** 2).sum(-1)).min(1)
+    return float((d <= radius).mean()), float(d.max())
+
+
+def style(ax):
+    ax.set_facecolor(SURFACE)
+    for s in ("top", "right"):
+        ax.spines[s].set_visible(False)
+    for s in ("left", "bottom"):
+        ax.spines[s].set_color(AXIS)
+    ax.tick_params(colors=MUTED, labelsize=8)
+    ax.grid(True, color=GRID, linewidth=0.6)
+    ax.set_axisbelow(True)
+
+
+def plot_task(task, rel, out_dir, radius):
+    samples = load_samples(task)
+    demos, goals, n_demos = load_demo_starts(rel)
+    ents = []
+    for k in samples:
+        name = k.split("/")[1]
+        if "table" in name or name == "robot" or k not in demos:
+            continue
+        xy_s = samples[k][:, :2]
+        if xy_s.std(0).max() < 1e-3 and demos[k][:, :2].std(0).max() < 1e-3:
+            continue  # static entity
+        ents.append(k)
+    n = len(ents) + (1 if goals else 0)
+    yaw_rows = [np.ptp(yaw_deg(samples[k][:, 3:7])) > 5 for k in ents]
+    fig_h = 5.0 + (1.8 if any(yaw_rows) else 0)
+    fig, axes = plt.subplots(2 if any(yaw_rows) else 1, max(n, 1), figsize=(4.4 * max(n, 1) + 0.8, fig_h), squeeze=False,
+                             gridspec_kw={"height_ratios": [3, 1]} if any(yaw_rows) else None)
+    fig.patch.set_facecolor(SURFACE)
+    stats = {}
+    # table footprint (from the sampled leg positions); every top-down panel uses it as its frame
+    legs = [samples[k][:, :2] for k in samples if "table_leg" in k]
+    ext = np.abs(np.concatenate(legs)).max(0) + 0.02 if legs else np.array([0.65, 0.65])
+    vmax_all = 1
+    for i, k in enumerate(ents):
+        ax = axes[0, i]; style(ax)
+        s_xy, d_xy = samples[k][:, :2], demos[k][:, :2]
+        lo, hi = -ext, ext
+        bins = [np.arange(lo[0], hi[0] + 0.02, 0.02), np.arange(lo[1], hi[1] + 0.02, 0.02)]
+        h, xe, ye = np.histogram2d(s_xy[:, 0], s_xy[:, 1], bins=bins)
+        vmax = max(1, np.percentile(h[h > 0], 95)); vmax_all = max(vmax_all, vmax)
+        mesh = ax.pcolormesh(xe, ye, h.T, cmap=CMAP, vmin=0, vmax=vmax, shading="flat")
+        ax.scatter(d_xy[:, 0], d_xy[:, 1], s=14, c=ORANGE, edgecolors=SURFACE, linewidths=0.7, zorder=3)
+        ax.add_patch(plt.Rectangle((-ext[0] + 0.02, -ext[1] + 0.02), 2 * ext[0] - 0.04, 2 * ext[1] - 0.04, fill=False, ec=AXIS, lw=0.9, ls="--"))
+        ax.text(ext[0] - 0.03, -ext[1] + 0.03, "table", color=MUTED, fontsize=7, ha="right", va="bottom")
+        cov, worst = coverage(s_xy, d_xy, radius)
+        stats[k] = {"coverage_frac": cov, "worst_gap_m": worst, "reset_x": [float(s_xy[:, 0].min()), float(s_xy[:, 0].max())],
+                    "reset_y": [float(s_xy[:, 1].min()), float(s_xy[:, 1].max())], "demo_x": [float(d_xy[:, 0].min()), float(d_xy[:, 0].max())],
+                    "demo_y": [float(d_xy[:, 1].min()), float(d_xy[:, 1].max())]}
+        ax.set_title(f"{k.split('/')[1]}\ndemos cover {cov*100:.0f}% of reset area (\u2264{radius*100:.0f} cm), worst gap {worst*100:.0f} cm",
+                     fontsize=8.5, color=INK, loc="left")
+        ax.set_xlabel("x [m]", color=INK2, fontsize=8); ax.set_ylabel("y [m]", color=INK2, fontsize=8)
+        ax.set_aspect("equal"); ax.set_xlim(lo[0], hi[0]); ax.set_ylim(lo[1], hi[1])
+        if any(yaw_rows):
+            ay = axes[1, i]; style(ay)
+            if yaw_rows[i]:
+                ys, yd = yaw_deg(samples[k][:, 3:7]), yaw_deg(demos[k][:, 3:7])
+                b = np.arange(-180, 181, 15)
+                ay.hist(ys, bins=b, density=True, color=BLUE, alpha=0.55, label="reset samples")
+                ay.hist(yd, bins=b, density=True, histtype="step", color=ORANGE, lw=2, label="demo starts")
+                ay.set_xlabel("yaw [deg]", color=INK2, fontsize=8); ay.set_xlim(-180, 180); ay.set_yticks([])
+                stats[k]["yaw_reset_range"] = [float(ys.min()), float(ys.max())]; stats[k]["yaw_demo_range"] = [float(yd.min()), float(yd.max())]
+            else:
+                ay.axis("off")
+    if goals:
+        ax = axes[0, len(ents)]; style(ax)
+        b, counts = next(iter(goals.items()))
+        vals = sorted(set(counts)); cnt = [counts.count(v) for v in vals]
+        ax.bar(vals, cnt, color=ORANGE, width=0.7)
+        ax.axhline(n_demos / max(1, len(vals)), color=BLUE, lw=1.5, ls="--")
+        ax.text(vals[-1] + 0.6, n_demos / max(1, len(vals)), "uniform", color=BLUE, fontsize=8, va="center")
+        for v, c in zip(vals, cnt):
+            ax.text(v, c + 0.3, str(c), ha="center", color=INK2, fontsize=8)
+        ax.set_title(f"{b}\n(discrete goal, demos per class; dashed = uniform)", fontsize=8.5, color=INK, loc="left")
+        ax.set_xticks(vals); ax.set_xticklabels([GOAL_LABELS.get(b, {}).__getitem__(v) if b in GOAL_LABELS and v < len(GOAL_LABELS[b]) else str(v) for v in vals])
+        stats[b] = dict(zip(map(str, vals), cnt))
+        if any(yaw_rows):
+            axes[1, len(ents)].axis("off")
+    handles = [plt.Rectangle((0, 0), 1, 1, fc=SEQ[4]), plt.Line2D([], [], marker="o", ls="", mfc=ORANGE, mec=SURFACE, ms=6)]
+    fig.legend(handles, [f"reset distribution ({len(next(iter(samples.values())))} sampled resets, 2 cm cells)", f"demo starts ({n_demos})"],
+               loc="lower left", frameon=False, fontsize=8, labelcolor=INK2, ncol=2)
+    fig.suptitle(f"{task} \u2014 where objects/goals can start vs where the demos started (top-down, env frame)",
+                 x=0.01, ha="left", fontsize=11, color=INK)
+    fig.tight_layout(rect=(0, 0.05, 0.93, 0.94), h_pad=2.5)
+    cax = fig.add_axes([0.945, 0.35, 0.012, 0.45])
+    cb = fig.colorbar(plt.cm.ScalarMappable(cmap=CMAP, norm=plt.Normalize(0, vmax_all)), cax=cax)
+    cb.set_label("resets per cell", color=INK2, fontsize=8); cb.ax.tick_params(colors=MUTED, labelsize=7); cb.outline.set_edgecolor(AXIS)
+    os.makedirs(out_dir, exist_ok=True)
+    out = os.path.join(out_dir, f"{task}.png"); fig.savefig(out, dpi=150, facecolor=SURFACE); plt.close(fig)
+    return out, stats
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--task", action="append", required=True, help="'<TaskId>:<category>/<Task>/<session>' (repeatable)")
+    ap.add_argument("--out-dir", default=os.path.join(REPO, "outputs", "demo_audit", "coverage"))
+    ap.add_argument("--radius", type=float, default=0.05, help="Coverage radius in metres (default 0.05)")
+    a = ap.parse_args()
+    report = {}
+    for spec in a.task:
+        task, rel = spec.split(":", 1)
+        out, stats = plot_task(task, rel, a.out_dir, a.radius)
+        report[task] = stats; print("wrote", out)
+        for k, v in stats.items():
+            if "coverage_frac" in v:
+                print(f"   {k:40s} covered {v['coverage_frac']*100:5.1f}%  worst gap {v['worst_gap_m']*100:4.1f} cm  reset x{v['reset_x']} y{v['reset_y']}")
+    with open(os.path.join(a.out_dir, "coverage_stats.json"), "w") as fp:
+        json.dump(report, fp, indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/demo_tools/recover_carton_task_state.py
+++ b/scripts/demo_tools/recover_carton_task_state.py
@@ -1,0 +1,285 @@
+# Copyright (c) 2025-2026, The DexVerse Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Back-fill the per-episode target face into old carton-regrasp recordings.
+
+``Dexverse-BimanualCartonRegrasp-v0`` pickles recorded before schema 4 (Aug 23
+2026 sessions) carry the goal frame in every scene state (``rigid_object/goal_frame``,
+so its position and yaw replay correctly) but **not** the per-episode env buffer
+``carton_grasp_face`` -- the sampled target face that selects the yellow face
+patches, the goal-cue corner set and the success gates. Replaying such a pickle
+re-samples the face, so the cue, the markers in rendered observations and the
+success check no longer match what the operator saw.
+
+The face is recoverable without the buffer: the success condition in force at
+recording time (``forbidden_faces_fit_in_cue_success`` / ``object_fit_in_cue_success``)
+requires the target face's outward normal to point within ``upright_tol_deg``
+(35 deg) of straight down for ``hold_steps`` consecutive steps, while every other
+face of a cuboid is at least 55 deg away. So for a successful episode the face
+whose normal points down during the final hold window *is* the sampled face.
+The tool also cross-checks the recovered face against the rest of the success
+gates (carton centre inside the cue's slack above the recorded goal frame, yaw
+alignment of the face's horizontal axis with the goal frame) so a corrupted or
+non-success episode is flagged instead of silently labelled.
+
+Recovered faces are written as ``episode["task_state"] = {"env_buffers":
+{"carton_grasp_face": int64}}`` -- the exact layout ``record_demos.py`` (schema 4)
+produces -- so ``create_demo_files_sequential.py`` restores them through
+``restore_episode_task_state`` with no further changes. The pickle's
+``schema_version`` is bumped to 4 and a ``task_state_recovery`` provenance block
+is added at the top level.
+
+Usage::
+
+    # dry run: print the recovered face + checks for every episode, write nothing
+    python scripts/demo_tools/recover_carton_task_state.py <pickle-or-dir> [...]
+
+    # write next to the inputs as <stem>.recovered.pkl
+    python scripts/demo_tools/recover_carton_task_state.py <pickle-or-dir> --write
+
+    # upgrade in place (original kept as <name>.pkl.schema3.bak)
+    python scripts/demo_tools/recover_carton_task_state.py <pickle-or-dir> --inplace
+"""
+
+from __future__ import annotations
+
+import argparse
+import math
+import pickle
+import shutil
+from pathlib import Path
+
+import numpy as np
+
+# --- carton geometry / face conventions -----------------------------------------
+# Mirrors ``dexverse.tasks.config.bimanual.carton_regrasp_cfg`` (importing the cfg
+# needs a running Isaac app, and this tool is meant to run on a plain python).
+CARTON_SCALE = 0.65
+_UNIT_HALF_X, _UNIT_HALF_Y, _UNIT_HEIGHT = 0.150 / 0.75, 0.176 / 0.75, 0.214 / 0.75
+_UNIT_CENTER_XY = (0.0015 / 0.75, 0.0005 / 0.75)
+CARTON_HALF = np.array([_UNIT_HALF_X, _UNIT_HALF_Y, _UNIT_HEIGHT / 2.0]) * CARTON_SCALE
+CARTON_CENTER_LOCAL = np.array([_UNIT_CENTER_XY[0] * CARTON_SCALE, _UNIT_CENTER_XY[1] * CARTON_SCALE, CARTON_HALF[2]])
+# faces ordered [+x, -x, +y, -y, +z, -z] -- the ``carton_grasp_face`` buffer value
+FACE_NAMES = ["+x", "-x", "+y", "-y", "+z", "-z"]
+FACE_AXIS = [0, 0, 1, 1, 2, 2]
+DOWN_NORMAL_PER_FACE = np.array([[1, 0, 0], [-1, 0, 0], [0, 1, 0], [0, -1, 0], [0, 0, 1], [0, 0, -1]], dtype=np.float64)
+# object-frame axis that maps to the goal frame's +x in the required pose
+HORIZONTAL_AXIS_PER_FACE = np.array([[0, 0, 1], [0, 0, 1], [1, 0, 0], [1, 0, 0], [1, 0, 0], [1, 0, 0]], dtype=np.float64)
+
+BUFFER_NAME = "carton_grasp_face"
+TASK_NAME = "Dexverse-BimanualLiftCarton-v1"
+LEGACY_TASK_NAME = "Dexverse-BimanualCartonRegrasp-v0"
+
+
+def _cue_half_extents(face: int, cue_scale: float) -> np.ndarray:
+    """Goal-frame half extents of the carton-shaped cue with ``face`` at the bottom."""
+    r = cue_scale / CARTON_SCALE
+    hx, hy, hz = CARTON_HALF * r
+    axis = FACE_AXIS[face]
+    if axis == 0:
+        return np.array([hz, hy, hx])
+    if axis == 1:
+        return np.array([hx, hz, hy])
+    return np.array([hx, hy, hz])
+
+
+def _rot(q: np.ndarray) -> np.ndarray:
+    """Rotation matrix from a (w, x, y, z) quaternion."""
+    w, x, y, z = (float(v) for v in q)
+    n = math.sqrt(w * w + x * x + y * y + z * z) or 1.0
+    w, x, y, z = w / n, x / n, y / n, z / n
+    return np.array(
+        [
+            [1 - 2 * (y * y + z * z), 2 * (x * y - z * w), 2 * (x * z + y * w)],
+            [2 * (x * y + z * w), 1 - 2 * (x * x + z * z), 2 * (y * z - x * w)],
+            [2 * (x * z - y * w), 2 * (y * z + x * w), 1 - 2 * (x * x + y * y)],
+        ]
+    )
+
+
+def _pose(state: dict, entity: str) -> np.ndarray:
+    return np.asarray(state["rigid_object"][entity]["root_pose"], dtype=np.float64).reshape(-1)[:7]
+
+
+def recover_face(
+    episode: dict,
+    *,
+    hold_steps: int,
+    upright_tol_deg: float,
+    yaw_tol_deg: float,
+    cue_scale: float,
+    goal_center_height: float,
+) -> dict:
+    """Recover the target face of one episode from its final ``hold_steps`` states.
+
+    Returns a dict with ``face`` (int), the per-face mean down-cosine over the
+    window, and the success-gate cross-checks evaluated at the last state.
+    """
+    states = episode.get("states")
+    if not states:
+        raise ValueError("episode has no per-step 'states' (recorded without --record_state)")
+    window = states[-hold_steps:]
+    down_cos = np.zeros((len(window), 6))
+    for i, st in enumerate(window):
+        R = _rot(_pose(st, "object")[3:])
+        down_cos[i] = -(R @ DOWN_NORMAL_PER_FACE.T)[2]  # cos(angle to straight down) per face
+    mean_cos = down_cos.mean(axis=0)
+    order = np.argsort(mean_cos)[::-1]
+    face, runner_up = int(order[0]), int(order[1])
+
+    # Cross-checks against the other success gates at the final state.
+    last = states[-1]
+    obj, goal = _pose(last, "object"), _pose(last, "goal_frame")
+    R_o, R_g = _rot(obj[3:]), _rot(goal[3:])
+    centre_w = obj[:3] + R_o @ CARTON_CENTER_LOCAL
+    centre_g = R_g.T @ (centre_w - goal[:3]) - np.array([0.0, 0.0, goal_center_height])
+    slack = _cue_half_extents(face, cue_scale) - _cue_half_extents(face, CARTON_SCALE)
+    yaw_cos = abs(float((R_o @ HORIZONTAL_AXIS_PER_FACE[face]) @ (R_g @ np.array([1.0, 0.0, 0.0]))))
+    upright_cos = math.cos(math.radians(upright_tol_deg))
+    return {
+        "face": face,
+        "face_name": FACE_NAMES[face],
+        "mean_down_cos": mean_cos,
+        "min_down_cos": float(down_cos[:, face].min()),
+        "runner_up": runner_up,
+        "runner_up_cos": float(mean_cos[runner_up]),
+        "upright_ok": bool(down_cos[:, face].min() >= upright_cos),
+        # a cuboid's other faces are >= 90 deg away from the down face; anything
+        # closer than the upright tolerance itself means the pose is ambiguous
+        "unambiguous": bool(mean_cos[runner_up] < upright_cos),
+        "centre_in_cue": bool(np.all(np.abs(centre_g) <= slack + 1e-6)),
+        "centre_offset": centre_g,
+        "cue_slack": slack,
+        "yaw_ok": bool(yaw_cos >= math.cos(math.radians(yaw_tol_deg))),
+        "yaw_cos": yaw_cos,
+    }
+
+
+def _iter_pickles(paths: list[Path]) -> list[Path]:
+    out: list[Path] = []
+    for p in paths:
+        if p.is_dir():
+            out.extend(sorted(q for q in p.rglob("*.pkl") if ".recovered" not in q.name))
+        else:
+            out.append(p)
+    return out
+
+
+def process_pickle(path: Path, args) -> tuple[int, int]:
+    with open(path, "rb") as fp:
+        payload = pickle.load(fp)
+    task = payload.get("env_name") or payload.get("task")
+    if task not in (TASK_NAME, LEGACY_TASK_NAME) and not args.force_task:
+        print(f"[skip] {path}: task {task!r} is not {TASK_NAME} (pass --force-task to override)")
+        return 0, 0
+    episodes = payload.get("episodes", [])
+    print(f"\n=== {path} (schema {payload.get('schema_version')}, seed {payload.get('seed')}, {len(episodes)} episodes)")
+    n_ok = n_bad = 0
+    face_hist = np.zeros(6, dtype=int)
+    for ep in episodes:
+        idx = ep.get("episode_index", "?")
+        existing = (ep.get("task_state") or {}).get("env_buffers", {}).get(BUFFER_NAME)
+        if existing is not None and not args.overwrite_existing:
+            print(f"  ep{idx:>3}: already has {BUFFER_NAME}={int(np.asarray(existing).reshape(-1)[0])} -- kept (use --overwrite-existing to recompute)")
+            n_ok += 1
+            continue
+        try:
+            r = recover_face(
+                ep,
+                hold_steps=args.hold_steps,
+                upright_tol_deg=args.upright_tol_deg,
+                yaw_tol_deg=args.yaw_tol_deg,
+                cue_scale=args.goal_cue_scale,
+                goal_center_height=args.goal_center_height,
+            )
+        except ValueError as exc:
+            print(f"  ep{idx:>3}: FAILED -- {exc}")
+            n_bad += 1
+            continue
+        success = ep.get("success")
+        checks = [r["upright_ok"], r["unambiguous"], r["centre_in_cue"], r["yaw_ok"], success is True]
+        ok = all(checks)
+        flag = "ok " if ok else "?? "
+        print(
+            f"  ep{idx:>3}: {flag}face={r['face']} ({r['face_name']})  down_cos min={r['min_down_cos']:.3f}"
+            f" runner-up={FACE_NAMES[r['runner_up']]}:{r['runner_up_cos']:.2f}"
+            f"  yaw_cos={r['yaw_cos']:.3f}  centre_off=({r['centre_offset'][0]:+.3f},{r['centre_offset'][1]:+.3f},{r['centre_offset'][2]:+.3f})"
+            f" slack=({r['cue_slack'][0]:.3f},{r['cue_slack'][1]:.3f},{r['cue_slack'][2]:.3f})  success={success}"
+        )
+        if not ok:
+            reasons = [
+                name for name, c in zip(["upright", "unambiguous", "centre_in_cue", "yaw", "success_flag"], checks) if not c
+            ]
+            print(f"          checks failed: {', '.join(reasons)}")
+            if not args.allow_failed_checks:
+                n_bad += 1
+                continue
+        task_state = dict(ep.get("task_state") or {})
+        env_buffers = dict(task_state.get("env_buffers") or {})
+        env_buffers[BUFFER_NAME] = np.asarray(r["face"], dtype=np.int64)
+        task_state["env_buffers"] = env_buffers
+        ep["task_state"] = task_state
+        face_hist[r["face"]] += 1
+        n_ok += 1
+
+    print(f"  recovered {n_ok}/{len(episodes)} episodes; face histogram {dict(zip(FACE_NAMES, face_hist.tolist()))}; flagged {n_bad}")
+    if n_bad and not args.allow_failed_checks:
+        print(f"  [warn] {n_bad} episode(s) failed the consistency checks and were left without a face")
+
+    if args.write or args.inplace:
+        payload["schema_version"] = max(int(payload.get("schema_version", 0)), 4)
+        payload["task_state_recovery"] = {
+            "tool": "scripts/demo_tools/recover_carton_task_state.py",
+            "buffer": BUFFER_NAME,
+            "method": "face whose outward normal points down over the final hold window of a successful episode",
+            "hold_steps": args.hold_steps,
+            "upright_tol_deg": args.upright_tol_deg,
+            "yaw_tol_deg": args.yaw_tol_deg,
+            "goal_cue_scale": args.goal_cue_scale,
+            "goal_center_height": args.goal_center_height,
+            "original_schema_version": int(payload.get("schema_version_original", payload.get("schema_version", 0))),
+            "episodes_recovered": n_ok,
+            "episodes_flagged": n_bad,
+        }
+        if args.inplace:
+            backup = path.with_name(path.name + ".schema3.bak")
+            if not backup.exists():
+                shutil.copy2(path, backup)
+            out_path = path
+        else:
+            out_path = path.with_name(path.stem + ".recovered.pkl")
+        with open(out_path, "wb") as fp:
+            pickle.dump(payload, fp, protocol=pickle.HIGHEST_PROTOCOL)
+        print(f"  wrote {out_path}" + (f" (backup: {backup})" if args.inplace else ""))
+    return n_ok, n_bad
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("paths", nargs="+", type=Path, help="Pickle files or directories (searched recursively for *.pkl).")
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument("--write", action="store_true", help="Write <stem>.recovered.pkl next to each input.")
+    mode.add_argument("--inplace", action="store_true", help="Overwrite each input (keeps <name>.pkl.schema3.bak).")
+    parser.add_argument("--overwrite-existing", action="store_true", help="Recompute faces even when task_state already has one.")
+    parser.add_argument("--allow-failed-checks", action="store_true", help="Still write a face for episodes that fail the consistency checks.")
+    parser.add_argument("--force-task", action="store_true", help="Process pickles whose task name is not the carton task.")
+    # Success-gate parameters in force when the demos were recorded (carton_regrasp_cfg.py @ 8df6b57).
+    parser.add_argument("--hold-steps", type=int, default=30)
+    parser.add_argument("--upright-tol-deg", type=float, default=35.0)
+    parser.add_argument("--yaw-tol-deg", type=float, default=25.0)
+    parser.add_argument("--goal-cue-scale", type=float, default=0.85)
+    parser.add_argument("--goal-center-height", type=float, default=0.22)
+    args = parser.parse_args()
+
+    total_ok = total_bad = 0
+    for path in _iter_pickles(args.paths):
+        ok, bad = process_pickle(path, args)
+        total_ok += ok
+        total_bad += bad
+    print(f"\nDone: {total_ok} episodes recovered, {total_bad} flagged." + ("" if (args.write or args.inplace) else " (dry run -- pass --write or --inplace to save)"))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/demo_tools/verify_versioned_demos.py
+++ b/scripts/demo_tools/verify_versioned_demos.py
@@ -1,0 +1,186 @@
+"""Verify a local demo import and write an ignored, private coverage inventory.
+
+No simulator, network access, uploads, or source modifications are performed.
+The inputs must be trusted outputs from import_versioned_demos.py.
+"""
+
+from __future__ import annotations
+
+import argparse
+import collections
+import json
+import pickle
+import subprocess
+from pathlib import Path
+
+import numpy as np
+
+from import_versioned_demos import BASELINE_PAIRS, IDENTITY_KEYS, ROOT, array_digest, sha256, write_json
+
+
+def nonfinite_arrays(value, prefix=""):
+    if isinstance(value, np.ndarray):
+        if np.issubdtype(value.dtype, np.number) and not np.isfinite(value).all():
+            yield prefix
+    elif isinstance(value, dict):
+        for key, child in value.items():
+            yield from nonfinite_arrays(child, f"{prefix}/{key}")
+    elif isinstance(value, (list, tuple)):
+        for index, child in enumerate(value):
+            yield from nonfinite_arrays(child, f"{prefix}/{index}")
+
+
+def verify(workspace):
+    report = json.loads((workspace / "import_report.json").read_text())
+    plan = json.loads((workspace / "plan.json").read_text())
+    dest = Path(report["destination"])
+    imported = [result for result in report["results"] if "output" in result]
+    failures = [result for result in report["results"] if result["status"] == "failed"]
+    rows, episodes_seen, duplicate_episodes, problems = [], {}, [], []
+    if len(report["results"]) != len(plan["items"]):
+        problems.append({"incomplete_import": {"planned": len(plan["items"]), "processed": len(report["results"])}})
+    sources = {item.get("source") or item.get("remote_file"): item for item in plan["items"]}
+    for result in imported:
+        output = dest / result["output"]
+        # Ordinary loading, deliberately without the compatibility unpickler.
+        with output.open("rb") as stream:
+            payload = pickle.load(stream)
+        provenance = payload["demo_import"]
+        item = sources[provenance["source"]]
+        source = Path(item["source"]) if "source" in item else workspace / "remote_raw" / item["remote_file"]
+        expected_hash = item.get("sha256") or item.get("remote_sha256") or result["source_sha256"]
+        checks = {
+            "source_hash_unchanged": sha256(source) == expected_hash == result["source_sha256"],
+            "output_hash_unchanged": sha256(output) == result["output_sha256"],
+            "identity_matches": payload["task"] == payload["env_name"] == result["target_task"]
+            and payload["task_version"] == result["version"],
+            "data_digest_matches": array_digest(
+                {key: value for key, value in payload.items() if key not in IDENTITY_KEYS and key != "demo_import"}
+            )
+            == provenance["array_and_episode_digest"],
+        }
+        invalid = list(nonfinite_arrays(payload["episodes"]))
+        checks["finite_episode_arrays"] = not invalid
+        row = {**result, "checks": checks, "nonfinite_array_paths": invalid}
+        rows.append(row)
+        if not all(checks.values()):
+            problems.append({"output": result["output"], "checks": checks})
+        for index, episode in enumerate(payload["episodes"]):
+            digest = array_digest({key: value for key, value in episode.items() if key != "episode_index"})
+            key = (result["target_task"], digest)
+            location = {"output": result["output"], "episode_index_in_file": index}
+            if key in episodes_seen:
+                duplicate_episodes.append({**location, "same_as": episodes_seen[key]})
+            else:
+                episodes_seen[key] = location
+        print(f"Verified {result['output']}", flush=True)
+
+    paths = [str(dest / row["output"]) for row in rows]
+    paths.extend(str(path) for path in workspace.rglob("*") if path.is_file())
+    ignored = subprocess.run(
+        ["git", "check-ignore", "--stdin", "-z"],
+        input="\0".join(paths) + "\0",
+        text=True,
+        capture_output=True,
+        check=False,
+        cwd=ROOT,
+    )
+    ignored_paths = set(ignored.stdout.split("\0"))
+    unignored = sorted(set(paths) - ignored_paths)
+    counts = collections.defaultdict(lambda: {"files": 0, "episodes": 0, "tasks": set(), "numpy_remapped_files": 0})
+    for row in rows:
+        group = f"review_v{row['version']}" if row["review_reasons"] else f"v{row['version']}"
+        count = counts[group]
+        count["files"] += 1
+        count["episodes"] += row["summary"]["episodes"]
+        count["tasks"].add(row["target_task"])
+        count["numpy_remapped_files"] += bool(row["numpy_remaps"])
+    for count in counts.values():
+        count["tasks"] = sorted(count["tasks"])
+    verified = {
+        "numpy_version": np.__version__,
+        "remote_revision": plan["remote_revision"],
+        "counts": dict(counts),
+        "failures": failures,
+        "verification_problems": problems,
+        "unignored_paths": unignored,
+        "duplicate_episodes": duplicate_episodes,
+        "excluded_older_local_sessions": plan["excluded_older_local_sessions"],
+        "files": rows,
+        "simulation_replay_verified": False,
+    }
+    write_json(workspace / "verification.json", verified)
+    lines = [
+        "# Local private demonstration inventory",
+        "",
+        "Private data: keep this inventory and all imported recordings local and Git-ignored.",
+        "",
+        f"Destination: `{dest}`",
+        "",
+        f"Remote snapshot: `{plan['remote_revision']}` (Hugging Face dataset; see plan.json).",
+        "",
+        f"Normalized and ordinarily reloaded with NumPy {np.__version__}. Source/output hashes and",
+        "numerical/episode digests checked. Simulation replay is **not verified**.",
+        "",
+        "Counts are recorded episode entries; sessions were not merged or episode-filtered.",
+        f"Exact repeated episodes (ignoring only episode_index): {len(duplicate_episodes)}.",
+        "",
+        "| Baseline family | v0 episodes (files) | v1 episodes (files) | Review episodes (files) |",
+        "|---|---:|---:|---:|",
+    ]
+    for v0, v1 in BASELINE_PAIRS.items():
+        family = [row for row in rows if row["target_task"] in {v0, v1}]
+        cells = []
+        for group in (0, 1, "review"):
+            matching = [
+                row
+                for row in family
+                if (
+                    bool(row["review_reasons"])
+                    if group == "review"
+                    else not row["review_reasons"] and row["version"] == group
+                )
+            ]
+            cells.append(
+                f"{sum(row['summary']['episodes'] for row in matching)} ({len(matching)})" if matching else "—"
+            )
+        lines.append(f"| {v0.removeprefix('Dexverse-').removesuffix('-v0')} | {' | '.join(cells)} |")
+    lines.extend(["", "## Review reasons", ""])
+    reasons = collections.Counter(reason for row in rows for reason in row["review_reasons"])
+    lines.extend(f"- `{reason}`: {count} files" for reason, count in sorted(reasons.items()))
+    lines.extend(
+        [
+            "",
+            "## Selection and provenance",
+            "",
+            "- Local v1: latest known production collection per task; older sessions, tests, backups and renders excluded.",
+            "- Remote v0: explicit baseline reruns preferred; otherwise state-recorded Shadow sessions.",
+            "- Known laptop placement-goal prototypes and carton sessions without target-face state are in `_review/v1`.",
+            "- Empty sessions are retained in `_review`, not counted as usable demonstrations.",
+            "- Missing coverage is not filled with recordings from a different task version or robot family.",
+            "- Each pickle's `demo_import` retains source identity, source SHA-256 and normalization provenance.",
+            "- `plan.json`, `import_report.json` and `verification.json` contain exact paths and per-file results.",
+            "- Originals were not modified. No data was staged, committed, uploaded or pushed.",
+            "",
+            f"Import failures: {len(failures)}; verification problems: {len(problems)}; unignored data paths: {len(unignored)}.",
+            "",
+        ]
+    )
+    (workspace / "INVENTORY.md").write_text("\n".join(lines))
+    print(
+        json.dumps(
+            {
+                key: value
+                for key, value in verified.items()
+                if key not in {"files", "excluded_older_local_sessions", "duplicate_episodes"}
+            },
+            indent=2,
+        )
+    )
+    return int(bool(failures or problems or unignored))
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--workspace", type=Path, default=ROOT / "outputs/demo_import")
+    raise SystemExit(verify(parser.parse_args().workspace.resolve()))

--- a/scripts/env_tools/check_cutaway_door_physics.py
+++ b/scripts/env_tools/check_cutaway_door_physics.py
@@ -1,0 +1,166 @@
+"""Bounded automatic-catch checks: cam, snap, hold, release and spring return.
+
+Places joints at each physical test's initial state, then lets actual contact
+and configured drives act. A separate predicate check seeds synthetic grasp
+door-contact history to isolate hands-free dwell; this is not a teleop demo.
+"""
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "source/dexverse"))
+from isaaclab.app import AppLauncher  # noqa: E402
+
+parser = argparse.ArgumentParser(description=__doc__)
+parser.add_argument("--report", type=Path, default=ROOT / "outputs/cutaway_door/physics.json")
+parser.add_argument("--opening-torque", type=float, default=1.0, help="Diagnostic hinge torque in Nm; latch remains passive.")
+AppLauncher.add_app_launcher_args(parser)
+args = parser.parse_args()
+app = AppLauncher(args).app
+
+import gymnasium as gym  # noqa: E402
+import torch  # noqa: E402
+import dexverse.tasks  # noqa: E402,F401
+from dexverse.tasks.utils import parse_env_cfg, strip_camera_cfgs, prune_stale_obs_refs  # noqa: E402
+from dexverse.baseline_v1.mdp import door_latch  # noqa: E402
+
+
+def main():
+    cfg = parse_env_cfg("Dexverse-OpenDoor-v1", device=args.device, num_envs=1)
+    cfg._apply_observation_preset("state")
+    strip_camera_cfgs(cfg)
+    prune_stale_obs_refs(cfg)
+    env = gym.make("Dexverse-OpenDoor-v1", cfg=cfg).unwrapped
+    asset = env.scene["articulation"]
+    door_id = asset.find_joints("door_hinge")[0][0]
+    latch_id = asset.find_joints("latch_slide")[0][0]
+    results = {}
+
+    def initialize(angle, height=0.0):
+        env.reset(seed=42)
+        robot = env.scene["robot"]
+        root = robot.data.root_state_w.clone()
+        root[:, 0] -= 2.0  # Move the hand away, not a prop holding the door.
+        robot.write_root_pose_to_sim(root[:, :7])
+        q = asset.data.default_joint_pos.clone()
+        q[:, door_id], q[:, latch_id] = angle, height
+        asset.write_joint_state_to_sim(q, torch.zeros_like(q))
+        target = torch.zeros_like(q)
+        target[:, door_id] = cfg.door_preload_angle
+        asset.set_joint_position_target(target)
+        asset.set_joint_effort_target(torch.zeros_like(q))
+        env.scene.write_data_to_sim()
+        env.sim.forward()
+        env.scene.update(cfg.sim.dt)
+
+    def simulate(steps):
+        angles, heights, support = [], [], []
+        for _ in range(steps):
+            env.scene.write_data_to_sim()
+            env.sim.step(render=False)
+            env.scene.update(cfg.sim.dt)
+            angles.append(float(asset.data.joint_pos[0, door_id]))
+            heights.append(float(asset.data.joint_pos[0, latch_id]))
+            force = env.scene["door_latch_contact"].data.force_matrix_w
+            support.append(float(force.norm(dim=-1).sum()) if force is not None else 0.0)
+        assert torch.isfinite(asset.data.joint_pos).all()
+        return {"angle": angles, "latch_height": heights, "support_force": support}
+
+    initialize(0.9)
+    env.episode_length_buf.fill_(1)
+    assert not door_latch.door_reclosed(env).item()
+    results["unlatched_closes"] = simulate(480)
+    env.episode_length_buf.fill_(2)
+    assert door_latch.door_reclosed(env).item(), "Reclosed failure did not trigger after opening"
+    print("FREE_CLOSE", results["unlatched_closes"]["angle"][::60], flush=True)
+    # Open using applied hinge torque as a stand-in for the hand, never by
+    # teleporting through the catch or directly driving the latch joint.
+    initialize(0.9)
+    effort = torch.zeros_like(asset.data.joint_pos)
+    effort[:, door_id] = args.opening_torque
+    asset.set_joint_effort_target(effort)
+    approach = {"angle": [], "latch_height": [], "support_force": []}
+    for _ in range(600):
+        sample = simulate(1)
+        for key in approach:
+            approach[key].extend(sample[key])
+        if sample["angle"][-1] >= 1.6057:  # ~92 degrees, then release opening effort.
+            break
+    results["automatic_engagement"] = approach
+    asset.set_joint_effort_target(torch.zeros_like(effort))
+    print("AUTO_APPROACH", approach["angle"][-1], max(approach["latch_height"]), flush=True)
+    results["catch_holds"] = simulate(360)
+    env.episode_length_buf.fill_(1)
+    assert not door_latch.door_latched_and_released(env).item(), "No recorded hand release yet"
+    # Isolate the final support/release gate. This is synthetic history for a
+    # predicate test, not a teleop demonstration or proof of hand reachability.
+    env.cutaway_door_progress[:, 1] = 1
+    for index in range(2, 62):
+        simulate(cfg.decimation)
+        env.episode_length_buf.fill_(index)
+        success = door_latch.door_latched_and_released(env)
+        assert bool(success.item()) == (index == 61), "Physical release dwell counted incorrectly"
+    print(
+        "CATCH_HOLD",
+        results["catch_holds"]["angle"][::60],
+        results["catch_holds"]["latch_height"][::60],
+        results["catch_holds"]["support_force"][::60],
+        flush=True,
+    )
+    q = asset.data.joint_pos.clone()
+    q[:, latch_id] = 0.05
+    asset.write_joint_state_to_sim(q, torch.zeros_like(q))
+    target = torch.zeros_like(q)
+    target[:, door_id] = cfg.door_preload_angle
+    target[:, latch_id] = 0.05  # Diagnostic release, not needed for task success.
+    asset.set_joint_position_target(target)
+    results["raised_catch_releases"] = simulate(480)
+    print("RELEASE", results["raised_catch_releases"]["angle"][::60], flush=True)
+    args.report.parent.mkdir(parents=True, exist_ok=True)
+    checks = {
+        "automatically_cammed": max(approach["latch_height"]) > 0.025,
+        "reached_open_angle": approach["angle"][-1] >= 1.6057,
+        "spring_returned_catch": max(results["catch_holds"]["latch_height"][-120:]) < 0.012,
+        "unlatched_closes": results["unlatched_closes"]["angle"][-1] < 0.09,
+        "catch_holds": min(results["catch_holds"]["angle"][-120:]) > 1.46,
+        "support_measured": max(results["catch_holds"]["support_force"][-120:]) > 0.05,
+        "raised_catch_releases": results["raised_catch_releases"]["angle"][-1] < 0.10,
+    }
+    args.report.write_text(
+        json.dumps(
+            {
+                "status": "passed" if all(checks.values()) else "failed",
+                "checks": checks,
+                "dt": cfg.sim.dt,
+                "opening_torque_nm": args.opening_torque,
+                "release_dwell_steps": cfg.hold_steps,
+                "synthetic_prior_door_contact": True,
+                "tests": results,
+            },
+            indent=2,
+        )
+    )
+    assert all(checks.values()), checks
+    assert results["unlatched_closes"]["angle"][-1] < 0.09, "Closing spring does not close the free door"
+    assert min(results["catch_holds"]["angle"][-120:]) > 1.46, "Catch did not physically hold open"
+    assert max(results["catch_holds"]["support_force"][-120:]) > 0.05, "No catch support contact"
+    assert results["raised_catch_releases"]["angle"][-1] < 0.10, "Door remains locked after catch clears"
+    print("CUTAWAY_PHYSICS: automatic cam/snap, contact retention, release dwell and spring return passed", flush=True)
+
+
+try:
+    main()
+except BaseException:
+    import traceback
+
+    traceback.print_exc()
+    sys.stdout.flush()
+    sys.stderr.flush()
+    os._exit(1)
+sys.stdout.flush()
+sys.stderr.flush()
+os._exit(0)

--- a/scripts/env_tools/check_task_upgrades.py
+++ b/scripts/env_tools/check_task_upgrades.py
@@ -1,0 +1,306 @@
+# Copyright (c) 2025-2026, The DexVerse Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Check task configurations and bounded reset/step smoke tests in this checkout.
+
+Run with the existing Isaac Lab Python environment. Source selection is explicit
+so an editable installation pointing at a different checkout cannot mask errors.
+Use --configs_only for every registered task, or --tasks followed by task IDs to
+run a small number of resets with the camera-free state preset.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import pickle
+import subprocess
+import sys
+import traceback
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "source" / "dexverse"))
+
+# Isaac Sim teardown/reinitialization can stall when multiple scenes run in one
+# process. Dispatch physics checks to bounded workers before launching Kit.
+if "--configs_only" not in sys.argv:
+    dispatch = argparse.ArgumentParser(add_help=False)
+    dispatch.add_argument("--tasks", nargs="+")
+    dispatch.add_argument("--report", type=Path, default=Path("outputs/task_upgrades/checks.json"))
+    selection, remaining = dispatch.parse_known_args()
+    if selection.tasks and len(selection.tasks) > 1:
+        selection.report.parent.mkdir(parents=True, exist_ok=True)
+        combined = {"tasks": {}}
+        for task in selection.tasks:
+            task_report = selection.report.parent / f"{selection.report.stem}_{task}.json"
+            command = [sys.executable, __file__, *remaining, "--tasks", task, "--report", str(task_report)]
+            try:
+                completed = subprocess.run(command, timeout=150, check=False)
+                if task_report.is_file():
+                    result = json.loads(task_report.read_text())
+                    combined["source"] = result["source"]
+                    combined["tasks"].update(result["tasks"])
+                else:
+                    combined["tasks"][task] = {"status": "failed", "error": f"worker exited {completed.returncode}"}
+            except subprocess.TimeoutExpired:
+                if task_report.is_file():
+                    result = json.loads(task_report.read_text())
+                    combined["tasks"].update(result["tasks"])
+                    combined["tasks"][task]["cleanup_timeout"] = True
+                else:
+                    combined["tasks"][task] = {"status": "failed", "error": "worker exceeded 150 seconds"}
+            selection.report.write_text(json.dumps(combined, indent=2) + "\n")
+        raise SystemExit(int(any(r["status"] == "failed" for r in combined["tasks"].values())))
+
+from isaaclab.app import AppLauncher  # noqa: E402
+from dexverse.teleop_utils.debug_visualization import (  # noqa: E402
+    add_debug_visualization_args, configure_v1_debug_visualization,
+)
+
+parser = argparse.ArgumentParser(description=__doc__)
+parser.add_argument("--tasks", nargs="+", default=None)
+parser.add_argument("--configs_only", action="store_true")
+parser.add_argument("--resets", type=int, default=3)
+parser.add_argument("--steps", type=int, default=8)
+parser.add_argument("--num_envs", type=int, default=1)
+parser.add_argument("--seed", type=int, default=42, help="Nonnegative validation seed; reset i uses seed+i.")
+parser.add_argument(
+    "--check_seed_repeatability", action="store_true",
+    help="Verify each seeded scene/task reset repeats after an intervening different-seed reset.",
+)
+parser.add_argument("--report", type=Path, default=Path("outputs/task_upgrades/checks.json"))
+parser.add_argument("--record_fixture", type=Path, default=None, help="Save the last reset as a replay fixture.")
+parser.add_argument("--inspect_visuals", action="store_true", help="Record marker visibility/purpose and retargeter debug flags.")
+parser.add_argument(
+    "--image", type=Path, default=None, help="Save a third-person RGB frame (requires --enable_cameras)."
+)
+AppLauncher.add_app_launcher_args(parser)
+add_debug_visualization_args(parser)
+args = parser.parse_args()
+if args.seed < 0 or args.seed + max(100, args.resets) + args.resets > 2**32 - 1:
+    parser.error("--seed must leave room for the validation/reset seed range in [0, 2**32-1]")
+if args.resets < 1 or args.steps < 1:
+    parser.error("--resets and --steps must be positive")
+app = AppLauncher(args).app
+
+import dexverse  # noqa: E402
+import dexverse.tasks  # noqa: E402, F401
+import gymnasium as gym  # noqa: E402
+import torch  # noqa: E402
+from dexverse.tasks.utils import parse_env_cfg, prune_stale_obs_refs, strip_camera_cfgs  # noqa: E402
+from dexverse.benchmark import action_layout, task_identity  # noqa: E402
+from dexverse.teleop_utils.episode_task_state import (  # noqa: E402
+    capture_episode_task_state,
+    restore_episode_task_state,
+    reset_managers_after_state_restore,
+)
+
+
+def compare_state(left, right):
+    """Compare reset scene/command/task tensors, allowing small float noise."""
+    if isinstance(left, dict):
+        assert left.keys() == right.keys()
+        for key in left:
+            compare_state(left[key], right[key])
+    else:
+        torch.testing.assert_close(left, right, atol=1e-6, rtol=1e-5)
+
+
+def main():
+    source = Path(dexverse.__file__).resolve()
+    if not source.is_relative_to(REPO_ROOT):
+        raise RuntimeError(f"Wrong checkout imported: {source}")
+    tasks = args.tasks or sorted(s.id for s in gym.registry.values() if s.id.startswith("Dexverse-"))
+    report = {"source": str(source), "configs_only": args.configs_only, "tasks": {}}
+    failed = False
+    for task in tasks:
+        env = None
+        try:
+            cfg = parse_env_cfg(task, device=args.device, num_envs=args.num_envs)
+            if args.enable_debug_vis is not None:
+                cfg = type(cfg)(enable_debug_vis=args.enable_debug_vis)
+                cfg.sim.device = args.device
+                cfg.scene.num_envs = args.num_envs
+            configure_v1_debug_visualization(cfg, cues_in_rgb=args.cues_in_rgb)
+            cfg.observation_preset = "state"
+            cfg._apply_observation_preset("state")
+            if not args.enable_cameras:
+                strip_camera_cfgs(cfg)
+                prune_stale_obs_refs(cfg)
+            cfg.seed = args.seed
+            cfg.sim.render_interval = cfg.decimation
+            result = {
+                "robot_type": cfg.robot_type, "status": "configured", "seed": args.seed,
+                "enable_debug_vis": cfg.enable_debug_vis, "cues_in_rgb": args.cues_in_rgb,
+            }
+            report["tasks"][task] = result
+            if not args.configs_only:
+                env = gym.make(task, cfg=cfg).unwrapped
+                terminations = {}
+                reset_seeds = [args.seed + index for index in range(args.resets)]
+                perturbation_seeds = [seed + max(100, args.resets) for seed in reset_seeds]
+                for reset_index in range(args.resets):
+                    env.reset(seed=reset_seeds[reset_index])
+                    # Finite observations alone cannot detect goals accidentally
+                    # placed on another cloned scene's table.
+                    for name in env.command_manager.active_terms:
+                        command = env.command_manager.get_term(name)
+                        if (type(command).__name__ == "ObjectUniformPoseCommand"
+                                and type(command).__module__.startswith("dexverse.baseline_v1.")
+                                and command.cfg.use_world_frame):
+                            ranges = command.cfg.ranges
+                            low = torch.tensor([ranges.pos_x[0], ranges.pos_y[0], ranges.pos_z[0]], device=env.device)
+                            high = torch.tensor([ranges.pos_x[1], ranges.pos_y[1], ranges.pos_z[1]], device=env.device)
+                            local = command.command[:, :3] - env.scene.env_origins
+                            assert ((local >= low - 1e-5) & (local <= high + 1e-5)).all(), (
+                                f"{name}: sampled goal lies outside its own scene's configured ranges"
+                            )
+                    snapshot = capture_episode_task_state(env)
+                    # A second reset changes random commands/choices. Restore
+                    # scene and task state, as the sequential converter does.
+                    scene_state = env.scene.get_state(is_relative=True)
+                    env.reset(seed=perturbation_seeds[reset_index])
+                    if args.check_seed_repeatability:
+                        env.reset(seed=reset_seeds[reset_index])
+                        compare_state(scene_state, env.scene.get_state(is_relative=True))
+                        compare_state(snapshot, capture_episode_task_state(env))
+                        # Still test state restoration from an unrelated reset.
+                        env.reset(seed=perturbation_seeds[reset_index])
+                    env.reset_to(scene_state, env_ids=None, is_relative=True)
+                    reset_managers_after_state_restore(env)
+                    skipped = restore_episode_task_state(env, snapshot)
+                    if skipped:
+                        raise RuntimeError(f"Task state did not round trip: {skipped}")
+                    replayed = capture_episode_task_state(env)
+
+                    compare_state(snapshot, replayed)
+                    env.command_manager.compute(dt=0.0)
+                    action = torch.zeros((env.num_envs, env.action_manager.total_action_dim), device=env.device)
+                    states = [env.scene.get_state(is_relative=True)]
+                    actions = []
+
+                    def assert_finite(value):
+                        if isinstance(value, dict):
+                            for child in value.values():
+                                assert_finite(child)
+                        elif isinstance(value, torch.Tensor) and value.is_floating_point():
+                            assert torch.isfinite(value).all(), "Non-finite simulation state or observation"
+
+                    for _ in range(args.steps):
+                        obs, reward, *_ = env.step(action)
+                        assert_finite(obs)
+                        assert_finite(reward)
+                        if args.record_fixture:
+                            states.append(env.scene.get_state(is_relative=True))
+                            actions.append(action[0].detach().cpu().numpy())
+                        for name in env.termination_manager.active_terms:
+                            count = int(env.termination_manager.get_term(name).sum().item())
+                            terminations[name] = terminations.get(name, 0) + count
+                if args.record_fixture:
+                    if env.num_envs != 1:
+                        raise ValueError("--record_fixture requires --num_envs 1")
+
+                    def cpu(value):
+                        if isinstance(value, dict):
+                            return {key: cpu(child) for key, child in value.items()}
+                        if isinstance(value, torch.Tensor):
+                            return value.detach().cpu().numpy()
+                        return value
+
+                    fixture = {
+                        "format": "dexverse_trajectory",
+                        "schema_version": 5,
+                        "task": task,
+                        "env_name": task,
+                        "robot_type": cfg.robot_type,
+                        "seed": args.seed,
+                        "reset_seed": reset_seeds[reset_index],
+                        **task_identity(task),
+                        "action_layout": action_layout(env),
+                        "record_state": True,
+                        "num_episodes": 1,
+                        "episodes": [
+                            {
+                                "episode_index": 0,
+                                "episode_name": "reset_smoke",
+                                "success": False,
+                                "initial_state": cpu(states[0]),
+                                "task_state": cpu(snapshot),
+                                "states": [cpu(state) for state in states],
+                                "actions": actions,
+                            }
+                        ],
+                    }
+                    args.record_fixture.parent.mkdir(parents=True, exist_ok=True)
+                    with args.record_fixture.open("wb") as stream:
+                        pickle.dump(fixture, stream)
+                if args.image:
+                    import matplotlib.pyplot as plt
+
+                    for _ in range(3):
+                        env.sim.render()
+                    camera = env.scene["third_person_camera"]
+                    rgb = camera.data.output["rgb"][0, ..., :3].detach().cpu().numpy()
+                    args.image.parent.mkdir(parents=True, exist_ok=True)
+                    plt.imsave(args.image, rgb)
+                    result["image"] = str(args.image)
+                if args.inspect_visuals:
+                    from pxr import Usd, UsdGeom
+                    import omni.usd
+
+                    stage = omni.usd.get_context().get_stage()
+                    result["visual_markers"] = {
+                        str(prim.GetPath()): {
+                            "purpose": UsdGeom.Imageable(prim).ComputePurpose(),
+                            "visibility": UsdGeom.Imageable(prim).ComputeVisibility(),
+                        }
+                        for prim in Usd.PrimRange(stage.GetPseudoRoot())
+                        if prim.IsA(UsdGeom.PointInstancer)
+                    }
+                    result["retargeter_debug_vis"] = [
+                        getattr(rtg, "debug_vis", None)
+                        for device in getattr(getattr(cfg, "teleop_devices", None), "devices", {}).values()
+                        for rtg in getattr(device, "retargeters", [])
+                    ]
+                result.update(
+                    status="stepped",
+                    resets=args.resets,
+                    steps_per_reset=args.steps,
+                    num_envs=env.num_envs,
+                    action_dim=env.action_manager.total_action_dim,
+                    termination_counts=terminations,
+                    reset_seeds=reset_seeds,
+                    perturbation_seeds=perturbation_seeds,
+                    seed_repeatability="passed" if args.check_seed_repeatability else "not_checked",
+                )
+            report["tasks"][task] = result
+            print(f"[task-upgrades] PASS {task}: {result}", flush=True)
+        except Exception:
+            failed = True
+            report["tasks"][task] = {"status": "failed", "error": traceback.format_exc()}
+            print(f"[task-upgrades] FAIL {task}\n{traceback.format_exc()}", flush=True)
+        finally:
+            args.report.parent.mkdir(parents=True, exist_ok=True)
+            args.report.write_text(json.dumps(report, indent=2) + "\n")
+            # A physics worker owns just one scene. Kit shutdown tears it down;
+            # do not separately destroy and recreate the simulation context.
+    return int(failed)
+
+
+try:
+    exit_code = main()
+finally:
+    if args.configs_only:
+        app.close()
+# Physics workers have already flushed their result and own no recordings.
+# Kit teardown can hang on marker subscriptions; terminate this bounded worker
+# directly after flushing stdout/stderr, letting the OS release its GPU context.
+if not args.configs_only:
+    sys.stdout.flush()
+    sys.stderr.flush()
+    os._exit(exit_code)
+raise SystemExit(exit_code)

--- a/scripts/env_tools/check_task_versions.py
+++ b/scripts/env_tools/check_task_versions.py
@@ -1,0 +1,113 @@
+"""Check the 100 original registrations and 20 isolated v1 configurations."""
+
+from __future__ import annotations
+
+import argparse
+from copy import deepcopy
+import json
+import os
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "source/dexverse"))
+
+from isaaclab.app import AppLauncher  # noqa: E402
+
+parser = argparse.ArgumentParser(description=__doc__)
+parser.add_argument("--report", type=Path, default=Path("outputs/task_versions/pairs.json"))
+AppLauncher.add_app_launcher_args(parser)
+args = parser.parse_args()
+app = AppLauncher(args).app
+
+import dexverse.tasks  # noqa: E402,F401
+import gymnasium as gym  # noqa: E402
+import yaml  # noqa: E402
+from dexverse.benchmark import BASELINE_PAIRS, BASELINE_V1_TASKS, LEGACY_UPGRADE_TASKS, task_identity  # noqa: E402
+from dexverse.tasks.utils import parse_env_cfg  # noqa: E402
+from dexverse.tasks.config.floating_teleop import apply_teleop_retargeter_mode  # noqa: E402
+from dexverse.devices.retargeters.simple_relative_retargeting import SimpleRelativeRetargeter  # noqa: E402
+from dexverse.robot_agents.shadow import floating as shadow  # noqa: E402
+from dexverse.baseline_v1.control_profile import SHADOW_WRIST_LIMITS  # noqa: E402
+
+
+def main():
+    shared_layouts = {name: deepcopy(value) for name, value in vars(shadow).items()
+                      if name.endswith("_SIMPLE_RELATIVE_RETARGETER_LAYOUT")}
+    specs = {s.id: s for s in gym.registry.values() if s.id.startswith("Dexverse-")}
+    assert len(specs) == 120
+    assert {task for task in specs if task.endswith("-v1")} == set(BASELINE_V1_TASKS)
+    assert len([task for task in specs if task.endswith("-v0")]) == 100
+    assert not (set(LEGACY_UPGRADE_TASKS) & specs.keys())
+    for task, spec in specs.items():
+        assert spec.kwargs["env_cfg_entry_point"].startswith("dexverse.baseline_v1.") == task.endswith("-v1"), task
+    report = {"registrations": 120, "pairs": {}}
+    for old, new in BASELINE_PAIRS.items():
+        configs = [parse_env_cfg(task, device=args.device, num_envs=1) for task in (old, new)]
+        a, b = configs
+        assert type(a) is not type(b)
+        for version, cfg in enumerate(configs):
+            assert cfg.is_finite_horizon is True
+            wrist_event = getattr(cfg.events, "set_shadow_wrist_joint_limits", None)
+            assert (wrist_event is not None) == bool(version)
+            if version:
+                assert (wrist_event.params["lower"], wrist_event.params["upper"]) == SHADOW_WRIST_LIMITS
+            for device in cfg.teleop_devices.devices.values():
+                for retargeter in device.retargeters:
+                    assert retargeter.task_version == version
+                    instance = SimpleRelativeRetargeter.__new__(SimpleRelativeRetargeter)
+                    instance.cfg = retargeter
+                    layout = instance._get_action_layout(cfg.robot_type)
+                    assert all(("wrist_euler_limits" in hand) == bool(version) for hand in layout["hands"].values())
+                    assert instance._get_robot_module() is shadow
+                    for side, hand in instance._get_dex_retargeting_spec()["hands"].items():
+                        assert "robot_agents/shadow/retarget/" in hand["config_paths"]["vector"]
+                        for scheme, path in hand["config_paths"].items():
+                            retargeter.retargeting_scheme = scheme
+                            instance._dex_config_temp_paths = []
+                            try:
+                                patched = instance._create_dex_config_with_urdf(path, hand["urdf_path"])
+                                original = yaml.safe_load(Path(path).read_text())
+                                expected = deepcopy(original)
+                                expected["retargeting"]["urdf_path"] = hand["urdf_path"]
+                                if version and scheme == "vector":
+                                    expected["retargeting"].update(low_pass_alpha=0.2, scaling_factor=1.125)
+                                assert yaml.safe_load(Path(patched).read_text()) == expected
+                                assert yaml.safe_load(Path(path).read_text()) == original
+                            finally:
+                                for temp in instance._dex_config_temp_paths:
+                                    Path(temp).unlink()
+            apply_teleop_retargeter_mode(cfg.teleop_devices, "absolute")
+            for device in cfg.teleop_devices.devices.values():
+                assert all(r.task_version == version for r in device.retargeters)
+        if "OpenLaptop" in old:
+            assert not hasattr(a.terminations, "base_displaced")
+            assert b.terminations.base_displaced.params["max_upward_z"] == 0.005
+        if "GraspCup" in old:
+            assert not hasattr(a.scene, "dispenser") and hasattr(b.scene, "dispenser")
+        if "BimanualLiftTray" in old:
+            assert not hasattr(a.scene, "rack") and hasattr(b.scene, "rack")
+        report["pairs"][old] = {
+            "v1": new,
+            "v0_identity": task_identity(old),
+            "v1_identity": task_identity(new),
+            "status": "passed",
+        }
+    args.report.parent.mkdir(parents=True, exist_ok=True)
+    assert all(getattr(shadow, name) == value for name, value in shared_layouts.items())
+    args.report.write_text(json.dumps(report, indent=2) + "\n")
+    print("VERSION_CHECK: 100 original v0 IDs, 20 isolated v1 pairs; robot/retargeter settings passed.", flush=True)
+
+
+try:
+    main()
+except BaseException:
+    import traceback
+
+    traceback.print_exc()
+    sys.stdout.flush()
+    sys.stderr.flush()
+    os._exit(1)
+sys.stdout.flush()
+sys.stderr.flush()
+os._exit(0)

--- a/scripts/env_tools/run_reset_audit.py
+++ b/scripts/env_tools/run_reset_audit.py
@@ -1,0 +1,177 @@
+# Copyright (c) 2025-2026, The DexVerse Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Batch driver for the reset-distribution audit.
+
+Runs ``sample_reset_distributions.py`` once per task (one Isaac process each,
+round-robin over the given GPUs), then aggregates every task's ``stats.json``
+into ``<out_dir>/report.md``. Plain python -- no Isaac import here.
+
+    python scripts/env_tools/run_reset_audit.py --tasks baseline --gpus 1,3,5
+    python scripts/env_tools/run_reset_audit.py --tasks Dexverse-PushT-v0 Dexverse-OpenLaptop-v0 --gpus 5
+    python scripts/env_tools/run_reset_audit.py --report_only            # re-aggregate existing results
+    python scripts/env_tools/run_reset_audit.py --replot                 # re-run stats/plots offline, then report
+
+``--tasks all`` enumerates every registered ``Dexverse-*`` id in a helper Isaac
+process (slow start-up, ~1 min).
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+import time
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SRC_DIR = REPO_ROOT / "source" / "dexverse"
+SAMPLER = Path(__file__).resolve().parent / "sample_reset_distributions.py"
+
+sys.path.insert(0, str(SRC_DIR))
+from dexverse.analysis.reset_audit import analyze_task_dir, plot_grid, write_report  # noqa: E402
+from dexverse.benchmark import baseline_tasks  # noqa: E402
+
+_LIST_ENVS_SNIPPET = r"""
+from isaaclab.app import AppLauncher
+app = AppLauncher(headless=True).app
+import dexverse.tasks, gymnasium as gym
+print("\n".join(sorted(s.id for s in gym.registry.values() if s.id.startswith("Dexverse-"))))
+app.close()
+"""
+
+
+def _list_all_tasks(python: str) -> list[str]:
+    env = dict(os.environ)
+    env.pop("DISPLAY", None)
+    env["PYTHONPATH"] = str(SRC_DIR) + os.pathsep + env.get("PYTHONPATH", "")
+    out = subprocess.run([python, "-c", _LIST_ENVS_SNIPPET], env=env, capture_output=True, text=True, check=False)
+    tasks = [line.strip() for line in out.stdout.splitlines() if line.strip().startswith("Dexverse-")]
+    if not tasks:
+        raise SystemExit(f"could not enumerate tasks:\n{out.stderr[-2000:]}")
+    return tasks
+
+
+def _run_one(task: str, gpu: str, args, log_dir: Path) -> tuple[str, int, float]:
+    log_path = log_dir / f"{task}.log"
+    cmd = [
+        args.python,
+        str(SAMPLER),
+        "--task",
+        task,
+        "--num_samples",
+        str(args.num_samples),
+        "--num_envs",
+        str(args.num_envs),
+        "--settle_steps",
+        str(args.settle_steps),
+        "--probe_resets",
+        str(args.probe_resets),
+        "--seed",
+        str(args.seed),
+        "--out_dir",
+        str(args.out_dir),
+        "--headless",
+    ]
+    if args.robot_type:
+        cmd += ["--robot_type", args.robot_type]
+    env = dict(os.environ)
+    env.pop("DISPLAY", None)  # forwarded X breaks headless GLX init
+    env["CUDA_VISIBLE_DEVICES"] = gpu
+    env["PYTHONPATH"] = str(SRC_DIR) + os.pathsep + env.get("PYTHONPATH", "")
+    env["PYTHONUNBUFFERED"] = "1"
+    t0 = time.time()
+    with open(log_path, "w") as log:
+        log.write("$ " + " ".join(cmd) + f"\n(CUDA_VISIBLE_DEVICES={gpu})\n\n")
+        log.flush()
+        proc = subprocess.run(cmd, cwd=str(REPO_ROOT), env=env, stdout=log, stderr=subprocess.STDOUT, check=False)
+    return task, proc.returncode, time.time() - t0
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--tasks", nargs="+", default=["baseline"], help="'baseline', 'all', or explicit gym ids.")
+    parser.add_argument("--version", choices=["v0", "v1", "all"], default="v0", help="Version selected by --tasks baseline.")
+    parser.add_argument("--gpus", type=str, default="0", help="Comma-separated GPU ids; one task per GPU at a time.")
+    parser.add_argument("--python", type=str, default=sys.executable, help="Interpreter with Isaac Sim / Isaac Lab.")
+    parser.add_argument("--num_samples", type=int, default=100)
+    parser.add_argument("--num_envs", type=int, default=1)
+    parser.add_argument("--settle_steps", type=int, default=30)
+    parser.add_argument("--probe_resets", type=int, default=8)
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--robot_type", type=str, default=None)
+    parser.add_argument("--out_dir", type=str, default="outputs/reset_audit")
+    parser.add_argument("--skip_existing", action="store_true", help="Skip tasks that already have samples.npz.")
+    parser.add_argument("--report_only", action="store_true", help="Only aggregate existing stats.json into report.md.")
+    parser.add_argument("--replot", action="store_true", help="Re-run stats/flags/plots offline for existing samples, then report.")
+    args = parser.parse_args()
+
+    out_dir = Path(args.out_dir)
+    if not out_dir.is_absolute():
+        out_dir = REPO_ROOT / out_dir
+    args.out_dir = out_dir
+    log_dir = out_dir / "logs"
+    log_dir.mkdir(parents=True, exist_ok=True)
+
+    if args.tasks == ["baseline"]:
+        tasks = list(baseline_tasks(args.version))
+    elif args.tasks == ["all"]:
+        tasks = _list_all_tasks(args.python)
+    else:
+        tasks = list(args.tasks)
+
+    failures: dict[str, str] = {}
+    if args.replot:
+        for t in tasks:
+            d = out_dir / t
+            if (d / "samples.npz").is_file():
+                try:
+                    stats = analyze_task_dir(d)
+                    print(f"[audit] {t}: {', '.join(f['flag'] for f in stats['flags']) or 'no flags'}")
+                except Exception as exc:  # noqa: BLE001
+                    failures[t] = f"replot failed: {exc}"
+                    print(f"[audit] {t}: replot failed: {exc}")
+    elif not args.report_only:
+        todo = [t for t in tasks if not (args.skip_existing and (out_dir / t / "samples.npz").is_file())]
+        gpus = [g.strip() for g in args.gpus.split(",") if g.strip()]
+        print(f"[audit] {len(todo)} task(s) on GPUs {gpus} with {args.python}")
+        # one worker per GPU; each worker pulls the next task from the shared queue
+        queue = list(todo)
+        results = []
+
+        def worker(gpu: str):
+            while queue:
+                task = queue.pop(0)
+                print(f"[audit] gpu {gpu}: {task} ...", flush=True)
+                res = _run_one(task, gpu, args, log_dir)
+                results.append(res)
+                print(f"[audit] gpu {gpu}: {task} -> rc={res[1]} ({res[2] / 60:.1f} min)", flush=True)
+
+        with ThreadPoolExecutor(max_workers=len(gpus)) as pool:
+            list(pool.map(worker, gpus))
+        for task, rc, _ in results:
+            if rc != 0 or not (out_dir / task / "stats.json").is_file():
+                tail = ""
+                lp = log_dir / f"{task}.log"
+                if lp.is_file():
+                    lines = lp.read_text(errors="replace").splitlines()
+                    tail = " | ".join(lines[-3:])[-400:]
+                failures[task] = f"exit code {rc}; see logs/{task}.log -- {tail}"
+
+    report = write_report([out_dir / t for t in tasks], out_dir / "report.md", failures=failures)
+    print(f"[audit] report: {report}")
+    try:
+        grid = plot_grid([out_dir / t for t in tasks], out_dir / "grid.png", title=f"Reset positions (top-down) -- {out_dir.name}")
+        print(f"[audit] grid: {grid}")
+    except Exception as exc:  # noqa: BLE001
+        print(f"[audit] grid failed: {exc}")
+    if failures:
+        print(f"[audit] {len(failures)} task(s) failed: {', '.join(failures)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/env_tools/sample_reset_distributions.py
+++ b/scripts/env_tools/sample_reset_distributions.py
@@ -1,0 +1,497 @@
+# Copyright (c) 2025-2026, The DexVerse Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Sample a task's reset distribution and dump it for the reset audit.
+
+Instantiates one Dexverse task headlessly, resets it ``--num_samples`` times and
+records, for every reset, the env-relative pose of every scene entity, the goal
+command(s), the robot palm position, and what happens during a short hold
+(``--settle_steps`` zero/hold actions): which termination terms fire and how far
+things move. Results go to ``<out_dir>/<task>/{samples.npz,meta.json}`` and are
+immediately analysed into ``stats.json`` + ``<task>.png`` by
+:mod:`dexverse.analysis.reset_audit` (which is simulator-free, so re-plotting
+later does not need Isaac).
+
+Typical use (headless server; DISPLAY must not leak into Isaac):
+
+    env -u DISPLAY CUDA_VISIBLE_DEVICES=5 python scripts/env_tools/sample_reset_distributions.py \\
+        --task Dexverse-PushT-v0 --num_samples 500 --headless
+
+Notes on the sampling protocol (see the plan / docstrings for the evidence):
+
+* ``--num_envs`` defaults to 1. World-frame goal commands (``use_world_frame``)
+  are sampled in absolute world coordinates, so with several envs only the env at
+  the origin gets an on-table goal; running one env keeps env-relative == world.
+  ``--num_envs N>1`` is available as a cross-check and is reported as such.
+* Command metrics are zeroed by ``CommandTerm.reset()`` and only refreshed at the
+  *end* of ``env.step()``, after terminations were evaluated. The main loop calls
+  ``command_manager.compute(dt=0.0)`` right after each reset so goal-distance
+  successes are evaluated against the real goal; a short raw *probe* phase records
+  how the env behaves without that fix (``probe/success_step1``).
+"""
+
+"""Launch Isaac Sim Simulator first."""
+
+import argparse
+import os
+import sys
+
+from isaaclab.app import AppLauncher
+
+parser = argparse.ArgumentParser(description="Sample reset distributions of a Dexverse task.")
+parser.add_argument("--task", type=str, required=True, help="Gym id, e.g. Dexverse-PushT-v0.")
+parser.add_argument("--num_samples", type=int, default=100, help="Number of reset samples to record.")
+parser.add_argument("--num_envs", type=int, default=1, help="Parallel envs (default 1; >1 only as a cross-check).")
+parser.add_argument("--settle_steps", type=int, default=30, help="Hold-action steps after each reset.")
+parser.add_argument("--probe_resets", type=int, default=8, help="Raw resets (no metric refresh) probing step-1 success; runs after the main loop.")
+parser.add_argument("--probe_steps", type=int, default=15, help="Hold steps per probe reset (>1 so PhysX is never reset right after a single step).")
+parser.add_argument("--seed", type=int, default=0, help="Seed for the env / sampling RNG.")
+parser.add_argument("--out_dir", type=str, default="outputs/reset_audit", help="Output root (per-task subdir is created).")
+parser.add_argument("--robot_type", type=str, default=None, help="Optional robot variant override.")
+parser.add_argument("--json_path", type=str, default=None, help="Template JSON spec for *Template environments.")
+parser.add_argument("--disable_fabric", action="store_true", default=False, help="Disable fabric and use USD I/O.")
+parser.add_argument("--no_plot", action="store_true", default=False, help="Skip stats/plot after sampling.")
+parser.add_argument("--debug_done", type=int, default=0, help="Print entity poses for the first N terminations seen during the hold.")
+AppLauncher.add_app_launcher_args(parser)
+args_cli = parser.parse_args()
+args_cli.headless = True  # this tool never needs a window
+
+app_launcher = AppLauncher(args_cli)
+simulation_app = app_launcher.app
+
+"""Rest everything follows."""
+
+# Line-buffer stdout so progress survives redirection to a log file.
+try:
+    sys.stdout.reconfigure(line_buffering=True)
+except Exception:  # noqa: BLE001
+    pass
+
+# Make sure *this* checkout's dexverse is the one imported, regardless of which
+# editable install the interpreter carries (several conda envs on the box point
+# at other checkouts).
+_REPO_SRC = os.path.realpath(os.path.join(os.path.dirname(__file__), "..", "..", "source", "dexverse"))
+if os.path.isdir(_REPO_SRC) and _REPO_SRC not in sys.path:
+    sys.path.insert(0, _REPO_SRC)
+
+import json  # noqa: E402
+import math  # noqa: E402
+import time  # noqa: E402
+from pathlib import Path  # noqa: E402
+
+import gymnasium as gym  # noqa: E402
+import numpy as np  # noqa: E402
+import torch  # noqa: E402
+
+import dexverse  # noqa: E402
+import dexverse.tasks  # noqa: F401, E402
+import isaaclab_tasks  # noqa: F401, E402
+from dexverse.analysis.reset_audit import analyze_task_dir  # noqa: E402
+from dexverse.tasks.utils import parse_env_cfg  # noqa: E402
+from dexverse.tasks.utils.scene_cleanup import prune_stale_obs_refs, strip_camera_cfgs  # noqa: E402
+from dexverse.teleop_utils.range_vis import collect_range_boxes  # noqa: E402
+from isaaclab.envs.mdp.actions import JointPositionAction, RelativeJointPositionAction  # noqa: E402
+from isaaclab.managers import SceneEntityCfg  # noqa: E402
+
+_loaded = os.path.realpath(os.path.dirname(os.path.dirname(dexverse.__file__)))
+if _loaded != _REPO_SRC:
+    raise RuntimeError(f"dexverse resolved to {_loaded}, expected {_REPO_SRC}")
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+
+def _np(t: torch.Tensor) -> np.ndarray:
+    return t.detach().cpu().numpy().astype(np.float64)
+
+
+def _numeric_params(params: dict) -> dict:
+    """JSON-safe subset of a manager term's params (numbers, strings, small lists, entity names)."""
+    out = {}
+    for k, v in (params or {}).items():
+        if isinstance(v, bool):
+            out[k] = v
+        elif isinstance(v, (int, float, str)):
+            out[k] = v
+        elif isinstance(v, SceneEntityCfg):
+            out[k] = {"entity": v.name, "body_names": v.body_names, "joint_names": v.joint_names}
+        elif isinstance(v, (list, tuple)) and len(v) <= 12 and all(isinstance(x, (int, float)) for x in v):
+            out[k] = list(v)
+        elif isinstance(v, dict) and all(isinstance(x, (int, float, list, tuple)) for x in v.values()):
+            out[k] = {kk: (list(vv) if isinstance(vv, (list, tuple)) else vv) for kk, vv in v.items()}
+    return out
+
+
+def _term_name(func) -> str:
+    return getattr(func, "__name__", type(func).__name__)
+
+
+def _reset_event_meta(env) -> list[dict]:
+    """Ordered list of reset events with the bits the audit cares about."""
+    events = []
+    active = getattr(env.event_manager, "active_terms", {})
+    reset_names = active.get("reset", []) if isinstance(active, dict) else []
+    for name in reset_names:
+        term = getattr(env.cfg.events, name, None)
+        if term is None:
+            continue
+        params = term.params or {}
+        entity = None
+        for key in ("asset_cfg", "object_cfg", "target_cfg"):
+            v = params.get(key)
+            if isinstance(v, SceneEntityCfg):
+                entity = v.name
+                break
+        ref = params.get("reference_asset_cfg")
+        events.append(
+            {
+                "name": name,
+                "func": _term_name(term.func),
+                "entity": entity,
+                "reference_entity": ref.name if isinstance(ref, SceneEntityCfg) else None,
+                "min_xy_distance": params.get("min_xy_distance"),
+                "pose_range": {k: list(v) for k, v in params["pose_range"].items()} if isinstance(params.get("pose_range"), dict) else None,
+            }
+        )
+    return events
+
+
+def _termination_meta(env) -> dict:
+    out = {}
+    for name in env.termination_manager.active_terms:
+        term = getattr(env.cfg.terminations, name, None)
+        if term is None:
+            continue
+        out[name] = {"func": _term_name(term.func), "params": _numeric_params(term.params), "time_out": bool(getattr(term, "time_out", False))}
+    return out
+
+
+def _command_meta(env) -> dict:
+    out = {}
+    for name in env.command_manager.active_terms:
+        term = env.command_manager.get_term(name)
+        cfg = term.cfg
+        ranges = getattr(cfg, "ranges", None)
+        out[name] = {
+            "class": type(term).__name__,
+            "use_world_frame": bool(getattr(cfg, "use_world_frame", False)),
+            "position_only": bool(getattr(cfg, "position_only", False)),
+            "asset_name": getattr(cfg, "asset_name", None),
+            "object_name": getattr(cfg, "object_name", None),
+            "ranges": {k: list(getattr(ranges, k)) for k in ("pos_x", "pos_y", "pos_z", "roll", "pitch", "yaw") if ranges is not None and getattr(ranges, k, None) is not None},
+        }
+    return out
+
+
+def _palm_bodies(env) -> dict[str, int]:
+    """``{label: body_index}`` for the robot palm body / bodies."""
+    robot = env.scene["robot"]
+    rc = getattr(env.cfg, "robot_config", None)
+    names = []
+    if rc is not None:
+        if getattr(rc, "left_palm_body_name", None) and getattr(rc, "right_palm_body_name", None):
+            names = [("right", rc.right_palm_body_name), ("left", rc.left_palm_body_name)]
+        elif getattr(rc, "palm_body_name", None):
+            names = [("palm", rc.palm_body_name)]
+    out = {}
+    for label, body in names:
+        try:
+            ids, _ = robot.find_bodies(body)
+        except Exception:  # noqa: BLE001
+            ids = []
+        if ids:
+            out[label] = int(ids[0])
+    return out
+
+
+def _hold_action(env) -> torch.Tensor:
+    """Action that keeps the robot where it is.
+
+    Zero is a hold for ``JointPositionAction`` with ``use_default_offset`` (target =
+    default joint pos = reset pose) and for ``RelativeJointPositionAction``. Any
+    other term gets its slice filled from the current joint positions (absolute
+    targets) so we never inject motion.
+    """
+    action = torch.zeros((env.num_envs, env.action_manager.total_action_dim), device=env.device)
+    offset = 0
+    for name in env.action_manager.active_terms:
+        term = env.action_manager.get_term(name)
+        dim = term.action_dim
+        if isinstance(term, RelativeJointPositionAction) or (
+            isinstance(term, JointPositionAction) and getattr(term.cfg, "use_default_offset", True)
+        ):
+            pass  # zeros hold
+        elif isinstance(term, JointPositionAction):
+            joint_pos = term._asset.data.joint_pos[:, term._joint_ids]  # noqa: SLF001
+            scale = term._scale  # noqa: SLF001
+            action[:, offset : offset + dim] = (joint_pos - term._offset) / scale  # noqa: SLF001
+            print(f"[reset_audit] action term '{name}' is absolute without default offset; holding current joint pos")
+        else:
+            print(f"[reset_audit] WARNING: action term '{name}' ({type(term).__name__}) -- zero may not be a hold")
+        offset += dim
+    return action
+
+
+def _snapshot(env, palm: dict[str, int]) -> dict[str, np.ndarray]:
+    """Env-relative poses of everything, per env (arrays of shape (num_envs, ...))."""
+    state = env.scene.get_state(is_relative=True)
+    out: dict[str, np.ndarray] = {}
+    for kind in ("rigid_object", "articulation"):
+        for name, entry in state.get(kind, {}).items():
+            out[f"{kind}/{name}/root_pose"] = _np(entry["root_pose"])
+            if kind == "articulation" and "joint_position" in entry:
+                out[f"{kind}/{name}/joint_pos"] = _np(entry["joint_position"])
+    origins = _np(env.scene.env_origins)
+    for name in env.command_manager.active_terms:
+        term = env.command_manager.get_term(name)
+        pw = getattr(term, "pose_command_w", None)
+        if pw is not None:
+            pw = _np(pw)
+            pw[:, :3] -= origins
+            out[f"commands/{name}/pose_w"] = pw
+        out[f"commands/{name}/command"] = _np(term.command)
+    body_pos = _np(env.scene["robot"].data.body_pos_w)  # (num_envs, num_bodies, 3)
+    for label, idx in palm.items():
+        out[f"palm/{label}/pos"] = body_pos[:, idx, :] - origins
+    # every robot body (palm, fingers, ...) so the audit can measure hand<->object clearance
+    out["robot/body_pos"] = body_pos - origins[:, None, :]
+    return out
+
+
+def _stack(rows: list[dict[str, np.ndarray]]) -> dict[str, np.ndarray]:
+    keys = rows[0].keys()
+    return {k: np.concatenate([r[k] for r in rows], axis=0) for k in keys}
+
+
+# ---------------------------------------------------------------------------
+# main
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    t0 = time.time()
+    env_cfg = parse_env_cfg(
+        args_cli.task,
+        device=args_cli.device,
+        num_envs=args_cli.num_envs,
+        use_fabric=not args_cli.disable_fabric,
+        json_path=args_cli.json_path,
+    )
+    if args_cli.robot_type is not None:
+        if not hasattr(env_cfg, "robot_type"):
+            raise ValueError(f"Task '{args_cli.task}' does not expose robot_type.")
+        cfg_cls = type(env_cfg)
+        env_cfg = cfg_cls(robot_type=args_cli.robot_type)
+        env_cfg.sim.device = args_cli.device if args_cli.device is not None else env_cfg.sim.device
+        env_cfg.sim.use_fabric = not args_cli.disable_fabric
+        env_cfg.scene.num_envs = args_cli.num_envs
+    env_cfg.seed = args_cli.seed
+    # State-only observations, no cameras (no --enable_cameras needed), no recorders.
+    if hasattr(env_cfg, "_apply_observation_preset"):
+        try:
+            env_cfg._apply_observation_preset("state")  # noqa: SLF001
+        except Exception as exc:  # noqa: BLE001
+            print(f"[reset_audit] observation preset 'state' not applied: {exc}")
+    strip_camera_cfgs(env_cfg)
+    prune_stale_obs_refs(env_cfg)
+    env_cfg.recorders = {}
+    # keep terminations (we read them); make sure time_out never trips during the hold
+    if getattr(env_cfg.terminations, "time_out", None) is not None:
+        env_cfg.episode_length_s = max(float(env_cfg.episode_length_s), 60.0)
+
+    env = gym.make(args_cli.task, cfg=env_cfg, disable_env_checker=True).unwrapped
+    print(f"[reset_audit] env created in {time.time() - t0:.1f}s; num_envs={env.num_envs}, device={env.device}")
+
+    with torch.inference_mode():
+        samples, meta = _sample(env, env_cfg, t0)
+
+    out_dir = Path(args_cli.out_dir) / args_cli.task
+    out_dir.mkdir(parents=True, exist_ok=True)
+    np.savez_compressed(out_dir / "samples.npz", **samples)
+    (out_dir / "meta.json").write_text(json.dumps(meta, indent=2))
+    print(f"[reset_audit] wrote {out_dir / 'samples.npz'} ({meta['num_samples']} samples) and meta.json")
+
+    env.close()
+
+    if not args_cli.no_plot:
+        stats = analyze_task_dir(out_dir)
+        flags = ", ".join(f["flag"] for f in stats.get("flags", [])) or "none"
+        print(f"[reset_audit] flags: {flags}")
+        print(f"[reset_audit] figure: {out_dir / stats.get('png', '')}")
+
+
+def _sample(env, env_cfg, t0: float) -> tuple[dict, dict]:
+    """Run probe + main sampling loop; returns (samples, meta). Call under inference_mode."""
+    palm = _palm_bodies(env)
+    hold = _hold_action(env)
+    term_names = list(env.termination_manager.active_terms)
+    origins_np = _np(env.scene.env_origins)
+
+    # ---------------- main sampling loop -------------------------------------------
+    env.reset(seed=args_cli.seed)
+    rounds = int(math.ceil(args_cli.num_samples / env.num_envs))
+    reset_rows, settled_rows = [], []
+    first_step = {name: [] for name in term_names}
+    done_step_rows, origin_rows, env_index_rows = [], [], []
+    range_boxes = None
+    debug_left = [int(args_cli.debug_done)]
+    for r in range(rounds):
+        env.reset()
+        # refresh command metrics / world goal for the just-sampled commands (see module docstring)
+        if env.command_manager.active_terms:
+            env.command_manager.compute(dt=0.0)
+        if range_boxes is None:
+            try:
+                boxes = collect_range_boxes(env, env_index=0)
+                o0 = origins_np[0]
+                range_boxes = [
+                    {
+                        "name": b.name,
+                        "kind": b.kind,
+                        "entity": b.entity,
+                        "center": [float(b.center[i] - o0[i]) for i in range(3)],
+                        "half_extent": [float(v) for v in b.half_extent],
+                        "rot_range": {k: [float(v[0]), float(v[1])] for k, v in b.rot_range.items()},
+                        "degenerate": bool(b.degenerate),
+                    }
+                    for b in boxes
+                ]
+            except Exception as exc:  # noqa: BLE001
+                print(f"[reset_audit] collect_range_boxes failed: {exc}")
+                range_boxes = []
+        snap0 = _snapshot(env, palm)
+        n = env.num_envs
+        fired = {name: np.full((n,), -1, dtype=np.int64) for name in term_names}
+        done_at = np.full((n,), -1, dtype=np.int64)
+        for k in range(1, args_cli.settle_steps + 1):
+            _, _, terminated, truncated, _ = env.step(hold)
+            done = _np(terminated | truncated).astype(bool)
+            for name in term_names:
+                flag = _np(env.termination_manager.get_term(name)).astype(bool)
+                newly = flag & (fired[name] < 0) & (done_at < 0)
+                fired[name][newly] = k
+            newly_done = done & (done_at < 0)
+            done_at[newly_done] = k
+            if args_cli.debug_done > 0 and newly_done.any() and debug_left[0] > 0:
+                debug_left[0] -= 1
+                which = [name for name in term_names if fired[name][newly_done].max() == k]
+                snap = _snapshot(env, palm)
+                for key, arr in snap.items():
+                    if key.endswith("/root_pose") or key.startswith("palm/") or key.endswith("/pose_w"):
+                        print(f"[reset_audit][debug] step {k} terms={which} {key} = {np.round(arr[newly_done][0][:3], 3).tolist()}")
+        snap1 = _snapshot(env, palm)
+        # envs that terminated were auto-reset inside step(): their settled state is a new sample -> mask
+        masked = done_at >= 0
+        for key, arr in snap1.items():
+            if masked.any():
+                arr = arr.copy()
+                arr[masked] = np.nan
+            snap1[key] = arr
+        reset_rows.append(snap0)
+        settled_rows.append({"settled/" + k: v for k, v in snap1.items()})
+        for name in term_names:
+            first_step[name].append(fired[name])
+        done_step_rows.append(done_at)
+        origin_rows.append(origins_np.copy())
+        env_index_rows.append(np.arange(n))
+        if (r + 1) % max(1, rounds // 10) == 0 or r == rounds - 1:
+            print(f"[reset_audit] round {r + 1}/{rounds} ({(r + 1) * n} samples), {time.time() - t0:.0f}s")
+
+    # ---------------- probe: raw env behaviour right after reset (no metric refresh) ---
+    # Runs AFTER the main loop and holds for ``--probe_steps`` per reset: resetting
+    # PhysX again after a single step, a dozen times in a row, was observed to make
+    # some assets (bleach bottle, cup) permanently lose collision with the table.
+    probe_success, probe_success_any, probe_obj_pose = [], [], []
+    obj_key = "rigid_object/object/root_pose" if "object" in env.scene.rigid_objects else None
+    if args_cli.probe_resets > 0 and "success" in term_names:
+        env.reset(seed=args_cli.seed + 12345)
+        n_probe_rounds = int(math.ceil(args_cli.probe_resets / env.num_envs))
+        for _ in range(n_probe_rounds):
+            env.reset()
+            snap = _snapshot(env, palm)
+            if obj_key and obj_key in snap:
+                probe_obj_pose.append(snap[obj_key])
+            any_fired = np.zeros((env.num_envs,), dtype=bool)
+            for k in range(1, max(1, args_cli.probe_steps) + 1):
+                env.step(hold)
+                flag = _np(env.termination_manager.get_term("success")).astype(bool)
+                if k == 1:
+                    probe_success.append(flag)
+                any_fired |= flag
+            probe_success_any.append(any_fired)
+        probe_success = np.concatenate(probe_success)[: args_cli.probe_resets]
+        probe_success_any = np.concatenate(probe_success_any)[: args_cli.probe_resets]
+        print(
+            f"[reset_audit] probe ({probe_success.size} raw resets x {args_cli.probe_steps} steps): "
+            f"success on step 1 in {probe_success.mean() * 100:.0f}%, within the window in {probe_success_any.mean() * 100:.0f}%"
+        )
+    else:
+        probe_success = np.zeros((0,), dtype=bool)
+        probe_success_any = np.zeros((0,), dtype=bool)
+
+    samples = _stack(reset_rows)
+    samples.update(_stack(settled_rows))
+    for name in term_names:
+        samples[f"term_first_step/{name}"] = np.concatenate(first_step[name])
+    samples["done_step"] = np.concatenate(done_step_rows)
+    samples["env_origin"] = np.concatenate(origin_rows)
+    samples["env_index"] = np.concatenate(env_index_rows)
+    samples = {k: v[: args_cli.num_samples] for k, v in samples.items()}
+    samples["probe/success_step1"] = probe_success
+    samples["probe/success_any"] = probe_success_any
+    if probe_obj_pose:
+        samples["probe/object_root_pose"] = np.concatenate(probe_obj_pose)[: args_cli.probe_resets]
+
+    # ---------------- meta ---------------------------------------------------------
+    state0 = env.scene.get_state(is_relative=True)
+    entities = {kind: sorted(state0.get(kind, {}).keys()) for kind in ("rigid_object", "articulation")}
+    default_root, default_joint, joint_names = {}, {}, {}
+    for kind in ("rigid_object", "articulation"):
+        for name in entities[kind]:
+            asset = env.scene[name]
+            drs = _np(asset.data.default_root_state)[0]
+            default_root[name] = [float(v) for v in drs[:7]]
+            if kind == "articulation":
+                default_joint[name] = [float(v) for v in _np(asset.data.default_joint_pos)[0]]
+                joint_names[name] = list(asset.joint_names)
+    table_half = None
+    try:
+        size = env.cfg.scene.table.spawn.size
+        table_half = [float(size[0]) / 2, float(size[1]) / 2]
+    except Exception:  # noqa: BLE001
+        pass
+    meta = {
+        "task": args_cli.task,
+        "robot_type": getattr(env.cfg, "robot_type", None),
+        "seed": args_cli.seed,
+        "num_samples": int(min(args_cli.num_samples, rounds * env.num_envs)),
+        "num_envs": int(env.num_envs),
+        "settle_steps": int(args_cli.settle_steps),
+        "probe_resets": int(probe_success.size),
+        "probe_steps": int(args_cli.probe_steps),
+        "step_dt": float(env.step_dt),
+        "episode_length_s": float(env_cfg.episode_length_s),
+        "entities": entities,
+        "joint_names": joint_names,
+        "default_root_state": default_root,
+        "default_joint_pos": default_joint,
+        "palm_bodies": {k: int(v) for k, v in palm.items()},
+        "robot_body_names": list(env.scene["robot"].body_names),
+        "table_half_xy": table_half,
+        "range_boxes": range_boxes or [],
+        "reset_events": _reset_event_meta(env),
+        "termination_terms": _termination_meta(env),
+        "commands": _command_meta(env),
+        "action_terms": {n: type(env.action_manager.get_term(n)).__name__ for n in env.action_manager.active_terms},
+        "elapsed_s": float(time.time() - t0),
+    }
+    return samples, meta
+
+
+if __name__ == "__main__":
+    main()
+    simulation_app.close()

--- a/scripts/env_tools/test_baseline_package.py
+++ b/scripts/env_tools/test_baseline_package.py
@@ -1,0 +1,47 @@
+"""Simulator-free regressions for the sibling baseline-v1 package layout."""
+
+import ast
+from pathlib import Path
+import runpy
+import sys
+from types import ModuleType
+
+from setuptools import find_packages
+
+ROOT = Path(__file__).resolve().parents[2]
+SOURCE = ROOT / "source/dexverse"
+sys.path.insert(0, str(SOURCE))
+from dexverse.benchmark import V1_CONFIGS
+
+
+def test_baseline_package_discovery_and_original_entrypoint():
+    packages = find_packages(where=str(SOURCE))
+    assert "dexverse.baseline_v1" in packages
+    assert "dexverse.baseline_v1.robots" not in packages
+    assert (SOURCE / "dexverse/baseline_v1/control_profile.py").is_file()
+    assert "dexverse.tasks.v1" not in packages
+    tree = ast.parse((SOURCE / "dexverse/tasks/__init__.py").read_text())
+    assert any(isinstance(node, ast.ImportFrom) and node.module == "dexverse"
+               and any(alias.name == "baseline_v1" for alias in node.names) for node in tree.body)
+    for module, _ in V1_CONFIGS.values():
+        assert (SOURCE / "dexverse/baseline_v1/config" / (module.replace(".", "/") + ".py")).is_file()
+
+
+def test_all_baselines_register_from_sibling_namespace(monkeypatch):
+    calls = []
+    registration = ModuleType("dexverse.tasks.utils.registration")
+    registration.register_env = lambda *args: calls.append(args)
+    monkeypatch.setitem(sys.modules, registration.__name__, registration)
+    runpy.run_path(str(SOURCE / "dexverse/baseline_v1/__init__.py"), run_name="dexverse.baseline_v1")
+    assert calls == [("dexverse.baseline_v1.config", task, module, cls)
+                     for task, (module, cls) in V1_CONFIGS.items()]
+
+
+def test_no_old_namespace_in_runtime_sources():
+    old_module = "dexverse.tasks" + ".v1"
+    old_path = "tasks/" + "v1/"
+    paths = list((SOURCE / "dexverse").rglob("*.py"))
+    paths += list((ROOT / "scripts/demo_tools").glob("*.py"))
+    for path in paths:
+        text = path.read_text()
+        assert old_module not in text and old_path not in text, path

--- a/scripts/env_tools/test_carton_face_cue.py
+++ b/scripts/env_tools/test_carton_face_cue.py
@@ -1,0 +1,108 @@
+"""Regressions for the four replayable, depth-visible carton corner spheres."""
+
+import ast
+from pathlib import Path
+import sys
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+SOURCE = Path(__file__).resolve().parents[2] / "source/dexverse/dexverse"
+CONFIG = SOURCE / "baseline_v1/config/bimanual/carton_regrasp_cfg.py"
+sys.path.insert(0, str(SOURCE.parent))
+from dexverse.teleop_utils.episode_task_state import capture_episode_task_state, restore_episode_task_state
+
+
+def _geometry():
+    nodes = []
+    for node in ast.parse(CONFIG.read_text()).body:
+        if isinstance(node, ast.Assign):
+            if any(isinstance(target, ast.Name) and target.id == "GOAL_FRAME_CFG" for target in node.targets):
+                break
+            nodes.append(node)
+        elif isinstance(node, ast.FunctionDef):
+            nodes.append(node)
+    namespace = {}
+    exec(compile(ast.Module(body=nodes, type_ignores=[]), str(CONFIG), "exec"), namespace)
+    return namespace
+
+
+@pytest.mark.parametrize("face", range(6))
+def test_four_spheres_form_selected_face_rectangle(face):
+    values = _geometry()
+    axes, half, origin = values["_AXES"], values["_HALF"], values["_CENTER"]
+    axis, sign = values["_FACES"][face]
+    points = values["FACE_CORNERS_PER_FACE"][face]
+    assert values["FACE_CORNER_RADIUS"] == 0.02
+    assert len(set(points)) == 4
+    normal = axes.index(axis)
+    for point in points:
+        assert point[normal] == pytest.approx(origin[axis] + sign * half[axis])
+    for index, name in enumerate(axes):
+        if index != normal:
+            assert sorted(set(p[index] for p in points)) == pytest.approx([origin[name] - half[name], origin[name] + half[name]])
+
+
+def test_config_uses_red_geometry_and_preserves_recorded_buffer():
+    tree = ast.parse(CONFIG.read_text())
+    call = next(n for n in ast.walk(tree) if isinstance(n, ast.Call)
+                and isinstance(n.func, ast.Attribute) and n.func.attr == "add_scene_vis_term"
+                and isinstance(n.args[0], ast.Constant) and n.args[0].value == "graspable_face")
+    keywords = {k.arg: k.value for k in call.args[1].keywords}
+    assert ast.unparse(keywords["func"]) == "CartonFaceCornerCue"
+    params = {k.value: v for k, v in zip(keywords["params"].keys, keywords["params"].values)}
+    assert ast.literal_eval(params["color"]) == (0.9, 0.03, 0.03)
+    assert ast.unparse(params["buffer_name"]) == "GRASP_FACE_BUFFER"
+    assert _geometry()["GRASP_FACE_BUFFER"] == "carton_grasp_face"
+    assert "ALLOWED_PATCHES_PER_FACE" not in CONFIG.read_text()
+    code = (SOURCE / "baseline_v1/config/bimanual/carton_face_cue.py").read_text()
+    assert "VisualizationMarkers" not in code
+    assert "invisibleToSecondaryRays" not in code
+    assert "use_fabric" not in code
+
+
+def test_green_spheres_mark_only_the_goal_frame():
+    tree = ast.parse(CONFIG.read_text())
+    call = next(n for n in ast.walk(tree) if isinstance(n, ast.Call)
+                and isinstance(n.func, ast.Attribute) and n.func.attr == "add_scene_vis_term"
+                and isinstance(n.args[0], ast.Constant) and n.args[0].value == "goal_box_corners")
+    params = next(kw.value for kw in call.args[1].keywords if kw.arg == "params")
+    fields = {key.value: value for key, value in zip(params.keys, params.values)}
+    assert ast.unparse(fields["asset_cfg"]) == "SceneEntityCfg('goal_frame')"
+    assert ast.literal_eval(fields["color"]) == (0.15, 0.75, 0.25)
+
+
+def test_record_restore_updates_four_local_offsets_and_skips_unchanged_choice(monkeypatch):
+    values = _geometry()
+    cls = next(n for n in ast.parse((CONFIG.parent / "carton_face_cue.py").read_text()).body
+               if isinstance(n, ast.ClassDef))
+    method = next(n for n in cls.body if isinstance(n, ast.FunctionDef) and n.name == "__call__")
+    namespace = {"torch": torch, "SceneEntityCfg": object}
+    monkeypatch.setitem(sys.modules, "pxr", SimpleNamespace(Gf=SimpleNamespace(Vec3d=lambda *p: p)))
+    exec(compile(ast.Module(body=[method], type_ignores=[]), str(CONFIG), "exec"), namespace)
+    writes = [[] for _ in range(4)]
+    cue = SimpleNamespace(_buffer_name="carton_grasp_face", _points=values["FACE_CORNERS_PER_FACE"],
+                          _translations=[[SimpleNamespace(Set=items.append) for items in writes]], _last_choice=[-1])
+    env = SimpleNamespace(num_envs=1, device="cpu", carton_grasp_face=torch.tensor([4]),
+                          cfg=SimpleNamespace(events=SimpleNamespace(sample_grasp_face=SimpleNamespace(
+                              params={"buffer_name": "carton_grasp_face"}))))
+    params = dict(points_per_choice=cue._points, buffer_name=cue._buffer_name, object_cfg=None,
+                  radius=0.02, color=(0.9, 0.03, 0.03))
+    snapshot = capture_episode_task_state(env)
+    assert snapshot["env_buffers"]["carton_grasp_face"].item() == 4
+    env.carton_grasp_face.fill_(1)
+    namespace["__call__"](cue, env, **params)
+    assert [items[-1] for items in writes] == cue._points[1]
+    assert restore_episode_task_state(env, snapshot) == []
+    namespace["__call__"](cue, env, **params)
+    assert [items[-1] for items in writes] == cue._points[4]
+    namespace["__call__"](cue, env, **params)
+    assert [len(items) for items in writes] == [2] * 4
+
+
+def test_carton_and_success_dimensions_unchanged():
+    values = _geometry()
+    assert values["CARTON_SCALE"] == 0.65
+    hx, hy, hz = values["CARTON_HALF_X"], values["CARTON_HALF_Y"], values["CARTON_HEIGHT"] / 2
+    assert values["cue_half_extents_per_face"](0.65) == [(hz, hy, hx)] * 2 + [(hx, hz, hy)] * 2 + [(hx, hy, hz)] * 2

--- a/scripts/env_tools/test_control_profile.py
+++ b/scripts/env_tools/test_control_profile.py
@@ -1,0 +1,106 @@
+"""CPU tests for v1 control overrides without duplicating/mutating shared robots."""
+
+import ast
+from copy import deepcopy
+from importlib import import_module
+import math
+from pathlib import Path
+import runpy
+import sys
+import tempfile
+from types import SimpleNamespace
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parents[2]
+SOURCE = ROOT / "source/dexverse/dexverse"
+PROFILE = SOURCE / "baseline_v1/control_profile.py"
+profile = runpy.run_path(str(PROFILE))
+
+
+def test_layout_adds_only_limits_and_is_independent():
+    layout = {"output_dim": 56, "hands": {side: {"finger_indices": [1, 2], "wrist_rot_order": "yaw_pitch_roll"}
+                                         for side in ("left", "right")}}
+    before = deepcopy(layout)
+    result = profile["action_layout"](layout)
+    expected = deepcopy(before)
+    for hand in expected["hands"].values():
+        hand["wrist_euler_limits"] = ((-2 * math.pi, 2 * math.pi),) * 3
+    assert result == expected
+    result["hands"]["left"]["finger_indices"].append(3)
+    assert layout == before
+
+
+@pytest.mark.parametrize("side", ["left", "right"])
+@pytest.mark.parametrize("scheme", ["vector", "dexpilot"])
+def test_yaml_overrides_only_intended_values(side, scheme):
+    path = SOURCE / f"robot_agents/shadow/retarget/{side}_{scheme}.yml"
+    original = yaml.safe_load(path.read_text())
+    before = deepcopy(original)
+    expected = deepcopy(original)
+    if scheme == "vector":
+        expected["retargeting"].update(low_pass_alpha=0.2, scaling_factor=1.125)
+    result = profile["retargeting_config"](original, scheme)
+    assert result == expected and original == before
+    result["retargeting"]["target_joint_names"] = []
+    assert original == before
+
+
+def _retargeter_methods():
+    tree = ast.parse((SOURCE / "devices/retargeters/simple_relative_retargeting.py").read_text())
+    cls = next(n for n in tree.body if isinstance(n, ast.ClassDef) and n.name == "SimpleRelativeRetargeter")
+    names = {"_get_action_layout", "_get_robot_module", "_create_dex_config_with_urdf"}
+    nodes = [n for n in cls.body if isinstance(n, ast.FunctionDef) and n.name in names]
+    namespace = dict(Any=object, yaml=yaml, tempfile=tempfile, import_module=import_module,
+                     SIMPLE_RETARGETER_LAYOUT_SOURCES={"floating_shadow_bimanual": ("dexverse.robot_agents.shadow.floating", "LAYOUT"),
+                                                      "other_robot": ("test_other_robot", "LAYOUT")},
+                     HAND_NAME_TO_TARGET={"left": "left", "right": "right"})
+    exec(compile(ast.Module(body=nodes, type_ignores=[]), "<control-profile-retargeter>", "exec"), namespace)
+    return type("TestRetargeter", (), {name: namespace[name] for name in names})
+
+
+@pytest.mark.parametrize("version", [0, 1])
+@pytest.mark.parametrize("robot", ["floating_shadow_bimanual", "other_robot"])
+def test_real_retargeter_routes_profile_without_mutating_sources(tmp_path, monkeypatch, version, robot):
+    cls = _retargeter_methods()
+    shared = SimpleNamespace(__name__="dexverse.robot_agents.shadow.floating", LAYOUT={"output_dim": 56, "hands": {"left": {}, "right": {}}})
+    other = SimpleNamespace(__name__="test_other_robot", LAYOUT=deepcopy(shared.LAYOUT))
+    monkeypatch.setitem(sys.modules, shared.__name__, shared)
+    monkeypatch.setitem(sys.modules, other.__name__, other)
+    monkeypatch.setitem(sys.modules, "dexverse.baseline_v1.control_profile", SimpleNamespace(**profile))
+    instance = cls()
+    instance.cfg = SimpleNamespace(task_version=version, robot_type=robot, retargeting_scheme="vector")
+    instance._dex_config_temp_paths = []
+    layout = instance._get_action_layout(robot)
+    enabled = version == 1 and robot == "floating_shadow_bimanual"
+    assert all(("wrist_euler_limits" in hand) == enabled for hand in layout["hands"].values())
+    assert shared.LAYOUT["hands"] == {"left": {}, "right": {}}
+    path = SOURCE / "robot_agents/shadow/retarget/left_vector.yml"
+    before = path.read_bytes()
+    try:
+        patched = instance._create_dex_config_with_urdf(str(path), "/resolved/robot.urdf")
+        values = yaml.safe_load(Path(patched).read_text())["retargeting"]
+        assert values["urdf_path"] == "/resolved/robot.urdf"
+        assert values["low_pass_alpha"] == (0.2 if enabled else 0.8)
+        assert values["scaling_factor"] == (1.125 if enabled else 1.3)
+        assert path.read_bytes() == before
+    finally:
+        for temporary in instance._dex_config_temp_paths:
+            Path(temporary).unlink()
+
+
+def test_shared_setup_is_copied_before_task_overrides():
+    tree = ast.parse((SOURCE / "baseline_v1/dexverse_base_env_cfg.py").read_text())
+    cls = next(n for n in tree.body if isinstance(n, ast.ClassDef) and n.name == "DexVerseBaseEnvCfg")
+    method = next(n for n in cls.body if isinstance(n, ast.FunctionDef) and n.name == "_configure_robot_from_type")
+    shared = SimpleNamespace(robot_config_kwargs={"fingertip_body_names": ["tip"]}, scene_robot={"actuator": {"stiffness": 10}})
+    namespace = dict(deepcopy=deepcopy, _get_tabletop_robot_setup_builders=lambda: {"floating_shadow_right": lambda: shared})
+    exec(compile(ast.Module(body=[method], type_ignores=[]), "<robot-setup>", "exec"), namespace)
+    received = []
+    instance = SimpleNamespace(robot_type="floating_shadow_right", _apply_robot_setup=received.append)
+    namespace[method.name](instance)
+    received[0].scene_robot["actuator"]["stiffness"] = 999
+    received[0].robot_config_kwargs["fingertip_body_names"].append("another")
+    assert shared.scene_robot["actuator"]["stiffness"] == 10
+    assert shared.robot_config_kwargs["fingertip_body_names"] == ["tip"]

--- a/scripts/env_tools/test_conversion_output.py
+++ b/scripts/env_tools/test_conversion_output.py
@@ -1,0 +1,119 @@
+"""Offline regressions for conversion reuse and worker exit status."""
+
+import copy
+from pathlib import Path
+import subprocess
+import sys
+
+import h5py
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "scripts/demo_tools"))
+from conversion_output import conversion_request, request_json, validate_existing_output
+
+
+def make_request(tmp_path, indices=(0, 1)):
+    source = tmp_path / "source.pkl"
+    if not source.exists():
+        source.write_bytes(b"opaque source bytes")
+    return conversion_request(
+        task="Dexverse-PushT-v1", identity={"benchmark_revision": "test-revision"},
+        pickles=[source], episodes=[{"episode_index": i, "actions": [0, 0, 0]} for i in indices],
+        options={"set_state": True, "observation_preset": "state", "seed": 42},
+    )
+
+
+def write_output(path, request):
+    with h5py.File(path, "w") as h:
+        h.attrs.update(conversion_complete=True, conversion_request=request_json(request),
+                       task=request["task"], replay_benchmark_revision=request["identity"]["benchmark_revision"],
+                       requested_episodes=len(request["episodes"]), num_episodes=len(request["episodes"]))
+        for i, ep in enumerate(request["episodes"]):
+            g = h.create_group(f"data/demo_{i}")
+            g.attrs.update(episode_index=ep["index"], num_samples=ep["steps"])
+            for name in ("actions", "source_actions", "obs/state/pose", "next_obs/state/pose", "terminations/success"):
+                g.create_dataset(name, shape=(ep["steps"], 1), dtype="f4")
+
+
+def test_matching_output_is_read_only(tmp_path):
+    request = make_request(tmp_path)
+    path = tmp_path / "output.h5"
+    write_output(path, request)
+    before = path.read_bytes()
+    validate_existing_output(path, request)
+    assert path.read_bytes() == before
+
+
+@pytest.mark.parametrize("change", ["episodes", "source", "revision", "implementation", "preset", "seed", "mode"])
+def test_previous_conversion_cannot_replace_a_different_request(tmp_path, change):
+    request = make_request(tmp_path, (0,))
+    path = tmp_path / "output.h5"
+    write_output(path, request)
+    updated = copy.deepcopy(request)
+    if change == "episodes":
+        updated = make_request(tmp_path, (0, 1))
+    elif change == "source":
+        (tmp_path / "source.pkl").write_bytes(b"changed source bytes")
+        updated = make_request(tmp_path, (0,))
+    elif change == "revision":
+        updated["identity"]["benchmark_revision"] = "new-revision"
+    elif change == "implementation":
+        updated["implementation_sha256"] = "changed"
+    elif change == "preset":
+        updated["options"]["observation_preset"] = "rgb"
+    elif change == "seed":
+        updated["options"]["seed"] = 43
+    else:
+        updated["options"]["set_state"] = False
+    with pytest.raises(ValueError, match="--overwrite"):
+        validate_existing_output(path, updated)
+
+
+@pytest.mark.parametrize("damage", ["legacy", "incomplete", "request", "count", "indices", "actions", "observations", "corrupt"])
+def test_incomplete_or_unverifiable_output_is_rejected(tmp_path, damage):
+    request = make_request(tmp_path)
+    path = tmp_path / "output.h5"
+    write_output(path, request)
+    if damage == "corrupt":
+        path.write_bytes(b"not an HDF5")
+    else:
+        with h5py.File(path, "a") as h:
+            if damage == "legacy":
+                del h.attrs["conversion_complete"]
+            elif damage == "incomplete":
+                h.attrs["conversion_complete"] = False
+            elif damage == "request":
+                del h.attrs["conversion_request"]
+            elif damage == "count":
+                del h["data/demo_1"]
+            elif damage == "indices":
+                h["data/demo_1"].attrs["episode_index"] = 0
+            else:
+                name = "actions" if damage == "actions" else "next_obs/state/pose"
+                del h[f"data/demo_0/{name}"]
+                h.create_dataset(f"data/demo_0/{name}", shape=(1, 1), dtype="f4")
+    with pytest.raises(ValueError, match="--overwrite"):
+        validate_existing_output(path, request)
+
+
+@pytest.mark.parametrize("body,expected", [("return 0", 0), ("return 7", 7),
+                                           ("raise ValueError('conversion failed')", 1),
+                                           ("raise KeyboardInterrupt", 130)])
+def test_worker_preserves_exit_status_even_with_destructive_atexit(body, expected):
+    # Models Kit shutdown replacing the status at interpreter exit.
+    program = f"""
+import atexit, os, sys
+sys.path.insert(0, {str(ROOT / 'scripts/demo_tools')!r})
+from conversion_output import exit_conversion
+atexit.register(lambda: os._exit(0))
+def run():
+    print('flushed worker output')
+    {body}
+exit_conversion(run)
+"""
+    result = subprocess.run([sys.executable, "-B", "-c", program], capture_output=True, text=True, timeout=20)
+    assert result.returncode == expected
+    assert "flushed worker output" in result.stdout
+    if expected == 1:
+        assert "ValueError: conversion failed" in result.stderr

--- a/scripts/env_tools/test_cup_rack_yaw.py
+++ b/scripts/env_tools/test_cup_rack_yaw.py
@@ -1,0 +1,318 @@
+"""CPU regressions for the v1 rack's hand-relative yaw and cup reset transform."""
+
+from __future__ import annotations
+
+import __future__
+import ast
+import math
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import torch
+from scipy.spatial.transform import Rotation
+
+ROOT = Path(__file__).resolve().parents[2] / "source/dexverse/dexverse/tasks"
+BASELINE_V1 = ROOT.parent / "baseline_v1"
+CONFIG = "config/functional/remove_cup_from_rack_cfg.py"
+sys.path.insert(0, str(ROOT.parents[1]))
+
+
+def _compile(nodes, namespace):
+    # Importing task modules would launch simulator dependencies. Compile the
+    # actual reset functions/defaults and event assignment, as other CPU tests do.
+    exec(compile(ast.Module(body=nodes, type_ignores=[]), "<rack-test>", "exec",
+                 flags=__future__.annotations.compiler_flag), namespace)
+
+
+def _defaults(version="v1"):
+    path = BASELINE_V1 / CONFIG if version == "v1" else ROOT / CONFIG
+    tree = ast.parse(path.read_text())
+    cls = next(node for node in tree.body if isinstance(node, ast.ClassDef))
+    namespace = {"math": math, "FLOATING_SHADOW_RIGHT_WRIST_POSITION_OFFSET": (-0.25, 0.0, 0.8)}
+    names = {"cup_holder_reset_x_range", "cup_holder_reset_y_range", "cup_holder_reset_yaw_range",
+             "cup_holder_face_point", "cup_offset_from_holder", "object_scale", "cup_holder_scale", "object_mass",
+             "target_x_range", "target_y_range", "object_half_height", "place_clearance",
+             "success_position_threshold", "success_max_tilt_rad", "destination_table_size",
+             "cup_holder_init_x_offset", "cup_holder_init_y_offset"}
+    _compile([node for node in cls.body if isinstance(node, ast.AnnAssign) and node.target.id in names], namespace)
+    return SimpleNamespace(**{name: namespace[name] for name in names if name in namespace}), cls
+
+
+def _event():
+    cfg, cls = _defaults()
+    cfg.events = SimpleNamespace()
+    post = next(node for node in cls.body if isinstance(node, ast.FunctionDef) and node.name == "__post_init__")
+    event = next(node for node in post.body if isinstance(node, ast.Assign)
+                 and ast.unparse(node.targets[0]) == "self.events.reset_cup_holder")
+    _compile([event], {"self": cfg, "mdp": SimpleNamespace(reset_root_pose_uniform_facing=_reset),
+                       "EventTerm": SimpleNamespace, "SceneEntityCfg": lambda name: SimpleNamespace(name=name)})
+    return cfg.events.reset_cup_holder.params
+
+
+def _quat_from_euler_xyz(roll, pitch, yaw):
+    values = torch.stack((roll, pitch, yaw), dim=-1).numpy()
+    return torch.tensor(Rotation.from_euler("xyz", values).as_quat(scalar_first=True), dtype=yaw.dtype)
+
+
+def _quat_apply(quat, vector):
+    return torch.tensor(Rotation.from_quat(quat.numpy(), scalar_first=True).apply(vector.numpy()), dtype=vector.dtype)
+
+
+def _quat_mul(left, right):
+    result = Rotation.from_quat(left.numpy(), scalar_first=True) * Rotation.from_quat(right.numpy(), scalar_first=True)
+    return torch.tensor(result.as_quat(scalar_first=True), dtype=left.dtype)
+
+
+_namespace = {"torch": torch, "math": math, "quat_from_euler_xyz": _quat_from_euler_xyz,
+              "quat_apply": _quat_apply, "quat_mul": _quat_mul,
+              "SceneEntityCfg": lambda name: SimpleNamespace(name=name)}
+for _file, _names in (("mdp/utils.py", {"resolve_env_ids"}),
+                       ("mdp/resets.py", {"reset_root_pose_uniform_facing", "sync_object"})):
+    _tree = ast.parse((BASELINE_V1 / _file).read_text())
+    _compile([node for node in _tree.body if isinstance(node, ast.FunctionDef) and node.name in _names], _namespace)
+_reset = _namespace["reset_root_pose_uniform_facing"]
+
+
+class _Asset:
+    def __init__(self, count):
+        state = torch.zeros(count, 13)
+        state[:, :3] = torch.tensor([0.0, 0.2, 0.5125])
+        state[:, 3] = 1.0
+        self.data = SimpleNamespace(default_root_state=state, root_pos_w=state[:, :3].clone(),
+                                    root_quat_w=state[:, 3:7].clone())
+        self.cfg = SimpleNamespace(spawn=SimpleNamespace(rigid_props=SimpleNamespace(kinematic_enabled=True)))
+
+    def write_root_pose_to_sim(self, pose, env_ids):
+        self.data.root_pos_w[env_ids] = pose[:, :3]
+        self.data.root_quat_w[env_ids] = pose[:, 3:7]
+
+    def write_root_velocity_to_sim(self, *args, **kwargs):
+        pytest.fail("Kinematic rack must not receive velocity writes")
+
+
+def _env(count):
+    class Scene(dict):
+        pass
+
+    scene = Scene(cup_holder=_Asset(count), object=_Asset(count))
+    scene.env_origins = torch.arange(count).unsqueeze(-1) * torch.tensor([[2.0, -3.0, 0.0]])
+    return SimpleNamespace(scene=scene, num_envs=count, device="cpu")
+
+
+def _relative_yaw(env):
+    rack = env.scene["cup_holder"].data
+    front = _quat_apply(rack.root_quat_w, torch.tensor([0.16, -0.01, 0.0]).expand(env.num_envs, -1))
+    target = torch.tensor([-0.25, 0.0]) + env.scene.env_origins[:, :2]
+    to_hand = target - rack.root_pos_w[:, :2]
+    delta = torch.atan2(front[:, 1], front[:, 0]) - torch.atan2(to_hand[:, 1], to_hand[:, 0])
+    return torch.atan2(torch.sin(delta), torch.cos(delta))
+
+
+def test_only_v1_uses_wide_hand_relative_yaw():
+    cfg, _ = _defaults()
+    baseline, _ = _defaults("v0")
+    assert cfg.cup_holder_reset_yaw_range == pytest.approx(tuple(map(math.radians, (-115, 115))))
+    assert baseline.cup_holder_reset_yaw_range == (-0.5, 0.5)
+    params = _event()
+    assert params["face_asset_cfg"] is None
+    assert params["face_point"] == (-0.25, 0.0)
+    assert params["open_dir_local"] == cfg.cup_offset_from_holder[:2]
+    assert params["yaw_jitter"] == cfg.cup_holder_reset_yaw_range
+
+
+@pytest.mark.parametrize("degrees", [-115, 0, 115])
+def test_heading_and_cup_seating_at_center_and_endpoints(degrees):
+    env = _env(8)
+    angle = math.radians(degrees)
+    params = _event() | {"yaw_jitter": (angle, angle)}
+    _reset(env, None, **params)
+    torch.testing.assert_close(_relative_yaw(env), torch.full((8,), angle), atol=2e-6, rtol=0)
+    # Cup orientation must stay rack-local even at the widest yaw endpoints.
+    cfg, _ = _defaults()
+    local_rot = Rotation.from_euler("z", -90, degrees=True).inv() * Rotation.from_euler("x", -105, degrees=True)
+    _namespace["sync_object"](
+        env, None, target_cfg=SimpleNamespace(name="object"), source_cfg=SimpleNamespace(name="cup_holder"),
+        source_local_offset=cfg.cup_offset_from_holder, quat_local=tuple(local_rot.as_quat(scalar_first=True)),
+    )
+    rack, cup = env.scene["cup_holder"].data, env.scene["object"].data
+    inverse = rack.root_quat_w.clone()
+    inverse[:, 1:] *= -1
+    torch.testing.assert_close(_quat_apply(inverse, cup.root_pos_w - rack.root_pos_w),
+                               torch.tensor(cfg.cup_offset_from_holder).expand(8, -1), atol=2e-6, rtol=0)
+    actual = _quat_mul(inverse, cup.root_quat_w)
+    expected = torch.tensor(local_rot.as_quat(scalar_first=True), dtype=actual.dtype).expand(8, -1)
+    assert torch.all(torch.abs((actual * expected).sum(-1)) > 1 - 1e-6)
+
+
+def test_seeded_distribution_covers_arc_and_subset_reset_leaves_others_untouched():
+    env = _env(2048)
+    # Avoid large float32 origins masking small heading differences in the histogram.
+    env.scene.env_origins.zero_()
+    torch.manual_seed(1003)
+    _reset(env, None, **_event())
+    rack = env.scene["cup_holder"].data
+    positions, rotations = rack.root_pos_w.clone(), rack.root_quat_w.clone()
+    degrees = torch.rad2deg(_relative_yaw(env))
+    assert degrees.min() >= -115.001 and degrees.max() <= 115.001
+    assert degrees.min() < -114 and degrees.max() > 114
+    assert torch.all(torch.histc(degrees, bins=10, min=-115, max=115) > 140)
+    torch.manual_seed(4200)
+    _reset(env, torch.tensor([1, 3]), **_event())
+    torch.testing.assert_close(rack.root_pos_w[[0, 2]], positions[[0, 2]])
+    torch.testing.assert_close(rack.root_quat_w[[0, 2]], rotations[[0, 2]])
+    torch.manual_seed(1003)
+    _reset(env, None, **_event())
+    torch.testing.assert_close(rack.root_pos_w, positions)
+    torch.testing.assert_close(rack.root_quat_w, rotations)
+
+
+def test_small_destination_geometry_and_goal(tmp_path):
+    from dexverse.assets.small_table_builder import ensure_small_table_asset
+    from pxr import Usd, UsdGeom, UsdPhysics
+
+    cfg, cls = _defaults()
+    post = next(node for node in cls.body if isinstance(node, ast.FunctionDef) and node.name == "__post_init__")
+    assert "self._configure_destination_table(table_pos=table_pos, table_top_z=table_top_z)" in ast.unparse(post)
+    helper = next(node for node in cls.body if isinstance(node, ast.FunctionDef)
+                  and node.name == "_configure_destination_table")
+    class RigidCfg(SimpleNamespace):
+        InitialStateCfg = SimpleNamespace
+
+    cfg.scene = SimpleNamespace()
+    cfg.commands = SimpleNamespace(object_pose=SimpleNamespace(ranges=SimpleNamespace()))
+    namespace = {
+        "ensure_small_table_asset": lambda name, **params: ensure_small_table_asset(name, out_dir=tmp_path, **params),
+        "RigidObjectCfg": RigidCfg,
+        "sim_utils": SimpleNamespace(UsdFileCfg=SimpleNamespace, RigidBodyPropertiesCfg=SimpleNamespace),
+        "dexverse_base_env": SimpleNamespace(spawn_usd_with_rigid_properties=object()),
+    }
+    _compile([helper], namespace)
+    namespace["_configure_destination_table"](cfg, table_pos=(0, 0, 0.575), table_top_z=0.6)
+    stand = cfg.scene.cup_destination_table
+    assert stand.init_state.pos == pytest.approx((0.1, -0.325, 0.6))
+    assert stand.spawn.rigid_props.kinematic_enabled
+    assert stand.spawn.collision_props is None
+    assert cfg.destination_table_size == (0.15, 0.15, 0.15)
+    stage = Usd.Stage.Open(stand.spawn.usd_path)
+    cubes = [prim for prim in stage.Traverse() if prim.IsA(UsdGeom.Cube)]
+    assert len(cubes) == 5
+    assert all(UsdPhysics.CollisionAPI(prim).GetCollisionEnabledAttr().Get() for prim in cubes)
+    top = next(prim for prim in cubes if prim.GetName() == "top")
+    assert tuple(top.GetAttribute("xformOp:scale").Get()) == pytest.approx((0.15, 0.15, 0.012))
+    bounds = UsdGeom.BBoxCache(Usd.TimeCode.Default(), [UsdGeom.Tokens.default_]).ComputeWorldBound(
+        stage.GetDefaultPrim()).ComputeAlignedRange()
+    assert tuple(bounds.GetSize()) == pytest.approx((0.15, 0.15, 0.15))
+    assert cfg.commands.object_pose.ranges.pos_z == pytest.approx((0.775, 0.775))
+    baseline, _ = _defaults("v0")
+    assert baseline.target_x_range == (0.05, 0.15)
+    assert baseline.target_y_range == (-0.4, -0.25)
+    assert not hasattr(baseline, "destination_table_size")
+    assert cfg.success_position_threshold == baseline.success_position_threshold
+    assert cfg.success_max_tilt_rad == baseline.success_max_tilt_rad
+
+
+def test_cup_shrinks_without_changing_rack_or_v0():
+    cfg, _ = _defaults()
+    baseline, _ = _defaults("v0")
+    assert cfg.object_scale == (0.9, 0.9, 0.9)
+    assert baseline.object_scale == (1.0, 1.0, 1.0)
+    assert cfg.cup_holder_scale == baseline.cup_holder_scale == (1.5, 1.5, 1.5)
+    assert cfg.cup_offset_from_holder == baseline.cup_offset_from_holder
+    assert cfg.object_mass == baseline.object_mass == 0.2
+    # The shared object builder sends scale to the USD spawner, which scales
+    # both rendered geometry and authored colliders (not just a visual marker).
+    base_tree = ast.parse((BASELINE_V1 / "config/functional/base_cfg.py").read_text())
+    builder = next(node for node in base_tree.body if isinstance(node, ast.FunctionDef)
+                   and node.name == "build_object_cfg_from_usd")
+    spawn_call = next(node for node in ast.walk(builder) if isinstance(node, ast.Call)
+                      and ast.unparse(node.func) == "sim_utils.UsdFileCfg")
+    assert any(kw.arg == "scale" and ast.unparse(kw.value) == "scale" for kw in spawn_call.keywords)
+
+
+def test_main_table_legs_and_bounds_remain_original_size():
+    cfg, cls = _defaults()
+    tree = ast.parse((BASELINE_V1 / "dexverse_base_env_cfg.py").read_text())
+    constants = {"DEFAULT_TABLE_THICKNESS", "DEFAULT_TABLE_TOP_HEIGHT", "DEFAULT_TABLE_SIZE",
+                 "DEFAULT_TABLE_INIT_POS", "DEFAULT_TABLE_INIT_ROT", "DEFAULT_TABLE_LEG_THICKNESS",
+                 "DEFAULT_TABLE_LEG_INSET"}
+    namespace = {}
+    _compile([node for node in tree.body if isinstance(node, ast.Assign)
+              and isinstance(node.targets[0], ast.Name) and node.targets[0].id in constants], namespace)
+    _compile([node for node in tree.body if isinstance(node, ast.FunctionDef)
+              and node.name in {"_compute_table_leg_size_and_pos", "_sync_table_legs_to_table"}], namespace)
+    cfg.scene = SimpleNamespace(table=SimpleNamespace(
+        spawn=SimpleNamespace(size=namespace["DEFAULT_TABLE_SIZE"]),
+        init_state=SimpleNamespace(pos=namespace["DEFAULT_TABLE_INIT_POS"], rot=namespace["DEFAULT_TABLE_INIT_ROT"]),
+    ))
+    signs = {"front_left": (1, 1), "front_right": (1, -1), "back_left": (-1, 1), "back_right": (-1, -1)}
+    for name in signs:
+        setattr(cfg.scene, f"table_leg_{name}", SimpleNamespace(spawn=SimpleNamespace(), init_state=SimpleNamespace()))
+    post = next(node for node in cls.body if isinstance(node, ast.FunctionDef) and node.name == "__post_init__")
+    super_index = next(i for i, node in enumerate(post.body) if ast.unparse(node) == "super().__post_init__()")
+    _compile(post.body[:super_index], {"self": cfg})
+    assert cfg.scene.table.spawn.size == (1.5, 1.5, 0.05)
+    assert namespace["DEFAULT_TABLE_SIZE"] == (1.5, 1.5, 0.05)
+    assert "self.scene.table.spawn.size =" not in ast.unparse(cls)
+    assert cfg.scene.table.init_state.pos == pytest.approx((0, 0, 0.575))
+    assert "_sync_table_legs_to_table(self.scene)" in ast.unparse(tree)
+    namespace["_sync_table_legs_to_table"](cfg.scene)
+    for name, (sx, sy) in signs.items():
+        leg = getattr(cfg.scene, f"table_leg_{name}")
+        assert leg.spawn.size == pytest.approx((0.08, 0.08, 0.55))
+        assert leg.init_state.pos == pytest.approx((sx * 0.63, sy * 0.63, 0.275))
+        assert leg.init_state.rot == cfg.scene.table.init_state.rot
+
+    # Execute the inherited footprint-bound setup against the original scene.
+    base_tree = ast.parse((BASELINE_V1 / "config/functional/base_cfg.py").read_text())
+    base_cls = next(node for node in base_tree.body if isinstance(node, ast.ClassDef)
+                    and node.name == "FunctionalGraspingEnvCfg")
+    base_post = next(node for node in base_cls.body if isinstance(node, ast.FunctionDef)
+                     and node.name == "__post_init__")
+    bounds = next(node for node in base_post.body if isinstance(node, ast.If)
+                  and ast.unparse(node.test) == "self.terminations.object_out_of_bound is not None")
+    cfg.terminations = SimpleNamespace(object_out_of_bound=SimpleNamespace(params={}))
+    _compile([bounds], {"self": cfg, "BOUND_Z_MIN": -0.2, "BOUND_Z_MAX": 1.5})
+    assert cfg.terminations.object_out_of_bound.params["in_bound_range"] == {
+        "x": (-0.75, 0.75), "y": (-0.75, 0.75), "z": (-0.2, 1.5),
+    }
+
+
+def test_main_table_fits_rack_and_small_destination_fits_goal_cup():
+    cfg, _ = _defaults()
+    # Conservative asset bounds (metres before spawn scaling), rounded up
+    # from the USDs. Radial envelopes cover every yaw, not just sampled ones.
+    rack_radius = math.hypot(0.084 * cfg.cup_holder_scale[0], 0.189 * cfg.cup_holder_scale[1])
+    cup_radius = math.sqrt(0.044**2 + 0.043**2 + 0.119**2) * max(cfg.object_scale)
+    seated_radius = math.hypot(*cfg.cup_offset_from_holder[:2]) + cup_radius
+    for axis in range(2):
+        initial = (cfg.cup_holder_init_x_offset, cfg.cup_holder_init_y_offset)[axis]
+        reset = (cfg.cup_holder_reset_x_range, cfg.cup_holder_reset_y_range)[axis]
+        max_center = max(abs(initial + offset) for offset in reset)
+        assert max_center + max(rack_radius, seated_radius) < 0.75
+        goals = (cfg.target_x_range, cfg.target_y_range)[axis]
+        stand_half = cfg.destination_table_size[axis] / 2
+        assert abs(sum(goals) / 2) + stand_half < 0.75
+        # An upright cup fits at every sampled target, at any cup yaw.
+        upright_radius = math.hypot(0.044, 0.043) * max(cfg.object_scale)
+        assert (goals[1] - goals[0]) / 2 + upright_radius < stand_half
+
+
+def test_small_destination_revision_rejects_previous_scene_recordings():
+    from dexverse.benchmark import (
+        BENCHMARK_REVISION, CUP_RACK_SMALL_DESTINATION_REVISION, task_identity, validate_replay_identity,
+    )
+
+    task = "Dexverse-RemoveCupFromRack-v1"
+    identity = task_identity(task)
+    assert identity["benchmark_revision"] == CUP_RACK_SMALL_DESTINATION_REVISION
+    validate_replay_identity({"task": task, **identity}, task)
+    for old_revision in (None, BENCHMARK_REVISION, "cup-rack-raised-destination-v1-2026-09-09",
+                         "cup-rack-small-cup-v1-2026-09-09", "cup-rack-compact-table-v1-2026-09-09"):
+        payload = {"task": task, "benchmark_revision": old_revision}
+        with pytest.raises(ValueError, match="15 x 15 cm raised destination"):
+            validate_replay_identity(payload, task)
+        validate_replay_identity(payload, task, explicit_override=True)
+    assert task_identity("Dexverse-RemoveCupFromRack-v0")["task_version"] == 0
+    assert task_identity("Dexverse-GraspBleach-v1")["benchmark_revision"] == BENCHMARK_REVISION

--- a/scripts/env_tools/test_cutaway_door.py
+++ b/scripts/env_tools/test_cutaway_door.py
@@ -1,0 +1,220 @@
+"""CPU asset topology and task-sequence checks for the replacement door v1."""
+
+import math
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+import pytest
+import torch
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "source/dexverse"))
+from dexverse.teleop_utils.door_latch_progress import new_door_latch_state, update_door_latch_state  # noqa: E402
+from dexverse.benchmark import task_identity, validate_replay_identity, V1_CONFIGS  # noqa: E402
+
+
+def step(state, index, angle=0.0, height=0.0, touch=False, support=False, clear=False, speed=0.0, latch_speed=0.0):
+    return update_door_latch_state(
+        state,
+        torch.tensor([index]),
+        torch.tensor([angle]),
+        torch.tensor([speed]),
+        torch.tensor([height]),
+        torch.tensor([latch_speed]),
+        *[torch.tensor([x]) for x in (touch, support, clear)],
+        hold_steps=3,
+    )
+
+
+def test_closed_start_and_reclosure_after_opening():
+    state = new_door_latch_state(1, "cpu")
+    assert not step(state, 0)[1].item()
+    step(state, 1, angle=0.4, touch=True)
+    assert step(state, 2, angle=0.05)[1].item()
+    assert step(state, 3, angle=1.57, support=True, clear=True)[1].item()
+    assert not step(state, 0)[1].item()  # Per-environment counter rollback clears history.
+
+
+def test_angle_alone_or_no_prior_hand_contact_do_not_succeed():
+    state = new_door_latch_state(1, "cpu")
+    for i in range(10):
+        assert not step(state, i, angle=1.57, support=True, clear=True)[0].item()
+    step(state, 10, angle=1.57, touch=True)
+    for i in range(11, 20):
+        assert not step(state, i, angle=1.57, clear=True)[0].item()
+
+
+def test_auto_latch_needs_release_dwell_without_manual_lift_or_prescribed_grasp():
+    state = new_door_latch_state(1, "cpu")
+    step(state, 0, angle=0.2, touch=True)
+    step(state, 1, angle=0.9, touch=True)
+    step(state, 2, angle=1.3, height=0.04, touch=True)
+    for i in range(3, 7):
+        assert not step(state, i, angle=1.54, support=True, clear=False)[0].item()
+    assert not step(state, 7, angle=1.54, support=True, clear=True)[0].item()
+    assert not step(state, 7, angle=1.54, support=True, clear=True)[0].item()  # No double-counting.
+    assert not step(state, 8, angle=1.54, support=True, clear=True)[0].item()
+    assert step(state, 9, angle=1.54, support=True, clear=True)[0].item()
+    assert not step(state, 10, angle=1.54, support=False, clear=True)[0].item()
+
+
+@pytest.mark.parametrize("interruption", [
+    {"touch": True}, {"clear": False}, {"support": False},
+    {"angle": 1.2}, {"height": 0.035}, {"speed": 0.1}, {"latch_speed": 0.05},
+])
+def test_release_dwell_restarts_on_recontact_or_loss_of_stable_latch(interruption):
+    state = new_door_latch_state(1, "cpu")
+    step(state, 0, angle=1.54, touch=True)
+    seated = {"angle": 1.54, "support": True, "clear": True}
+    assert not step(state, 1, **seated)[0].item()
+    assert not step(state, 2, **seated)[0].item()
+    assert not step(state, 3, **(seated | interruption))[0].item()
+    assert state[0, 4] == 0
+    assert not step(state, 4, **seated)[0].item()
+    assert not step(state, 5, **seated)[0].item()
+    assert step(state, 6, **seated)[0].item()
+
+
+def test_skipped_evaluation_does_not_count_as_continuous_release():
+    state = new_door_latch_state(1, "cpu")
+    step(state, 0, angle=1.54, touch=True)
+    for index in (1, 2, 5, 6):
+        assert not step(state, index, angle=1.54, support=True, clear=True)[0].item()
+    assert step(state, 7, angle=1.54, support=True, clear=True)[0].item()
+
+
+def test_urdf_has_real_cutout_and_separate_physical_catch():
+    root = ET.parse(ROOT / "scripts/asset_tools/urdf/cutaway_door.urdf").getroot()
+    assert {link.attrib["name"] for link in root.findall("link")} == {"frame", "door", "latch"}
+    joints = {joint.attrib["name"]: joint for joint in root.findall("joint")}
+    assert set(joints) == {"door_hinge", "latch_slide"}
+    assert joints["latch_slide"].find("parent").attrib["link"] == "frame"
+    assert float(joints["door_hinge"].find("limit").attrib["upper"]) > 1.57
+    # Test the centre of the window against all four solid collision boxes.
+    panel = root.find("link[@name='door']")
+    assert len(panel.findall("collision")) == 4
+    point = (0.25, 0.0, 0.25)
+    for collider in panel.findall("collision"):
+        center = list(map(float, collider.find("origin").attrib["xyz"].split()))
+        size = list(map(float, collider.find("geometry/box").attrib["size"].split()))
+        assert not all(abs(p - c) < s / 2 for p, c, s in zip(point, center, size))
+
+
+def test_door_revision_rejects_predecessor_without_affecting_other_tasks():
+    task = "Dexverse-OpenDoor-v1"
+    assert "open_cutaway_door_cfg" in V1_CONFIGS[task][0]
+    validate_replay_identity({"task": task, **task_identity(task)}, task)
+    for revision in (None, "baseline-v1-2026-09-08", "door-cutaway-latch-v1-2026-09-08",
+                     "door-cutaway-latch-framed-v1-2026-09-08"):
+        with pytest.raises(ValueError, match="provenance"):
+            validate_replay_identity({"task": task, "benchmark_revision": revision}, task)
+    assert task_identity("Dexverse-GraspBleach-v1")["benchmark_revision"] == "baseline-v1-2026-09-08"
+
+
+def test_progress_resets_only_environment_whose_step_counter_rolls_back():
+    state = new_door_latch_state(2, "cpu")
+    state[:, :4] = 1
+    state[:, 4] = 2
+    state[:, 5] = 10
+    update_door_latch_state(
+        state,
+        torch.tensor([0, 11]),
+        torch.tensor([0.0, 1.54]),
+        torch.zeros(2),
+        torch.zeros(2),
+        torch.zeros(2),
+        torch.zeros(2, dtype=torch.bool),
+        torch.tensor([False, True]),
+        torch.tensor([False, True]),
+        hold_steps=3,
+    )
+    assert not state[0, :5].any()
+    assert state[1, 6] == 1
+
+
+def test_narrow_window_and_matching_beveled_latch():
+    directory = ROOT / "scripts/asset_tools/urdf"
+    root = ET.parse(directory / "cutaway_door.urdf").getroot()
+    boxes = [_box(collider) for collider in root.find("link[@name='door']").findall("collision")]
+
+    def solid(point):
+        return any(all(abs(p - c) < h for p, c, h in zip(point, center, half)) for center, half in boxes)
+
+    assert solid((0.25, 0, 0.205)) and solid((0.25, 0, 0.295))
+    assert not solid((0.25, 0, 0.215)) and not solid((0.25, 0, 0.285))
+    mesh = root.find("link[@name='latch']/collision[@name='latch_bevel']/geometry/mesh")
+    vertices = [tuple(map(float, line.split()[1:])) for line in
+                (directory / mesh.attrib["filename"]).read_text().splitlines() if line.startswith("v ")]
+    assert len(vertices) == 6
+    sizes = [max(v[i] for v in vertices) - min(v[i] for v in vertices) for i in range(3)]
+    assert sizes == pytest.approx([0.05, 0.12, 0.06])
+    assert (0, 0, 0) in vertices and (0.05, 0, 0.06) in vertices  # Camming slope.
+    # Outward-facing, watertight triangles for both rendering and collision.
+    faces = [tuple(int(x) - 1 for x in line.split()[1:]) for line in
+             (directory / mesh.attrib["filename"]).read_text().splitlines() if line.startswith("f ")]
+    edges = [(face[i], face[(i + 1) % 3]) for face in faces for i in range(3)]
+    assert all(edges.count((b, a)) == 1 for a, b in edges)
+    volume = 0.0
+    for face in faces:
+        a, b, c = (torch.tensor(vertices[i], dtype=torch.float64) for i in face)
+        volume += float(torch.dot(a, torch.linalg.cross(b, c))) / 6
+    assert volume == pytest.approx(0.5 * 0.05 * 0.06 * 0.12)
+
+
+def _box(element):
+    center = tuple(map(float, element.find("origin").attrib["xyz"].split()))
+    half = tuple(float(x) / 2 for x in element.find("geometry/box").attrib["size"].split())
+    return center, half
+
+
+def test_full_frame_blocks_initial_edge_hooks_but_leaves_window_and_later_regrasp_clear():
+    root = ET.parse(ROOT / "scripts/asset_tools/urdf/cutaway_door.urdf").getroot()
+    frame = root.find("link[@name='frame']")
+    names = {"frame_header", "frame_sill", "frame_free_jamb", "frame_hinge_jamb", "frame_hinge_rebate"}
+    for name in names:
+        assert _box(frame.find(f"collision[@name='{name}']")) == _box(frame.find(f"visual[@name='{name}']"))
+    boxes = [_box(collider) for collider in frame.findall("collision")]
+
+    def blocked(point, radius=0.008):
+        # An 8 mm radius probe represents a finger trying to wrap an edge;
+        # this geometry check is not a full articulated-hand adversarial test.
+        return any(
+            sum(max(abs(p - c) - h, 0) ** 2 for p, c, h in zip(point, center, half)) < radius**2
+            for center, half in boxes
+        )
+
+    for point in ((0.26, 0, 0.428), (0.348, 0, 0.25), (0.26, 0, 0.012), (-0.004, -0.009, 0.22)):
+        assert blocked(point)
+    assert not blocked((0.25, 0, 0.25))  # Initial window access.
+    for degrees in (40, 60, 90):
+        angle = math.radians(degrees)
+        for height in (0.02, 0.42):
+            assert not blocked((0.26 * math.cos(angle), 0.26 * math.sin(angle), height))
+
+
+def test_full_frame_does_not_intersect_panel_through_entire_hinge_sweep():
+    root = ET.parse(ROOT / "scripts/asset_tools/urdf/cutaway_door.urdf").getroot()
+    frame = [_box(collider) for collider in root.find("link[@name='frame']").findall("collision")]
+    panel = [_box(collider) for collider in root.find("link[@name='door']").findall("collision")]
+    # Separating-axis test for rotated boxes, including the two bodies' 2 mm
+    # contact offsets. Frame geometry must not rely on parent collision filtering.
+    for quarter_degree in range(385):
+        angle = math.radians(quarter_degree / 4)
+        u, v = (math.cos(angle), math.sin(angle)), (-math.sin(angle), math.cos(angle))
+        for center, half in panel:
+            rotated = (center[0] * u[0] + center[1] * v[0], center[0] * u[1] + center[1] * v[1])
+            for fixed, fixed_half in frame:
+                if abs(center[2] - fixed[2]) >= half[2] + fixed_half[2] + 0.004:
+                    continue
+                delta = (rotated[0] - fixed[0], rotated[1] - fixed[1])
+                separated = False
+                for axis in ((1, 0), (0, 1), u, v):
+                    distance = abs(sum(d * a for d, a in zip(delta, axis)))
+                    extent = (
+                        half[0] * abs(sum(x * a for x, a in zip(u, axis)))
+                        + half[1] * abs(sum(x * a for x, a in zip(v, axis)))
+                        + sum(h * abs(a) for h, a in zip(fixed_half, axis))
+                    )
+                    separated |= distance >= extent + 0.004
+                assert separated, f"Frame intersects panel at {quarter_degree / 4} degrees"

--- a/scripts/env_tools/test_debug_visualization.py
+++ b/scripts/env_tools/test_debug_visualization.py
@@ -1,0 +1,141 @@
+"""CPU regressions for unified debug controls without launching Isaac Sim/XR."""
+
+import argparse
+import ast
+import importlib.util
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "source/dexverse"))
+from dexverse.teleop_utils.debug_visualization import (  # noqa: E402
+    add_debug_visualization_args, configure_v1_debug_visualization,
+)
+
+
+@pytest.mark.parametrize("teleop,debug,rgb", [(True, True, True), (False, None, False)])
+def test_shared_cli_defaults_and_switches(teleop, debug, rgb):
+    parser = argparse.ArgumentParser()
+    add_debug_visualization_args(parser, teleop=teleop)
+    args = parser.parse_args([])
+    assert args.enable_debug_vis is debug and args.cues_in_rgb is rgb
+    args = parser.parse_args(["--no-enable_debug_vis", "--cues_in_rgb"])
+    assert args.enable_debug_vis is False and args.cues_in_rgb is True
+    args = parser.parse_args(["--enable_debug_vis", "--no-cues_in_rgb"])
+    assert args.enable_debug_vis is True and args.cues_in_rgb is False
+
+
+def _config(version, debug):
+    package = "dexverse.baseline_v1" if version == 1 else "dexverse.tasks"
+    cls = type("Config", (), {"__module__": f"{package}.config.test"})
+    cfg = cls()
+    cfg.enable_debug_vis = debug
+    cfg.teleop_devices = SimpleNamespace(devices={"handtracking": SimpleNamespace(
+        retargeters=[SimpleNamespace(task_version=version, debug_vis=True)]
+    )})
+    return cfg
+
+
+@pytest.mark.parametrize("debug,rgb", [(False, False), (False, True), (True, False), (True, True)])
+def test_v1_retarg_and_camera_policy_are_independent(monkeypatch, debug, rgb):
+    calls = []
+    monkeypatch.setitem(sys.modules, "dexverse.baseline_v1.visual_purpose",
+                        SimpleNamespace(set_camera_hiding_enabled=calls.append))
+    cfg = _config(1, debug)
+    configure_v1_debug_visualization(cfg, cues_in_rgb=rgb)
+    assert calls == [not rgb]
+    rtg = cfg.teleop_devices.devices["handtracking"].retargeters[0]
+    assert rtg.task_version == 1 and rtg.debug_vis is debug
+
+
+def test_v0_rendering_and_retarg_untouched(monkeypatch):
+    calls = []
+    monkeypatch.setitem(sys.modules, "dexverse.baseline_v1.visual_purpose",
+                        SimpleNamespace(set_camera_hiding_enabled=calls.append))
+    cfg = _config(0, False)
+    configure_v1_debug_visualization(cfg, cues_in_rgb=True)
+    assert not calls
+    assert cfg.teleop_devices.devices["handtracking"].retargeters[0].debug_vis is True
+
+
+def _method(relative_path, class_name, method_name, namespace):
+    path = ROOT / relative_path
+    cls = next(node for node in ast.parse(path.read_text()).body
+               if isinstance(node, ast.ClassDef) and node.name == class_name)
+    method = next(node for node in cls.body if isinstance(node, ast.FunctionDef) and node.name == method_name)
+    # Avoid evaluating simulator type annotations.
+    module = ast.Module(body=[ast.ImportFrom(module="__future__", names=[ast.alias(name="annotations")], level=0), method],
+                        type_ignores=[])
+    exec(compile(ast.fix_missing_locations(module), str(path), "exec"), namespace)
+    return namespace[method_name]
+
+
+def test_disabled_hand_visualizers_do_not_process_tracking_or_show_markers():
+    for method in ("_visualize_hand_keypoints", "_visualize_canonical_hand_keypoints", "_visualize_wrist_poses"):
+        call = _method("source/dexverse/dexverse/devices/retargeters/simple_relative_retargeting.py",
+                       "SimpleRelativeRetargeter", method, {})
+        rtg = SimpleNamespace(_debug_visualization_enabled=False)
+        call(rtg, None) if method != "_visualize_wrist_poses" else call(rtg)
+
+
+def test_zero_agent_hydra_debug_flag_is_consumed_before_config_construction():
+    path = ROOT / "scripts/zero_agent.py"
+    tree = ast.parse(path.read_text())
+    loop = next(node for node in tree.body if isinstance(node, ast.For)
+                and ast.unparse(node.target) == "raw_arg")
+    for explicit, override, expected in ((None, "true", True), (None, "false", False), (False, "true", False)):
+        namespace = {
+            "hydra_args": [f"env.enable_debug_vis={override}", "env.seed=1000"],
+            "remaining_hydra_args": [], "args_cli": SimpleNamespace(enable_debug_vis=explicit),
+            "parser": argparse.ArgumentParser(),
+        }
+        exec(compile(ast.Module(body=[loop], type_ignores=[]), str(path), "exec"), namespace)
+        assert namespace["args_cli"].enable_debug_vis is expected
+        assert namespace["remaining_hydra_args"] == ["env.seed=1000"]
+
+
+@pytest.mark.parametrize("debug", [False, True])
+def test_command_goal_remains_visible_when_current_pose_debug_is_off(debug):
+    class Marker:
+        def __init__(self, cfg):
+            self.visible = False
+        def set_visibility(self, visible):
+            self.visible = visible
+
+    hidden = []
+    method = _method("source/dexverse/dexverse/baseline_v1/mdp/commands/pose_commands.py",
+                     "ObjectUniformPoseCommand", "_set_debug_vis_impl",
+                     {"VisualizationMarkers": Marker, "hide_marker_from_cameras": hidden.append})
+    command = SimpleNamespace(_env=SimpleNamespace(cfg=SimpleNamespace(enable_debug_vis=debug)),
+                              cfg=SimpleNamespace(goal_pose_visualizer_cfg=None, curr_pose_visualizer_cfg=None))
+    method(command, True)
+    assert command.goal_visualizer.visible
+    assert (command.curr_visualizer is not None) is debug
+    assert command.goal_visualizer not in hidden
+    assert len(hidden) == int(debug)
+    method(command, False)
+    assert not command.goal_visualizer.visible
+
+
+def test_scissors_debug_cues_follow_shared_camera_policy():
+    path = ROOT / "source/dexverse/dexverse/baseline_v1/config/articulation/cut_strip_scissors_cfg.py"
+    tree = ast.parse(path.read_text())
+    method = next(node for node in ast.walk(tree) if isinstance(node, ast.FunctionDef) and node.name == "configure_debug_vis")
+    flags = [value.value for node in ast.walk(method) if isinstance(node, ast.Dict)
+             for key, value in zip(node.keys, node.values)
+             if isinstance(key, ast.Constant) and key.value == "hide_from_cameras"]
+    assert flags == [True, True]
+
+
+def test_camera_hiding_switch_can_be_reset_between_launch_configurations():
+    path = ROOT / "source/dexverse/dexverse/baseline_v1/visual_purpose.py"
+    spec = importlib.util.spec_from_file_location("isolated_visual_purpose", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    module.set_camera_hiding_enabled(False)
+    assert module.CAMERA_HIDING_ENABLED is False
+    module.set_camera_hiding_enabled(True)
+    assert module.CAMERA_HIDING_ENABLED is True

--- a/scripts/env_tools/test_demo_import.py
+++ b/scripts/env_tools/test_demo_import.py
@@ -1,0 +1,147 @@
+"""CPU regressions for non-destructive NumPy-compatible demo import."""
+
+import importlib.util
+import io
+import pickle
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+SCRIPT = Path(__file__).resolve().parents[1] / "demo_tools/import_versioned_demos.py"
+spec = importlib.util.spec_from_file_location("demo_import", SCRIPT)
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+
+
+def session():
+    return {
+        "format": "dexbench_trajectory",
+        "task": "Dexbench-GraspCup-v0",
+        "env_name": "Dexbench-GraspCup-v0",
+        "robot_type": "floating_shadow_right",
+        "num_episodes": 1,
+        "episodes": [
+            {
+                "actions": np.arange(56, dtype=np.float32).reshape(2, 28),
+                "success": True,
+                "states": [{}, {}, {}],
+                "initial_state": {},
+            }
+        ],
+    }
+
+
+def test_numpy2_module_name_remaps_without_changing_array_values():
+    payload = session()
+    # Protocol 0 has newline-delimited module names and no framed byte lengths.
+    raw = pickle.dumps(payload, protocol=0).replace(b"cnumpy.core.multiarray\n", b"cnumpy._core.multiarray\n")
+    loader = module.NumpyCompatUnpickler(io.BytesIO(raw))
+    restored = loader.load()
+    assert loader.remapped
+    assert module.array_digest(restored) == module.array_digest(payload)
+    normalized = pickle.loads(pickle.dumps(restored, protocol=4))
+    assert module.array_digest(normalized) == module.array_digest(payload)
+
+
+def test_unsupported_pickle_constructor_is_rejected():
+    with pytest.raises(pickle.UnpicklingError, match="Unsupported"):
+        module.NumpyCompatUnpickler(io.BytesIO(b"cos\nsystem\n.")).load()
+
+
+def test_legacy_byte_constructor_only_accepts_latin1():
+    assert module._latin1_encode("\u00ff") == b"\xff"
+    with pytest.raises(pickle.UnpicklingError, match="latin1"):
+        module._latin1_encode("data", "utf-8")
+
+
+def test_import_preserves_source_and_arrays_and_does_not_overwrite(tmp_path):
+    source = tmp_path / "Dexbench-GraspCup-v0.pkl"
+    source.write_bytes(pickle.dumps(session(), protocol=4))
+    original = source.read_bytes()
+    item = {
+        "source": str(source),
+        "target_task": "Dexverse-GraspCup-v0",
+        "version": 0,
+        "collection": "test",
+        "sha256": module.sha256(source),
+    }
+    dest = tmp_path / "demonstrations"
+    result = module.convert(item, source, dest)
+    assert result["status"] == "imported" and not result["review_reasons"]
+    assert source.read_bytes() == original
+    output = dest / result["output"]
+    data = pickle.loads(output.read_bytes())
+    assert data["task"] == "Dexverse-GraspCup-v0" and data["task_version"] == 0
+    assert data["task_source_revision"] is None
+    assert data["demo_import"]["original_identity"]["task"] == "Dexbench-GraspCup-v0"
+    np.testing.assert_array_equal(data["episodes"][0]["actions"], session()["episodes"][0]["actions"])
+    before = output.read_bytes()
+    assert module.convert(item, source, dest)["status"] == "already_imported"
+    assert output.read_bytes() == before
+    modified = session()
+    modified["episodes"][0]["actions"] *= 2
+    source.write_bytes(pickle.dumps(modified, protocol=4))
+    item["sha256"] = module.sha256(source)
+    with pytest.raises(FileExistsError):
+        module.convert(item, source, dest)
+    assert output.read_bytes() == before
+
+
+def test_review_recordings_are_not_in_usable_version_tree(tmp_path):
+    source = tmp_path / "prototype.pkl"
+    payload = session()
+    payload["episodes"][0]["states"] = []
+    source.write_bytes(pickle.dumps(payload, protocol=4))
+    result = module.convert(
+        {"source": str(source), "target_task": "Dexverse-GraspCup-v0", "version": 0, "collection": "test"},
+        source,
+        tmp_path / "demos",
+    )
+    assert result["output"].startswith("_review/v0/")
+    assert "missing_or_misaligned_recorded_states" in result["review_reasons"]
+
+
+def test_interrupted_serialization_never_publishes_partial_output(tmp_path, monkeypatch):
+    source = tmp_path / "session.pkl"
+    source.write_bytes(pickle.dumps(session(), protocol=4))
+    dest = tmp_path / "demos"
+
+    def fail_dump(payload, stream, protocol):
+        stream.write(b"partial")
+        raise OSError("simulated interruption")
+
+    monkeypatch.setattr(module.pickle, "dump", fail_dump)
+    with pytest.raises(OSError, match="simulated interruption"):
+        module.convert(
+            {"source": str(source), "target_task": "Dexverse-GraspCup-v0", "version": 0, "collection": "test"},
+            source,
+            dest,
+        )
+    assert not list(dest.rglob("*.pkl"))
+    assert not list(dest.rglob("*.tmp"))
+
+
+def test_review_recording_requires_explicit_replay_decision():
+    from dexverse.benchmark import validate_replay_identity
+
+    payload = {
+        "task": "Dexverse-GraspCup-v1",
+        "demo_import": {"compatibility": "needs_review", "review_reasons": ["prototype_scene"]},
+    }
+    with pytest.raises(ValueError, match="needs review"):
+        validate_replay_identity(payload, payload["task"])
+    validate_replay_identity(payload, payload["task"], explicit_override=True)
+
+
+def test_bulk_replay_discovery_skips_review_tree(tmp_path):
+    import sys
+    sys.path.insert(0, str(SCRIPT.parent))
+    from demo_selection import discover_groups
+    usable = tmp_path / "v1/functional/task/session.pkl"
+    review = tmp_path / "_review/v1/functional/task/session.pkl"
+    for path in (usable, review):
+        path.parent.mkdir(parents=True)
+        path.touch()
+    groups, _ = discover_groups(tmp_path, all_tasks=True, legacy_collections=True)
+    assert [path for group in groups for path in group.pickles] == [usable]

--- a/scripts/env_tools/test_demo_release.py
+++ b/scripts/env_tools/test_demo_release.py
@@ -1,0 +1,185 @@
+"""Offline release/transfer regressions; no simulator or HF access."""
+
+import json
+from pathlib import Path
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "demo_tools"))
+import demo_release as release
+import download_demos as download
+
+
+def args(**kwargs):
+    return SimpleNamespace(**dict(all=False, baseline=False, category=[], task=[], pattern=[], version="all", legacy=False) | kwargs)
+
+
+def manifest():
+    return {"schema": release.SCHEMA, "tasks": [
+        {"key": key, "task": key.split("/")[-1], "episodes": 0, "files": [], "status": "missing", "reason": "not collected"}
+        for key in release.baseline_entries()]}
+
+
+def fixture_release(tmp_path):
+    root = tmp_path / "release"
+    root.mkdir()
+    data = manifest()
+    entry = data["tasks"][0]
+    name = f"demonstrations/{entry['key']}/demos.pkl"
+    path = root / name
+    path.parent.mkdir(parents=True)
+    path.write_bytes(b"test payload, no unpickling on transfer")
+    entry.update(status="complete", episodes=50, files=[{"path": name, "sha256": release.sha256(path), "bytes": path.stat().st_size, "episodes": 50}])
+    (root / release.MANIFEST).write_text(json.dumps(data))
+    (root / "README.md").write_text("Dataset card")
+    return root, data, path
+
+
+def test_baseline_defaults_to_both_versions():
+    patterns = download._build_patterns(args(baseline=True))
+    assert len(patterns) == 40
+    assert sum(p.startswith("demonstrations/v0/") for p in patterns) == 20
+    assert sum(p.startswith("demonstrations/v1/") for p in patterns) == 20
+    assert len(download._build_patterns(args(baseline=True, version="v1"))) == 20
+
+
+def test_explicit_task_and_category_patterns():
+    assert download._build_patterns(args(task=["functional/Dexverse-GraspCup-v1"])) == [
+        "demonstrations/v1/functional/Dexverse-GraspCup-v1/**"]
+    assert download._build_patterns(args(category=["functional"])) == [
+        "demonstrations/v0/functional/**", "demonstrations/v1/functional/**"]
+    with pytest.raises(ValueError):
+        download._build_patterns(args(task=["v1/functional/Dexverse-GraspCup-v1"], version="v0"))
+    assert download._build_patterns(args(task=["Dexverse-PushT-v1"])) == [
+        "demonstrations/v1/non_prehensile/Dexverse-PushT-v1/**"]
+    for selector in ("Dexverse-PushT-v1", "non_prehensile/Dexverse-PushT-v1"):
+        with pytest.raises(ValueError, match="conflicts"):
+            download._build_patterns(args(task=[selector], version="v0"))
+    with pytest.raises(ValueError, match="Unknown"):
+        download._build_patterns(args(task=["Dexverse-PushT"]))
+
+
+def test_legacy_is_explicit_v0_only():
+    patterns = download._build_patterns(args(baseline=True, legacy=True))
+    assert len(patterns) == 20 and all("-v0/" in p for p in patterns)
+    assert all(not p.startswith("demonstrations/v0/") for p in patterns)
+    with pytest.raises(ValueError):
+        download._build_patterns(args(baseline=True, version="v1", legacy=True))
+
+
+@pytest.mark.parametrize("path", ["../escape", "/absolute", "v1/../../escape", "a\\b", "a//b", "a/./b", ""])
+def test_unsafe_paths_rejected(path):
+    with pytest.raises(ValueError):
+        release.safe_relative(path)
+
+
+def test_symlink_escape(tmp_path):
+    root = tmp_path / "root"
+    root.mkdir()
+    (root / "escape").symlink_to(tmp_path, target_is_directory=True)
+    with pytest.raises(ValueError):
+        release.contained_path(root, "escape/test")
+
+
+def test_manifest_coverage_and_file_validation():
+    data = manifest()
+    release.validate_manifest(data)
+    data["tasks"].pop()
+    with pytest.raises(ValueError):
+        release.validate_manifest(data)
+    data = manifest()
+    data["tasks"][0].update(status="complete", episodes=50)
+    with pytest.raises(ValueError):
+        release.validate_manifest(data)
+
+
+def test_manifest_selection_reports_gaps(tmp_path):
+    _, data, _ = fixture_release(tmp_path)
+    entries, gaps = download.select_release(data, download._build_patterns(args(baseline=True)))
+    assert len(entries) == 1 and len(gaps) == 39
+
+
+def test_allow_list_blocks_extra_private_files(tmp_path):
+    root, _, _ = fixture_release(tmp_path)
+    release.verify_release(root)
+    (root / "private_report.json").write_text("private")
+    with pytest.raises(ValueError, match="extra"):
+        release.verify_release(root)
+
+
+def test_modified_release_rejected(tmp_path):
+    root, _, path = fixture_release(tmp_path)
+    path.write_bytes(b"modified")
+    with pytest.raises(ValueError, match="mismatch"):
+        release.verify_release(root)
+
+
+def test_offline_validation_cli(tmp_path, monkeypatch, capsys):
+    root, _, _ = fixture_release(tmp_path)
+    # The validator must not need the remote client or load the opaque pickle.
+    monkeypatch.setitem(sys.modules, "huggingface_hub", None)
+    monkeypatch.setattr(sys, "argv", ["demo_release", "--release-dir", str(root)])
+    release.main()
+    output = capsys.readouterr().out
+    assert "Verified 3 allow-listed files" in output
+    assert "50 trajectories" in output
+    assert "nothing uploaded" in output
+
+
+def test_download_verify_skip_and_no_overwrite(tmp_path):
+    _, data, source = fixture_release(tmp_path)
+    entries = data["tasks"][0]["files"]
+    calls = []
+    def fetch(path):
+        calls.append(path)
+        return source
+    dest = tmp_path / "dest"
+    download.fetch_selected(entries, dest, fetch)
+    download.fetch_selected(entries, dest, fetch)
+    assert len(calls) == 1
+    target = dest / entries[0]["path"].removeprefix("demonstrations/")
+    target.write_bytes(b"my own data")
+    with pytest.raises(FileExistsError):
+        download.fetch_selected(entries, dest, fetch)
+    assert target.read_bytes() == b"my own data"
+
+
+def test_corrupt_download_not_installed(tmp_path):
+    _, data, source = fixture_release(tmp_path)
+    entries = data["tasks"][0]["files"]
+    source.write_bytes(b"x" * entries[0]["bytes"])
+    with pytest.raises(ValueError, match="checksum"):
+        download.fetch_selected(entries, tmp_path / "dest", lambda _: source)
+    assert not list((tmp_path / "dest").rglob("*.pkl"))
+
+
+@pytest.mark.parametrize("mode", ["normal", "dry", "strict"])
+def test_download_cli_pins_revision_and_honors_no_fetch_modes(tmp_path, monkeypatch, mode):
+    root, data, _ = fixture_release(tmp_path)
+    calls = []
+    class API:
+        def repo_info(self, **kwargs):
+            assert kwargs["revision"] == "a-tag"
+            return SimpleNamespace(sha="immutable-commit")
+    def fetch(**kwargs):
+        assert kwargs["revision"] == "immutable-commit"
+        calls.append(kwargs["filename"])
+        return str(root / kwargs["filename"])
+    monkeypatch.setitem(sys.modules, "huggingface_hub", SimpleNamespace(HfApi=API, hf_hub_download=fetch))
+    monkeypatch.setitem(sys.modules, "huggingface_hub.errors", SimpleNamespace(EntryNotFoundError=FileNotFoundError))
+    argv = ["download", "--repo", "owner/test", "--revision", "a-tag", "--baseline", "--dest", str(tmp_path / "dest")]
+    if mode == "dry":
+        argv.append("--dry-run")
+    if mode == "strict":
+        argv.append("--require-complete")
+    monkeypatch.setattr(sys, "argv", argv)
+    if mode == "strict":
+        with pytest.raises(SystemExit, match="incomplete"):
+            download.main()
+    else:
+        assert download.main() == 0
+    assert calls[0] == release.MANIFEST
+    assert len(calls) == (2 if mode == "normal" else 1)
+    assert len(list((tmp_path / "dest").rglob("*.pkl"))) == (1 if mode == "normal" else 0)

--- a/scripts/env_tools/test_demo_release.py
+++ b/scripts/env_tools/test_demo_release.py
@@ -2,6 +2,7 @@
 
 import json
 from pathlib import Path
+import runpy
 import sys
 from types import SimpleNamespace
 
@@ -43,6 +44,13 @@ def test_baseline_defaults_to_both_versions():
     assert sum(p.startswith("demonstrations/v0/") for p in patterns) == 20
     assert sum(p.startswith("demonstrations/v1/") for p in patterns) == 20
     assert len(download._build_patterns(args(baseline=True, version="v1"))) == 20
+
+
+def test_all_release_downloaders_share_public_repo_default():
+    assert download.DEFAULT_REPO == "dexverse/DexVerse_release"
+    tools = Path(__file__).resolve().parents[1] / "asset_tools"
+    for script in ("download_assets.py", "download_robot_agents.py"):
+        assert runpy.run_path(str(tools / script))["DEFAULT_REPO"] == download.DEFAULT_REPO
 
 
 def test_explicit_task_and_category_patterns():
@@ -156,20 +164,26 @@ def test_corrupt_download_not_installed(tmp_path):
 
 
 @pytest.mark.parametrize("mode", ["normal", "dry", "strict"])
-def test_download_cli_pins_revision_and_honors_no_fetch_modes(tmp_path, monkeypatch, mode):
+@pytest.mark.parametrize("repo", [None, "owner/test"])
+def test_download_cli_pins_revision_and_honors_no_fetch_modes(tmp_path, monkeypatch, mode, repo):
     root, data, _ = fixture_release(tmp_path)
     calls = []
+    expected_repo = repo or "dexverse/DexVerse_release"
     class API:
         def repo_info(self, **kwargs):
+            assert kwargs["repo_id"] == expected_repo
             assert kwargs["revision"] == "a-tag"
             return SimpleNamespace(sha="immutable-commit")
     def fetch(**kwargs):
+        assert kwargs["repo_id"] == expected_repo
         assert kwargs["revision"] == "immutable-commit"
         calls.append(kwargs["filename"])
         return str(root / kwargs["filename"])
     monkeypatch.setitem(sys.modules, "huggingface_hub", SimpleNamespace(HfApi=API, hf_hub_download=fetch))
     monkeypatch.setitem(sys.modules, "huggingface_hub.errors", SimpleNamespace(EntryNotFoundError=FileNotFoundError))
-    argv = ["download", "--repo", "owner/test", "--revision", "a-tag", "--baseline", "--dest", str(tmp_path / "dest")]
+    argv = ["download", "--revision", "a-tag", "--baseline", "--dest", str(tmp_path / "dest")]
+    if repo is not None:
+        argv.extend(["--repo", repo])
     if mode == "dry":
         argv.append("--dry-run")
     if mode == "strict":

--- a/scripts/env_tools/test_demo_selection.py
+++ b/scripts/env_tools/test_demo_selection.py
@@ -1,0 +1,153 @@
+"""Offline task/version selection tests, including download-to-convert routing."""
+
+import ast
+import json
+from pathlib import Path
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "scripts/demo_tools"))
+from demo_release import baseline_entries, baseline_key, sha256, SCHEMA
+from demo_selection import discover_groups, validate_selected_identity, worker_arguments, PickleGroup
+from download_demos import _build_patterns, fetch_selected, select_release
+
+
+def write_demo(root, key):
+    path = root / key / "demos.pkl"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"opaque fixture: selection and transfer must not unpickle")
+    return path
+
+
+@pytest.mark.parametrize("key", baseline_entries())
+def test_every_baseline_id_and_path_resolves_exactly(key):
+    for selector in (key, key.split("/", 1)[1], key.split("/")[-1]):
+        assert baseline_key(selector) == key
+        assert baseline_key(selector, key[:2]) == key
+        with pytest.raises(ValueError, match="conflicts"):
+            baseline_key(selector, "v1" if key.startswith("v0") else "v0")
+
+
+@pytest.mark.parametrize("selector", ["Dexverse-PushT", "Dexverse-PushT-v2", "../outside", "", "/abs",
+                                     "v0/non_prehensile/Dexverse-PushT-v1", "functional/Dexverse-PushT-v1"])
+def test_no_version_guessing_or_unsafe_paths(selector):
+    with pytest.raises(ValueError):
+        baseline_key(selector)
+
+
+def test_selects_only_canonical_pickle_and_keeps_versions_separate(tmp_path):
+    v0, v1 = (f"v{v}/non_prehensile/Dexverse-PushT-v{v}" for v in (0, 1))
+    paths = [write_demo(tmp_path, key) for key in (v0, v1)]
+    write_demo(tmp_path, v1 + "/local_collection/old")
+    write_demo(tmp_path, "_review/" + v1)
+    groups, warnings = discover_groups(tmp_path, tasks=["Dexverse-PushT-v0", "Dexverse-PushT-v1", v1])
+    assert not warnings and len(groups) == 2
+    assert [g.pickles for g in groups] == [[p] for p in paths]
+    assert [g.expected_task for g in groups] == ["Dexverse-PushT-v0", "Dexverse-PushT-v1"]
+    assert groups[0].output_stem != groups[1].output_stem
+    groups, warnings = discover_groups(tmp_path, all_tasks=True, version="v1")
+    assert len(groups) == 1 and len(warnings) == 19
+    assert groups[0].pickles == [paths[1]]
+
+
+def test_no_fallback_to_raw_sessions_or_other_version(tmp_path):
+    write_demo(tmp_path, "v1/non_prehensile/Dexverse-PushT-v1/local_collection/latest")
+    write_demo(tmp_path, "v0/non_prehensile/Dexverse-PushT-v0")
+    with pytest.raises(FileNotFoundError, match="Download with"):
+        discover_groups(tmp_path, tasks=["Dexverse-PushT-v1"])
+
+
+def test_version_root_and_conflicting_selectors(tmp_path):
+    path = write_demo(tmp_path, "v1/non_prehensile/Dexverse-PushT-v1")
+    groups, _ = discover_groups(tmp_path / "v1", tasks=["Dexverse-PushT-v1"])
+    assert groups[0].pickles == [path]
+    for kwargs in (dict(version="v0"), dict(tasks=["Dexverse-PushT-v0"])):
+        with pytest.raises(ValueError, match="conflicts"):
+            discover_groups(tmp_path / "v1", all_tasks=not bool(kwargs.get("tasks")), **kwargs)
+    with pytest.raises(ValueError):
+        discover_groups(tmp_path, tasks=["Dexverse-PushT-v1"], all_tasks=True)
+    with pytest.raises(ValueError):
+        discover_groups(tmp_path, files=[str(path)], version="v1")
+
+
+def test_download_and_release_root_select_same_pickle(tmp_path):
+    release = tmp_path / "release"
+    key = "v1/non_prehensile/Dexverse-PushT-v1"
+    source = write_demo(release / "demonstrations", key)
+    manifest = {"schema": SCHEMA, "tasks": [dict(key=k, task=k.split("/")[-1], episodes=0,
+                files=[], status="missing", reason="No data") for k in baseline_entries()]}
+    row = next(r for r in manifest["tasks"] if r["key"] == key)
+    row.update(episodes=50, status="complete", files=[dict(path=f"demonstrations/{key}/demos.pkl",
+               sha256=sha256(source), bytes=source.stat().st_size, episodes=50)])
+    (release / "demonstrations/release_manifest.json").write_text(json.dumps(manifest))
+    args = SimpleNamespace(all=False, baseline=False, category=[], task=["Dexverse-PushT-v1"],
+                           pattern=[], version="all", legacy=False)
+    selected, absent = select_release(manifest, _build_patterns(args))
+    assert len(selected) == 1 and not absent
+    fetch_selected(selected, tmp_path / "download", lambda name: release / name)
+    for root in (release, release / "demonstrations", tmp_path / "download"):
+        groups, warnings = discover_groups(root, tasks=["Dexverse-PushT-v1"])
+        assert not warnings and len(groups) == 1
+        assert groups[0].pickles[0].read_bytes() == source.read_bytes()
+    with pytest.raises(FileNotFoundError, match="missing"):
+        discover_groups(release, tasks=["Dexverse-OpenDoor-v1"])
+    source.write_bytes(b"corrupted")
+    with pytest.raises(ValueError, match="checksum"):
+        discover_groups(release, tasks=["Dexverse-PushT-v1"])
+
+
+def test_symlink_escape_and_review_need_explicit_file(tmp_path):
+    source = write_demo(tmp_path / "external", "v1/non_prehensile/Dexverse-PushT-v1")
+    root = tmp_path / "root"
+    root.mkdir()
+    (root / "v1").symlink_to(tmp_path / "external/v1", target_is_directory=True)
+    with pytest.raises(ValueError, match="escapes"):
+        discover_groups(root, tasks=["Dexverse-PushT-v1"])
+    groups, _ = discover_groups(root, files=[str(source)])
+    assert groups[0].pickles == [source] and groups[0].expected_task is None
+
+
+def test_legacy_is_explicit_and_filters_review_and_backups(tmp_path):
+    path = write_demo(tmp_path, "non_prehensile/Task/session")
+    write_demo(tmp_path, "_review/non_prehensile/Task/session")
+    write_demo(tmp_path, "non_prehensile/Task copy/session")
+    groups, _ = discover_groups(tmp_path, all_tasks=True, legacy_collections=True)
+    assert len(groups) == 1 and groups[0].pickles == [path]
+    assert groups[0].expected_task is None
+
+
+def test_wrong_payload_version_or_task_cannot_follow_path_label():
+    task = "Dexverse-PushT-v1"
+    validate_selected_identity(dict(task=task, env_name=task, task_version=1), task)
+    for payload in ({}, dict(task="Dexverse-PushT-v0"), dict(task=task, env_name="Dexverse-PushT-v0"),
+                    dict(task=task, task_version=0)):
+        with pytest.raises(ValueError):
+            validate_selected_identity(payload, task)
+
+
+def test_cli_selection_precedes_simulator_and_defaults_to_cpu():
+    source = (ROOT / "scripts/demo_tools/create_demo_files_sequential.py").read_text()
+    assert source.index("_selected_groups, _selection_warnings = discover_groups(") < source.index("app_launcher = AppLauncher(")
+    assert 'parser.set_defaults(device="cpu")' in source
+    tree = ast.parse(source)
+    convert = next(n for n in tree.body if isinstance(n, ast.FunctionDef) and n.name == "_convert_one_group")
+    calls = [n for n in ast.walk(convert) if isinstance(n, ast.Call)]
+    check = next(n for n in calls if ast.unparse(n.func) == "validate_selected_identity")
+    build = next(n for n in calls if ast.unparse(n.func) == "_build_env_for_pickle")
+    assert check.lineno < build.lineno
+
+
+def test_worker_keeps_exact_task_identity_and_nonselection_options(tmp_path):
+    group = PickleGroup("v1/non_prehensile/Dexverse-PushT-v1", "Dexverse-PushT-v1", tmp_path,
+                        [tmp_path / "demos.pkl"], "Dexverse-PushT-v1")
+    arguments = ["--task", "Dexverse-PushT-v0", "--task=Dexverse-PushT-v1", "--version", "all",
+                 "--demos-root=somewhere", "--all", "--device", "cpu", "--select-episodes", "0", "1",
+                 "--obs-groups", "state", "--output-dir", "out"]
+    result = worker_arguments(group, arguments)
+    assert result[:-2] == ["--device", "cpu", "--select-episodes", "0", "1", "--obs-groups", "state", "--output-dir", "out"]
+    data = json.loads(result[-1])
+    assert data["expected_task"] == group.expected_task and data["output_stem"] == group.output_stem
+    assert data["pickles"] == [str(tmp_path / "demos.pkl")]

--- a/scripts/env_tools/test_dispenser_cup_scale.py
+++ b/scripts/env_tools/test_dispenser_cup_scale.py
@@ -1,0 +1,133 @@
+"""CPU regressions for dispenser cup geometry and its task-local scale change."""
+
+from __future__ import annotations
+
+import __future__
+import ast
+import math
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+ROOT = Path(__file__).resolve().parents[2] / "source/dexverse/dexverse"
+sys.path.insert(0, str(ROOT.parent))
+CONFIG = ROOT / "baseline_v1/config/functional/place_cup_under_dispenser_cfg.py"
+
+
+def _compile(nodes, namespace):
+    # Use the actual config expressions/functions without simulator imports.
+    exec(compile(ast.Module(body=nodes, type_ignores=[]), str(CONFIG), "exec",
+                 flags=__future__.annotations.compiler_flag), namespace)
+
+
+def _config():
+    tree = ast.parse(CONFIG.read_text())
+    names = {"CUP_SCALE", "CUP_RADIUS", "CUP_HEIGHT", "CUP_UP_AXIS_LOCAL", "_S45",
+             "CUP_REST_ORIENTATIONS", "CUP_REST_ORDER", "STAGE_KEY", "CUP_SPAWN_BUFFER"}
+    namespace = {"math": math, "ForbiddenZone": SimpleNamespace}
+    _compile([node for node in tree.body if isinstance(node, ast.Assign)
+              and isinstance(node.targets[0], ast.Name) and node.targets[0].id in names], namespace)
+    cls = next(node for node in tree.body if isinstance(node, ast.ClassDef))
+    _compile([node for node in cls.body if isinstance(node, ast.AnnAssign)], namespace)
+    cfg = SimpleNamespace(**{node.target.id: namespace[node.target.id]
+                             for node in cls.body if isinstance(node, ast.AnnAssign)})
+    post = next(node for node in cls.body if isinstance(node, ast.FunctionDef) and node.name == "__post_init__")
+    return cfg, namespace, post
+
+
+def test_scale_reset_heights_and_rim_zone_are_consistent_and_v0_unchanged():
+    cfg, values, _ = _config()
+    assert cfg.object_scale == (0.81, 0.81, 0.81)
+    assert values["CUP_RADIUS"] == pytest.approx(0.034425)
+    assert values["CUP_HEIGHT"] == pytest.approx(0.09558)
+    orientations = values["CUP_REST_ORIENTATIONS"]
+    assert orientations["side"][1] == pytest.approx(values["CUP_RADIUS"] + 0.003)
+    assert orientations["upside_down"][1] == pytest.approx(values["CUP_HEIGHT"] + 0.003)
+    assert orientations["upright"][1] == 0.003
+    rim, = cfg.forbidden_zones
+    assert rim.center == pytest.approx((0, 0, 0.11 * 0.81))
+    assert rim.radius == pytest.approx(0.035 * 0.81)
+    assert rim.half_height == pytest.approx(0.005 * 0.81)
+    assert rim.radius < values["CUP_RADIUS"]
+    assert rim.center[2] + rim.half_height < values["CUP_HEIGHT"]
+    assert cfg.pour_goal_object_local_offset == pytest.approx((0, 0, 0.081))
+    for path in ("tasks/config/functional/grasp_cup_cfg.py", "baseline_v1/config/functional/grasp_cup_cfg.py"):
+        tree = ast.parse((ROOT / path).read_text())
+        fields = {node.target.id: node.value for node in ast.walk(tree) if isinstance(node, ast.AnnAssign)
+                  and isinstance(node.target, ast.Name)}
+        assert ast.literal_eval(fields["object_scale"]) == (0.9, 0.9, 0.9)
+        assert ast.literal_eval(fields["object_mass"]) == 0.2
+        assert ast.literal_eval(fields["object_static_friction"]) == 2.5
+
+
+def _placed_stage():
+    cfg, namespace, post = _config()
+    cfg.events = SimpleNamespace()
+    cfg.forbidden_zone_asset_cfg = lambda: SimpleNamespace(name="robot", body_ids=[0])
+    namespace.update(self=cfg, table_top_z=0.6, EventTerm=SimpleNamespace,
+                     SceneEntityCfg=lambda name: SimpleNamespace(name=name), SPOT_LOCAL=(0.0, 0.0, 0.012))
+    graphs = {}
+    namespace["mdp"] = SimpleNamespace(
+        reset_root_pose_uniform_orientations=object(), object_axis_upright=object(), object_placed_at_spot=object(),
+        StageGraphSpec=SimpleNamespace, StageSpec=SimpleNamespace,
+        register_stage_graph=lambda key, graph, **kwargs: graphs.update({key: graph}),
+    )
+    event = next(node for node in post.body if isinstance(node, ast.Assign)
+                 and ast.unparse(node.targets[0]) == "self.events.reset_cup")
+    register = next(node for node in post.body if isinstance(node, ast.Expr) and isinstance(node.value, ast.Call)
+                    and ast.unparse(node.value.func) == "mdp.register_stage_graph")
+    _compile([event, register], namespace)
+    assert cfg.events.reset_cup.params["orientations"] == list(namespace["CUP_REST_ORIENTATIONS"].values())
+    stage = graphs[namespace["STAGE_KEY"]].stages[1]
+    assert stage.params["object_radius"] == namespace["CUP_RADIUS"]
+    assert stage.params["object_axis_length"] == namespace["CUP_HEIGHT"]
+    return stage.params
+
+
+def test_smaller_release_geometry_keeps_30_step_hold_and_placement_tolerances():
+    params = _placed_stage()
+    assert params["hold_steps"] == 30
+    assert params["xy_tol"] == 0.03 and params["z_tol"] == 0.02
+    assert params["max_lin_speed"] == 0.05 and params["release_clearance"] == 0.02
+    namespace = {"torch": torch, "SceneEntityCfg": lambda name: SimpleNamespace(name=name),
+                 "quat_apply": lambda quat, vector: vector}  # All test orientations are identity.
+    tree = ast.parse((ROOT / "baseline_v1/mdp/terminations.py").read_text())
+    _compile([node for node in tree.body if isinstance(node, ast.FunctionDef)
+              and node.name in {"_points_to_segment_distance", "object_placed_at_spot"}], namespace)
+    evaluate = namespace["object_placed_at_spot"]
+    # Hand is beyond the new release radius but within the old one: ensures
+    # the stage actually consumes the new cup radius, not a stale 0.9 scale.
+    obj = SimpleNamespace(data=SimpleNamespace(root_pos_w=torch.tensor([[0., 0., 0.612]]),
+                          root_quat_w=torch.tensor([[1., 0., 0., 0.]]), root_lin_vel_w=torch.zeros(1, 3)))
+    spot = SimpleNamespace(data=SimpleNamespace(root_pos_w=torch.tensor([[0., 0., 0.6]]),
+                           root_quat_w=obj.data.root_quat_w))
+    robot = SimpleNamespace(data=SimpleNamespace(body_pos_w=torch.tensor([[[0.056, 0., 0.65]]])))
+    env = SimpleNamespace(scene={"object": obj, "dispenser": spot, "robot": robot}, num_envs=1,
+                          device="cpu", episode_length_buf=torch.tensor([1]))
+    for step in range(1, 31):
+        env.episode_length_buf.fill_(step)
+        assert evaluate(env, **params).item() == (step == 30)
+    robot.data.body_pos_w[0, 0, 0] = 0.04
+    assert not evaluate(env, **params).item()
+    assert env._placed_hold_state[params["cache_key"]]["count"].item() == 0
+
+
+def test_dispenser_revision_requires_review_for_earlier_cup_recordings():
+    from dexverse.benchmark import (
+        BENCHMARK_REVISION, DISPENSER_SMALL_CUP_REVISION, task_identity, validate_replay_identity,
+    )
+    task = "Dexverse-GraspCup-v1"
+    identity = task_identity(task)
+    assert identity["benchmark_revision"] == DISPENSER_SMALL_CUP_REVISION
+    validate_replay_identity({"task": task, **identity}, task)
+    for revision in (None, BENCHMARK_REVISION):
+        payload = {"task": task, "benchmark_revision": revision}
+        with pytest.raises(ValueError, match="smaller cup"):
+            validate_replay_identity(payload, task)
+        validate_replay_identity(payload, task, explicit_override=True)
+    baseline = "Dexverse-GraspCup-v0"
+    validate_replay_identity({"task": baseline, **task_identity(baseline)}, baseline)
+    assert task_identity("Dexverse-GraspBleach-v1")["benchmark_revision"] == BENCHMARK_REVISION

--- a/scripts/env_tools/test_faucet_spawn.py
+++ b/scripts/env_tools/test_faucet_spawn.py
@@ -1,0 +1,133 @@
+"""CPU checks for faucet v1 reach and whole-assembly tabletop clearance."""
+
+from __future__ import annotations
+
+import __future__
+import ast
+import itertools
+import math
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+import torch
+from scipy.spatial.transform import Rotation as R
+
+ROOT = Path(__file__).resolve().parents[2] / "source/dexverse/dexverse"
+sys.path.insert(0, str(ROOT.parent))
+CONFIG = ROOT / "baseline_v1/config/articulation/openfaucet_cfg.py"
+
+
+def _compile(nodes, namespace):
+    exec(compile(ast.Module(body=nodes, type_ignores=[]), str(CONFIG), "exec",
+                 flags=__future__.annotations.compiler_flag), namespace)
+
+
+def _defaults():
+    tree = ast.parse(CONFIG.read_text())
+    cls = next(node for node in tree.body if isinstance(node, ast.ClassDef))
+    names = {"articulation_init_pos", "articulation_init_rot", "articulation_scale",
+             "articulation_half_height_est", "articulation_reset_pose_range", "sink_scale",
+             "sink_init_rot", "sink_offset_from_faucet", "support_footprint", "success_threshold"}
+    namespace = {"math": math, "R": R}
+    _compile([node for node in cls.body if isinstance(node, ast.AnnAssign) and node.target.id in names], namespace)
+    return SimpleNamespace(**{name: namespace[name] for name in names})
+
+
+def test_faucet_is_closer_without_changing_yaw_size_or_success():
+    cfg = _defaults()
+    assert cfg.articulation_init_pos == (0.15, 0, 0)
+    ranges = cfg.articulation_reset_pose_range
+    assert np.array(ranges["x"]) + cfg.articulation_init_pos[0] == pytest.approx((0.1, 0.2))
+    assert ranges["y"] == [-0.1, 0.1]
+    assert ranges["yaw"] == [-3.14159, 3.14159]
+    assert all(ranges[axis] == [0, 0] for axis in ("z", "roll", "pitch"))
+    assert cfg.articulation_scale == (0.75, 0.75, 0.75)
+    assert cfg.sink_scale == (0.83, 0.83, 0.83)
+    assert cfg.articulation_half_height_est == 0.1
+    assert cfg.success_threshold == math.radians(80)
+    # Entire new root range is closer than the closest old root position.
+    assert math.hypot(0.2 - (-0.25), 0.1) < 0.3 - (-0.25)
+
+
+def test_full_assembly_fits_table_at_every_yaw():
+    from dexverse.assets import SYNTHESIS_DIR
+    from pxr import Usd, UsdGeom
+
+    def corners(relative_path):
+        stage = Usd.Stage.Open(str(SYNTHESIS_DIR / relative_path))
+        box = UsdGeom.BBoxCache(Usd.TimeCode.Default(), [UsdGeom.Tokens.default_]).ComputeWorldBound(
+            stage.GetDefaultPrim()).ComputeAlignedRange()
+        return np.array(list(itertools.product(*zip(box.GetMin(), box.GetMax()))))
+
+    cfg = _defaults()
+    faucet_rot = R.from_quat(cfg.articulation_init_rot, scalar_first=True)
+    sink_rot = R.from_quat(cfg.sink_init_rot, scalar_first=True)
+    sink_local = (faucet_rot.inv() * sink_rot).apply(corners("sink/sink.usd") * cfg.sink_scale)
+    sink_local += cfg.sink_offset_from_faucet
+    faucet_local = corners("faucet001/model_faucet_3.usd") * cfg.articulation_scale
+    radius = max(np.linalg.norm(sink_local[:, :2], axis=1).max(),
+                 np.linalg.norm(faucet_local[:, :2], axis=1).max(),
+                 np.linalg.norm(np.array(cfg.support_footprint) / 2))
+    assert radius < 0.48
+    # Read actual shared table dimensions: do not assume a test-only table size.
+    namespace = {}
+    tree = ast.parse((ROOT / "baseline_v1/dexverse_base_env_cfg.py").read_text())
+    _compile([node for node in tree.body if isinstance(node, ast.Assign)
+              and isinstance(node.targets[0], ast.Name)
+              and node.targets[0].id in {"DEFAULT_TABLE_THICKNESS", "DEFAULT_TABLE_SIZE"}], namespace)
+    for axis, key in enumerate(("x", "y")):
+        endpoints = np.array(cfg.articulation_reset_pose_range[key]) + cfg.articulation_init_pos[axis]
+        # A radial bound contains all rotated box corners for continuous yaw.
+        assert namespace["DEFAULT_TABLE_SIZE"][axis] / 2 - max(abs(endpoints)) - radius >= 0.07
+    assert 0.5 + radius > 0.75  # The old root range could overhang.
+
+
+def test_seeded_reset_uses_new_ranges_with_env_origins_and_subset_ids():
+    cfg = _defaults()
+
+    def quat_from_euler_xyz(roll, pitch, yaw):
+        values = torch.stack((roll, pitch, yaw), dim=-1).numpy()
+        return torch.tensor(R.from_euler("xyz", values).as_quat(scalar_first=True), dtype=yaw.dtype)
+
+    def quat_mul(left, right):
+        result = R.from_quat(left.numpy(), scalar_first=True) * R.from_quat(right.numpy(), scalar_first=True)
+        return torch.tensor(result.as_quat(scalar_first=True), dtype=left.dtype)
+
+    namespace = {"torch": torch, "quat_from_euler_xyz": quat_from_euler_xyz, "quat_mul": quat_mul}
+    for file, names in (("utils.py", {"resolve_env_ids"}), ("resets.py", {"reset_root_pose_uniform"})):
+        tree = ast.parse((ROOT / "baseline_v1/mdp" / file).read_text())
+        _compile([node for node in tree.body if isinstance(node, ast.FunctionDef) and node.name in names], namespace)
+    count = 256
+    states = torch.zeros(count, 13)
+    states[:, :3] = torch.tensor((0.15, 0.0, 0.6 + cfg.articulation_half_height_est))
+    states[:, 3:7] = torch.tensor(cfg.articulation_init_rot)
+    poses = torch.zeros(count, 7)
+    asset = SimpleNamespace(
+        data=SimpleNamespace(default_root_state=states), cfg=SimpleNamespace(),
+        write_root_pose_to_sim=lambda pose, env_ids: poses.__setitem__(env_ids, pose),
+        write_root_velocity_to_sim=lambda velocity, env_ids: None,
+    )
+
+    class Scene(dict):
+        pass
+
+    scene = Scene(articulation=asset)
+    scene.env_origins = torch.arange(count).unsqueeze(-1) * torch.tensor([[2.0, -3.0, 0.0]])
+    env = SimpleNamespace(scene=scene, num_envs=count, device="cpu")
+    params = dict(asset_cfg=SimpleNamespace(name="articulation"), pose_range=cfg.articulation_reset_pose_range)
+    reset = namespace["reset_root_pose_uniform"]
+    torch.manual_seed(42)
+    reset(env, None, **params)
+    first = poses.clone()
+    local = poses[:, :3] - scene.env_origins
+    assert local[:, 0].min() >= 0.1 - 1e-4 and local[:, 0].max() <= 0.2 + 1e-4
+    assert local[:, 1].abs().max() <= 0.1 + 1e-4
+    assert local[:, 0].std() > 0.025 and local[:, 1].std() > 0.05
+    reset(env, torch.tensor([1, 3]), **params)
+    torch.testing.assert_close(poses[[0, 2, 4]], first[[0, 2, 4]])
+    torch.manual_seed(42)
+    reset(env, None, **params)
+    torch.testing.assert_close(poses, first)

--- a/scripts/env_tools/test_goal_origins.py
+++ b/scripts/env_tools/test_goal_origins.py
@@ -1,0 +1,75 @@
+"""CPU regressions for the real v1 pose sampler across translated scenes."""
+
+import ast
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def command_classes():
+    path = ROOT / "source/dexverse/dexverse/baseline_v1/mdp/commands/pose_commands.py"
+    tree = ast.parse(path.read_text())
+    # Load the actual classes without starting Kit; only quaternion math and
+    # the unused manager constructor need stand-ins for these CPU cases.
+    nodes = [n for n in tree.body if isinstance(n, ast.ClassDef)]
+    namespace = {"CommandTerm": object, "torch": torch,
+                 "quat_from_euler_xyz": lambda r, p, y: torch.tensor([1., 0., 0., 0.]).repeat(len(r), 1),
+                 "quat_unique": lambda q: q, "quat_apply": lambda q, v: v}
+    import __future__
+
+    exec(compile(ast.Module(body=nodes, type_ignores=[]), str(path), "exec",
+                 flags=__future__.annotations.compiler_flag), namespace)
+    return namespace
+
+
+def make_command(tracking=False, world=True):
+    classes = command_classes()
+    cls = classes["ObjectAssetTrackingPoseCommand" if tracking else "ObjectUniformPoseCommand"]
+    cmd = cls.__new__(cls)
+    # CommandTerm exposes device via the environment; the CPU stand-in does not.
+    cmd.device = "cpu"
+    cmd.num_envs = 3
+    origins = torch.tensor([[0., 0., 0.], [1.5, -3., .5], [-1.5, 3., 1.]])
+    cmd._env = SimpleNamespace(scene=SimpleNamespace(env_origins=origins))
+    cmd.cfg = SimpleNamespace(use_world_frame=world, make_quat_unique=True,
+                             local_offset=(.1, .2, .3),
+                             ranges=SimpleNamespace(pos_x=(.4, .4), pos_y=(.1, .1), pos_z=(.8, .8),
+                                                    roll=(0., 0.), pitch=(0., 0.), yaw=(0., 0.)))
+    cmd.pose_command_b = torch.zeros(3, 7)
+    cmd.pose_command_w = torch.zeros(3, 7)
+    cmd._local_offset = torch.tensor(cmd.cfg.local_offset)
+    return cmd, origins
+
+
+@pytest.mark.parametrize("world", [True, False])
+def test_partial_resets_keep_goals_in_their_own_frame_without_accumulation(world):
+    cmd, origins = make_command(world=world)
+    cmd._resample_command([0, 1, 2])
+    expected = torch.tensor([[.4, .1, .8]]).repeat(3, 1)
+    if world:
+        expected += origins
+    torch.testing.assert_close(cmd.pose_command_b[:, :3], expected)
+    saved = cmd.pose_command_b[0].clone()
+    for _ in range(3):
+        cmd._resample_command(torch.tensor([1, 2]))
+        torch.testing.assert_close(cmd.pose_command_b[:, :3], expected)
+        torch.testing.assert_close(cmd.pose_command_b[0], saved)
+    if world:
+        torch.testing.assert_close(cmd.pose_command_w, cmd.pose_command_b)
+
+
+def test_asset_tracking_does_not_add_origin_twice():
+    cmd, origins = make_command(tracking=True)
+    cmd.target = SimpleNamespace(data=SimpleNamespace(
+        root_pos_w=origins + torch.tensor([.2, .3, .4]),
+        root_quat_w=torch.tensor([1., 0., 0., 0.]).repeat(3, 1)))
+    cmd._resample_command([0, 1, 2])
+    expected = cmd.target.data.root_pos_w + torch.tensor(cmd.cfg.local_offset)
+    torch.testing.assert_close(cmd.pose_command_b[:, :3], expected)
+    cmd.target.data.root_pos_w += .1
+    cmd._update_command()
+    torch.testing.assert_close(cmd.pose_command_w[:, :3], expected + .1)

--- a/scripts/env_tools/test_pusht_obstacles.py
+++ b/scripts/env_tools/test_pusht_obstacles.py
@@ -1,0 +1,228 @@
+"""CPU regressions for goal-local Push-T rods and swept XY/yaw reachability."""
+
+import ast
+import importlib.util
+import itertools
+import math
+from pathlib import Path
+import sys
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+import torch
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "source/dexverse"))
+PATH = ROOT / "source/dexverse/dexverse/baseline_v1/mdp/pusht_obstacles.py"
+spec = importlib.util.spec_from_file_location("pusht_layout", PATH)
+layout = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(layout)
+
+
+def test_t_bound_matches_actual_asset():
+    from pxr import Usd, UsdGeom
+    from dexverse.assets import DEXVERSE_AUTHORED_ASSETS_DIR
+    stage = Usd.Stage.Open(str(DEXVERSE_AUTHORED_ASSETS_DIR / "push_t/tee.usda"))
+    bounds = UsdGeom.BBoxCache(Usd.TimeCode.Default(), [UsdGeom.Tokens.default_]).ComputeWorldBound(stage.GetDefaultPrim()).ComputeAlignedRange()
+    lo, hi = np.array(bounds.GetMin()), np.array(bounds.GetMax())
+    np.testing.assert_allclose(np.array(layout.TEE_XY_BOUNDS), np.stack((lo[:2], hi[:2]), axis=-1), atol=1e-7)
+    corners = np.array(list(itertools.product(*layout.TEE_XY_BOUNDS)))
+    assert np.linalg.norm(corners, axis=1).max() == pytest.approx(layout.TEE_ROOT_RADIUS)
+    for i, name in enumerate(("bar_horizontal", "bar_vertical")):
+        box = UsdGeom.BBoxCache(Usd.TimeCode.Default(), [UsdGeom.Tokens.default_]).ComputeWorldBound(
+            stage.GetPrimAtPath(f"/tee/{name}")).ComputeAlignedRange()
+        lo, hi = np.array(box.GetMin()), np.array(box.GetMax())
+        np.testing.assert_allclose((lo[:2] + hi[:2]) / 2, layout.TEE_RECT_CENTERS[i], atol=1e-7)
+        np.testing.assert_allclose((hi[:2] - lo[:2]) / 2, layout.TEE_RECT_HALF_SIZES[i], atol=1e-7)
+    assert layout.ROD_MIN_SPACING - 2 * layout.ROD_RADIUS == pytest.approx(.15)
+
+
+def independently_check_path(path, rods, *, table_center=(0., 0.)):
+    """Dense world-polygon checks independent of the planner's local boxes."""
+    for start, end in zip(path[:-1], path[1:]):
+        delta = end - start
+        delta[2] = (delta[2] + math.pi) % (2 * math.pi) - math.pi
+        travel = np.linalg.norm(delta[:2]) + layout.TEE_ROOT_RADIUS * abs(delta[2])
+        n = max(1, int(np.ceil(travel / .002)))
+        poses = start + np.linspace(0., 1., n + 1)[:, None] * delta
+        for center, half in zip(layout.TEE_RECT_CENTERS, layout.TEE_RECT_HALF_SIZES):
+            local = center + half * np.array([[-1, -1], [1, -1], [1, 1], [-1, 1]])
+            c, s = np.cos(poses[:, 2]), np.sin(poses[:, 2])
+            rotation = np.stack((c, -s, s, c), axis=-1).reshape(-1, 2, 2)
+            vertices = np.einsum("nij,kj->nki", rotation, local) + poses[:, None, :2]
+            assert (np.abs(vertices - table_center) <= .75 - layout.PATH_MARGIN + 1e-7).all()
+            edge = np.roll(vertices, -1, axis=1) - vertices
+            relative = rods[None, None, :, :] - vertices[:, :, None, :]
+            t = np.clip((relative * edge[:, :, None, :]).sum(-1) / (edge * edge).sum(-1)[:, :, None], 0, 1)
+            distance = np.linalg.norm(relative - t[..., None] * edge[:, :, None, :], axis=-1)
+            assert distance.min() >= layout.ROD_RADIUS + layout.PATH_MARGIN - 1e-7
+            cross = edge[:, :, None, 0] * relative[..., 1] - edge[:, :, None, 1] * relative[..., 0]
+            assert not (cross >= 0).all(axis=1).any(), "Rod inside T bar"
+
+
+def test_dense_uniform_proposals_block_direct_route_but_have_clear_detour():
+    torch.manual_seed(42)
+    samples = layout.sample_layouts(64)
+    rods = samples[:, 6:].reshape(-1, layout.ROD_COUNT, 2)
+    r = layout.TEE_CLEARANCE_RADIUS
+    assert layout.ROD_COUNT == 10 and layout.ROD_HEIGHT == .04
+    assert (rods.abs() + layout.ROD_RADIUS < .75).all()
+    distance = torch.cdist(rods, rods) + torch.eye(layout.ROD_COUNT).unsqueeze(0) * 10
+    assert distance.min() >= layout.ROD_MIN_SPACING - 1e-6
+    assert distance.min() < .20, "Sampling must actually use the tighter spacing"
+    radius = torch.linalg.vector_norm(rods - samples[:, None, 3:5], dim=-1)
+    assert radius.min() >= layout.GOAL_ROD_RADII[0] - 1e-6
+    assert radius.max() <= layout.GOAL_ROD_RADII[1] + 1e-6
+    for point in (samples[:, :2], samples[:, 3:5]):
+        assert (point.abs() < .75 - r).all()
+    assert torch.linalg.vector_norm(samples[:, :2] - samples[:, 3:5], dim=-1).min() >= layout.START_GOAL_MIN_DISTANCE - 1e-6
+    assert ((samples[:, [2, 5]] >= 0) & (samples[:, [2, 5]] < 2 * math.pi)).all()
+    # Sequential proposals are diverse, not a fixed grid or identical ring.
+    assert (rods.std(0) > .10).all()
+    for i in range(layout.ROD_COUNT):
+        assert torch.unique(rods[:, i, 0]).numel() == len(samples)
+    assert layout.direct_path_blocked(samples[:, :2].numpy(), samples[:, 3:5].numpy(), rods.numpy()).all()
+    for row, obstacles in zip(samples.numpy(), rods.numpy()):
+        bearing = np.sort(np.arctan2(obstacles[:, 1] - row[4], obstacles[:, 0] - row[3]))
+        assert np.diff(np.r_[bearing, bearing[0] + 2 * math.pi]).max() <= layout.MAX_ROD_ANGULAR_GAP + 1e-6
+        path = layout.find_clear_path(row[:3], row[3:6], obstacles)
+        assert path is not None
+        np.testing.assert_allclose(path[0], row[:3])
+        np.testing.assert_allclose(path[-1], row[3:6])
+        independently_check_path(path, obstacles)
+        assert np.linalg.norm(np.diff(path[:, :2], axis=0), axis=-1).sum() > np.linalg.norm(row[:2] - row[3:5])
+
+
+def test_seed_repeatability_and_partial_batch():
+    torch.manual_seed(42)
+    first = layout.sample_layouts(5)
+    torch.manual_seed(43)
+    different = layout.sample_layouts(5)
+    torch.manual_seed(42)
+    torch.testing.assert_close(layout.sample_layouts(5), first)
+    assert not torch.equal(first, different)
+    assert layout.sample_layouts(0).shape == (0, 6 + 2 * layout.ROD_COUNT)
+
+
+def test_no_unsafe_fallback_for_impossible_settings():
+    with pytest.raises(ValueError, match="Table too small"):
+        layout.sample_layouts(1, table_size=(.5, .5))
+    with pytest.raises(RuntimeError, match="within budget"):
+        layout.sample_layouts(1, spawn_x=(0., .001), spawn_y=(0., .001), max_rounds=2)
+
+
+def test_planner_rejects_wall_and_handles_shifted_table():
+    start, goal = np.array([-.4, 0., 0.]), np.array([.4, 0., math.pi])
+    wall = np.stack((np.zeros(51), np.linspace(-.75, .75, 51)), axis=-1)
+    assert layout.direct_path_blocked(start[:2], goal[:2], wall)
+    assert layout.find_clear_path(start, goal, wall) is None
+    obstacle = np.array([[0., 0.]])
+    path = layout.find_clear_path(start, goal, obstacle)
+    assert path is not None
+    shift = np.array([2., -3., 0.])
+    shifted = layout.find_clear_path(start + shift, goal + shift, obstacle + shift[:2], table_center=shift[:2])
+    assert shifted is not None
+    np.testing.assert_allclose(shifted[[0, -1]] - shift, [start, goal])
+
+
+def test_actual_shape_allows_clear_notches_and_checks_swept_rotation():
+    pose = np.zeros(3)
+    rod = np.array([[.08, .10]])  # Inside bounding box, outside both actual bars.
+    assert layout.pose_clearance(pose, rod) > layout.PATH_MARGIN
+    assert np.linalg.norm(rod[0]) < layout.TEE_CLEARANCE_RADIUS + layout.ROD_RADIUS
+    assert layout.pose_clearance(np.array([0., 0., math.pi]), rod) > layout.PATH_MARGIN
+    assert not layout.motion_is_clear(pose, np.array([0., 0., math.pi]), rod)
+    # Seam connection must take the short turn, not an almost-full revolution.
+    assert layout.motion_is_clear(np.array([0., 0., .01]), np.array([0., 0., 2 * math.pi - .01]), rod)
+    assert layout.pose_clearance(pose, np.array([[0., 0.]])) < 0
+    assert layout.pose_clearance(np.array([.72, 0., 0.]), np.empty((0, 2))) < 0
+
+
+def test_planner_turns_through_passage_that_rejects_rotation_envelope():
+    # Synthetic channel narrower than the old 37 cm rotation envelope. The
+    # starting yaw cannot translate through it; a changed yaw fits the real T.
+    rods = np.array([(x, y) for x in np.linspace(-.21, .21, 15) for y in (-.15, .15)])
+    start, goal = np.array([-.45, 0., math.pi / 4]), np.array([.45, 0., math.pi / 4])
+    assert not layout.motion_is_clear(start, goal, rods)
+    path = layout.find_clear_path(start, goal, rods)
+    assert path is not None
+    assert np.abs(path[:, 1]).max() < .04  # Through the channel, not around it.
+    assert np.abs(layout.angle_delta(start[2], path[:, 2])).max() > .20
+    independently_check_path(path, rods)
+
+
+def test_sampler_supports_translated_table():
+    torch.manual_seed(123)
+    first = layout.sample_layouts(2)
+    torch.manual_seed(123)
+    shifted = layout.sample_layouts(2, table_center=(2., -3.))
+    first[:, :2] += torch.tensor([2., -3.])
+    first[:, 3:5] += torch.tensor([2., -3.])
+    first[:, 6:] += torch.tensor([2., -3.] * layout.ROD_COUNT)
+    torch.testing.assert_close(shifted, first)
+
+
+def test_all_ten_collision_rods_declared():
+    path = ROOT / "source/dexverse/dexverse/baseline_v1/config/non_prehensile/pusht_cfg.py"
+    tree = ast.parse(path.read_text())
+    scene = next(n for n in tree.body if isinstance(n, ast.ClassDef) and n.name == "PushTSceneCfg")
+    rods = {n.target.id for n in scene.body if isinstance(n, ast.AnnAssign) and n.target.id.startswith("push_t_rod_")}
+    assert rods == set(layout.ROD_NAMES)
+
+
+class Asset:
+    def __init__(self, count, z, dynamic=False):
+        self.dynamic = dynamic
+        default = torch.zeros(count, 13)
+        default[:, 2], default[:, 3] = z, 1
+        self.data = SimpleNamespace(default_root_state=default, root_pos_w=torch.zeros(count, 3))
+        self.pose = default[:, :7].clone()
+        self.velocity = torch.ones(count, 6)
+
+    def write_root_pose_to_sim(self, pose, env_ids):
+        self.pose[env_ids] = pose
+        self.data.root_pos_w[env_ids] = pose[:, :3]
+
+    def write_root_velocity_to_sim(self, values, env_ids):
+        assert self.dynamic, "Must not write kinematic rod/goal velocities"
+        self.velocity[env_ids] = values
+
+
+def test_reset_subset_origins_and_kinematic_pose_only():
+    class Scene(dict):
+        pass
+    scene = Scene(object=Asset(4, .621, True), goal_tee=Asset(4, .603), table=Asset(4, .575))
+    scene.update({name: Asset(4, .62) for name in layout.ROD_NAMES})
+    scene.env_origins = torch.tensor([[0., 0., 0.], [3., 0., 0.], [0., 3., 0.], [3., 3., 0.]])
+    env = SimpleNamespace(scene=scene, num_envs=4, device="cpu")
+    ids = torch.tensor([1, 3])
+    torch.manual_seed(42)
+    layout.reset_push_t_with_rods(env, ids)
+    first = scene['object'].pose.clone()
+    assert scene['object'].pose[[0, 2], :2].count_nonzero() == 0
+    torch.testing.assert_close(scene['object'].velocity[ids], torch.zeros(2, 6))
+    assert scene['object'].pose[ids, 0].min() > 2.5
+    assert scene['push_t_rod_0'].pose[ids, 2].tolist() == pytest.approx([.62, .62])
+    torch.manual_seed(42)
+    layout.reset_push_t_with_rods(env, ids)
+    torch.testing.assert_close(scene['object'].pose, first)
+    assert layout.rod_positions_in_table(env).shape == (4, 30)
+
+
+def test_only_v1_has_rods_looser_success_and_revision_guard():
+    v1 = ROOT / "source/dexverse/dexverse/baseline_v1/config/non_prehensile/pusht_cfg.py"
+    v0 = ROOT / "source/dexverse/dexverse/tasks/config/non_prehensile/pusht_cfg.py"
+    def threshold(path):
+        tree = ast.parse(path.read_text())
+        return next(ast.literal_eval(n.value) for n in tree.body if isinstance(n, ast.Assign)
+                    and ast.unparse(n.targets[0]) == "OVERLAP_SUCCESS_THRESHOLD")
+    assert threshold(v1) == .70 and threshold(v0) == .90
+    assert "push_t_rod_0" in v1.read_text() and "push_t_rod" not in v0.read_text()
+    from dexverse.benchmark import task_identity, validate_replay_identity, BENCHMARK_REVISION
+    identity = task_identity("Dexverse-PushT-v1")
+    validate_replay_identity({"task": "Dexverse-PushT-v1", **identity}, "Dexverse-PushT-v1")
+    for old in (None, BENCHMARK_REVISION, "push-t-orange-rods-v1-2026-09-10",
+                "push-t-ten-low-rods-detour-v1-2026-09-10"):
+        with pytest.raises(ValueError, match="orange rods"):
+            validate_replay_identity({"task": "Dexverse-PushT-v1", "benchmark_revision": old}, "Dexverse-PushT-v1")

--- a/scripts/env_tools/test_seed_controls.py
+++ b/scripts/env_tools/test_seed_controls.py
@@ -1,0 +1,132 @@
+"""Simulator-free regressions for launcher seed plumbing and recording metadata."""
+
+from __future__ import annotations
+
+import __future__
+import argparse
+import ast
+import os
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "source/dexverse"))
+from dexverse.benchmark import task_identity  # noqa: E402
+from dexverse.teleop_utils.debug_visualization import configure_v1_debug_visualization  # noqa: E402
+
+
+def tree(script):
+    return ast.parse((ROOT / "scripts" / script).read_text())
+
+
+def test_replay_seed_applied_after_robot_rebuild_before_make():
+    tree = ast.parse((ROOT / "scripts/demo_tools/create_demo_files_sequential.py").read_text())
+    build = next(n for n in tree.body if isinstance(n, ast.FunctionDef) and n.name == "_build_env_for_pickle")
+    assignments = [n for n in ast.walk(build) if isinstance(n, ast.Assign)]
+    rebuild = next(n for n in assignments if ast.unparse(n).startswith("env_cfg = cfg_cls("))
+    seed = next(n for n in assignments if ast.unparse(n) == "env_cfg.seed = args_cli.seed")
+    make = next(n for n in assignments if ast.unparse(n).startswith("env = gym.make("))
+    assert rebuild.lineno < seed.lineno < make.lineno
+
+
+def load_node(node, namespace):
+    # Avoid importing launch scripts, which would start Isaac Sim / XR.
+    exec(compile(ast.Module(body=[node], type_ignores=[]), "<seed-test>", "exec",
+                 flags=__future__.annotations.compiler_flag), namespace)
+
+
+@pytest.mark.parametrize("script,default", [
+    ("record_demos.py", None), ("teleop_agent.py", None), ("zero_agent.py", None),
+    ("env_tools/check_task_upgrades.py", 42),
+])
+def test_seed_cli_accepts_fixed_and_omitted_seed(script, default):
+    parser = argparse.ArgumentParser()
+    node = next(node for node in tree(script).body if isinstance(node, ast.Expr)
+                and isinstance(node.value, ast.Call) and node.value.args
+                and isinstance(node.value.args[0], ast.Constant) and node.value.args[0].value == "--seed")
+    load_node(node, {"parser": parser})
+    assert parser.parse_args([]).seed == default
+    assert parser.parse_args(["--seed", "4200"]).seed == 4200
+
+
+@pytest.mark.parametrize("seed,expected", [(1000, 1000), (-1, -1), (None, 42)])
+def test_collection_seed_survives_robot_config_rebuild(seed, expected):
+    class Config:
+        def __init__(self, **kwargs):
+            self.seed = 42
+            self.robot_type = kwargs.get("robot_type", "old_robot")
+            self.sim = SimpleNamespace(device="cpu")
+            self.scene = SimpleNamespace(num_envs=5)
+            self.terminations = SimpleNamespace(success=object(), time_out=object())
+            self.observations = SimpleNamespace(policy=SimpleNamespace(concatenate_terms=True))
+
+    args = SimpleNamespace(task="Dexverse-OpenDoor-v1", device="cuda:0", json_path=None,
+                           robot_type="floating_shadow_right", usd_path=None,
+                           enable_debug_vis=None, seed=seed, xr=False, cues_in_rgb=False)
+    node = next(node for node in tree("record_demos.py").body
+                if isinstance(node, ast.FunctionDef) and node.name == "create_environment_config")
+    namespace = {"args_cli": args, "parse_env_cfg": lambda *a, **k: Config(),
+                 "configure_v1_debug_visualization": configure_v1_debug_visualization}
+    load_node(node, namespace)
+    cfg, success = namespace[node.name]()
+    assert cfg.seed == expected
+    assert cfg.robot_type == "floating_shadow_right" and cfg.scene.num_envs == 1
+    assert success is not None and cfg.terminations.success is None
+
+
+@pytest.mark.parametrize("script", ["zero_agent.py", "teleop_agent.py"])
+def test_preview_seed_is_applied_after_overrides_and_before_gym_make(script):
+    main = next(node for node in tree(script).body if isinstance(node, ast.FunctionDef) and node.name == "main")
+    seed_write = next(node for node in ast.walk(main) if isinstance(node, ast.Assign)
+                      and ast.unparse(node).startswith("env_cfg.seed = args_cli.seed"))
+    override = next(node for node in ast.walk(main) if isinstance(node, ast.Call)
+                    and ast.unparse(node.func) == "_apply_hydra_env_overrides")
+    spawn = next(node for node in ast.walk(main) if isinstance(node, ast.Call)
+                 and ast.unparse(node.func) == "gym.make")
+    assert override.lineno < seed_write.lineno < spawn.lineno
+
+
+@pytest.mark.parametrize("device", ["cpu", "cuda:0", None])
+def test_recorder_keeps_resolved_seed_and_device_in_session_metadata(tmp_path, device):
+    node = next(node for node in tree("record_demos.py").body
+                if isinstance(node, ast.ClassDef) and node.name == "TrajectoryPickleRecorder")
+    namespace = {"os": os, "task_identity": task_identity}
+    load_node(node, namespace)
+    recorder = namespace[node.name](str(tmp_path / "seeded.pkl"), task_name="Dexverse-OpenDoor-v1",
+                                    env_name="Dexverse-OpenDoor-v1", seed=1000, sim_device=device)
+    assert recorder._metadata["seed"] == 1000
+    assert recorder._metadata["sim_device"] == device
+    assert recorder._metadata["benchmark_revision"] == task_identity("Dexverse-OpenDoor-v1")["benchmark_revision"]
+
+
+def test_collection_defaults_to_cpu_and_records_actual_environment_device():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--device", default="cuda:0")
+    parser.add_argument("--rendering_mode", default="balanced")
+    module = tree("record_demos.py")
+    defaults = next(node for node in module.body if isinstance(node, ast.Expr)
+                    and isinstance(node.value, ast.Call) and ast.unparse(node.value.func) == "parser.set_defaults")
+    load_node(defaults, {"parser": parser})
+    assert parser.parse_args([]).device == "cpu"
+    assert parser.parse_args([]).rendering_mode == "performance"
+    assert parser.parse_args(["--device", "cuda:0"]).device == "cuda:0"
+    main = next(node for node in module.body if isinstance(node, ast.FunctionDef) and node.name == "main")
+    recorder = next(node for node in ast.walk(main) if isinstance(node, ast.Call)
+                    and ast.unparse(node.func) == "TrajectoryPickleRecorder")
+    assert any(kw.arg == "sim_device" and ast.unparse(kw.value) == "str(env.device)" for kw in recorder.keywords)
+
+
+def test_repeatability_comparison_rejects_different_reset_values():
+    node = next(node for node in tree("env_tools/check_task_upgrades.py").body
+                if isinstance(node, ast.FunctionDef) and node.name == "compare_state")
+    namespace = {"torch": torch}
+    load_node(node, namespace)
+    compare = namespace[node.name]
+    value = {"object": {"root_pose": torch.zeros((2, 7))}}
+    compare(value, {"object": {"root_pose": torch.zeros((2, 7))}})
+    with pytest.raises(AssertionError):
+        compare(value, {"object": {"root_pose": torch.ones((2, 7))}})

--- a/scripts/env_tools/test_stapler_contact_filters.py
+++ b/scripts/env_tools/test_stapler_contact_filters.py
@@ -1,0 +1,122 @@
+"""CPU regressions for explicit bimanual stapler-release contact filters."""
+
+from __future__ import annotations
+
+import __future__
+import ast
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import torch
+from pxr import Usd, UsdGeom, UsdPhysics
+
+ROOT = Path(__file__).resolve().parents[2] / "source/dexverse/dexverse"
+CONFIG = ROOT / "baseline_v1/config/articulation/reload_stapler_cfg.py"
+ROBOT_USD = ROOT / "robot_agents/shadow/floating_shadow_bimanual/floating_shadow_bimanual.usd"
+
+
+def _compile(nodes, namespace):
+    # Avoid launching Isaac Sim just to inspect the actual config expressions.
+    exec(compile(ast.Module(body=nodes, type_ignores=[]), str(CONFIG), "exec",
+                 flags=__future__.annotations.compiler_flag), namespace)
+
+
+def _resolver():
+    tree = ast.parse(CONFIG.read_text())
+    node = next(node for node in tree.body if isinstance(node, ast.FunctionDef)
+                and node.name == "_robot_contact_filter_paths")
+    namespace = {}
+    _compile([node], namespace)
+    return namespace[node.name]
+
+
+def test_real_bimanual_usd_resolves_each_body_without_joint_or_material_scopes():
+    paths = _resolver()(str(ROBOT_USD), "{ENV_REGEX_NS}/Robot")
+    stage = Usd.Stage.Open(str(ROBOT_USD))
+    root = stage.GetDefaultPrim()
+    assert len(root.GetChildren()) == 74  # Reproduces the erroneous wildcard count.
+    assert len(paths) == len(set(paths)) == 71
+    for side in ("lh", "rh"):
+        assert f"{{ENV_REGEX_NS}}/Robot/{side}_palm" in paths
+        assert f"{{ENV_REGEX_NS}}/Robot/{side}_ffmiddle" in paths
+        assert f"{{ENV_REGEX_NS}}/Robot/{side}_thtip" in paths
+    for path in paths:
+        relative = path.removeprefix("{ENV_REGEX_NS}/Robot/")
+        assert "*" not in relative and "(" not in relative
+        assert stage.GetPrimAtPath(root.GetPath().AppendPath(relative)).HasAPI(UsdPhysics.RigidBodyAPI)
+    assert not any(path.endswith(("/Looks", "/joints", "/root_joint")) for path in paths)
+
+
+def test_resolver_handles_nested_and_root_bodies_and_rejects_empty_robot(tmp_path):
+    path = tmp_path / "robot.usda"
+    stage = Usd.Stage.CreateNew(str(path))
+    root = UsdGeom.Xform.Define(stage, "/Root").GetPrim()
+    stage.SetDefaultPrim(root)
+    stage.GetRootLayer().Save()
+    resolve = _resolver()
+    with pytest.raises(ValueError, match="No robot rigid bodies"):
+        resolve(str(path), "{ENV_REGEX_NS}/SelectedRobot")
+    UsdPhysics.RigidBodyAPI.Apply(root)
+    body = UsdGeom.Xform.Define(stage, "/Root/assembly/finger").GetPrim()
+    UsdPhysics.RigidBodyAPI.Apply(body)
+    stage.GetRootLayer().Save()
+    assert resolve(str(path), "{ENV_REGEX_NS}/SelectedRobot") == [
+        "{ENV_REGEX_NS}/SelectedRobot", "{ENV_REGEX_NS}/SelectedRobot/assembly/finger",
+    ]
+
+
+def test_all_three_release_sensors_are_wired_to_explicit_robot_filters():
+    tree = ast.parse(CONFIG.read_text())
+    namespace = {"_robot_contact_filter_paths": _resolver(), "ContactSensorCfg": SimpleNamespace}
+    _compile([node for node in tree.body if isinstance(node, ast.Assign)
+              and isinstance(node.targets[0], ast.Name)
+              and node.targets[0].id in {"STAPLER_LINKS", "TARGET_TABLE_HEIGHTS", "TARGET_TABLE_PRIM_PATHS"}], namespace)
+    cls = next(node for node in tree.body if isinstance(node, ast.ClassDef))
+    post = next(node for node in cls.body if isinstance(node, ast.FunctionDef) and node.name == "__post_init__")
+    start = next(i for i, node in enumerate(post.body) if isinstance(node, ast.Assign)
+                 and ast.unparse(node.targets[0]) == "target_filter_paths")
+    end = next(i for i, node in enumerate(post.body) if isinstance(node, ast.For)
+               and ast.unparse(node.iter) == "STAPLER_LINKS")
+    scene = SimpleNamespace(robot=SimpleNamespace(
+        spawn=SimpleNamespace(usd_path=str(ROBOT_USD)), prim_path="{ENV_REGEX_NS}/Robot",
+    ))
+    namespace["self"] = SimpleNamespace(scene=scene)
+    _compile(post.body[start:end + 1], namespace)
+    names = namespace["robot_contact_sensor_names"]
+    assert len(names) == 3
+    for link, name in zip(namespace["STAPLER_LINKS"], names, strict=True):
+        sensor = getattr(scene, name)
+        assert sensor.prim_path == f"{{ENV_REGEX_NS}}/Articulation/{link}"
+        assert sensor.filter_prim_paths_expr == namespace["robot_filter_paths"]
+        assert getattr(scene, f"{link}_target_tables_s").filter_prim_paths_expr == list(
+            namespace["TARGET_TABLE_PRIM_PATHS"])
+    success = next(node for node in post.body if isinstance(node, ast.Assign)
+                   and ast.unparse(node.targets[0]) == "self.terminations.success.params")
+    params = {ast.literal_eval(key): ast.unparse(value) for key, value in zip(success.value.keys, success.value.values)}
+    assert params["robot_sensor_names"] == "robot_contact_sensor_names"
+    assert params["robot_force_threshold"] == "self.release_contact_force_threshold"
+    assert params["hold_steps"] == "self.success_hold_steps"
+
+
+def test_release_force_reduction_checks_both_hands_and_every_sensor():
+    tree = ast.parse((ROOT / "baseline_v1/mdp/terminations.py").read_text())
+    cls = next(node for node in tree.body if isinstance(node, ast.ClassDef)
+               and node.name == "joint_pose_contact_release_hold_success")
+    helper = next(node for node in cls.body if isinstance(node, ast.FunctionDef)
+                  and node.name == "_sensors_exceed_force")
+    helper.decorator_list = []
+    namespace = {"torch": torch}
+    _compile([helper], namespace)
+    evaluate = namespace[helper.name]
+    paths = _resolver()(str(ROBOT_USD), "{ENV_REGEX_NS}/Robot")
+    sensors = {f"sensor_{i}": SimpleNamespace(data=SimpleNamespace(
+        force_matrix_w=torch.zeros(2, 1, len(paths), 3))) for i in range(3)}
+    env = SimpleNamespace(num_envs=2, device="cpu", scene=SimpleNamespace(sensors=sensors))
+    assert not evaluate(env, list(sensors), 0.1).any()
+    for sensor in sensors.values():
+        for side in ("lh", "rh"):
+            column = paths.index(f"{{ENV_REGEX_NS}}/Robot/{side}_palm")
+            sensor.data.force_matrix_w[1, 0, column, 0] = 0.11
+            assert evaluate(env, list(sensors), 0.1).tolist() == [False, True]
+            sensor.data.force_matrix_w.zero_()

--- a/scripts/env_tools/test_task_upgrade_data.py
+++ b/scripts/env_tools/test_task_upgrade_data.py
@@ -1,0 +1,369 @@
+# Copyright (c) 2025-2026, The DexVerse Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""CPU regressions for replay-critical data and local procedural assets."""
+
+from __future__ import annotations
+
+import ast
+import importlib.util
+import pickle
+import subprocess
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+import torch
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "source" / "dexverse"))
+
+from dexverse.benchmark import (  # noqa: E402
+    BASELINE_TASKS,
+    BASELINE_V1_TASKS,
+    BASELINE_PAIRS,
+    V1_CONFIGS,
+    LEGACY_UPGRADE_TASKS,
+    BENCHMARK_REVISION,
+    LEGACY_UPGRADE_REVISION,
+    V0_BENCHMARK_REVISION,
+    baseline_tasks,
+    task_identity,
+    validate_replay_identity,
+)
+from dexverse.teleop_utils.episode_task_state import (  # noqa: E402
+    capture_episode_task_state,
+    restore_episode_task_state,
+    reset_managers_after_state_restore,
+)
+
+
+def _script(name):
+    path = ROOT / "scripts" / "demo_tools" / f"{name}.py"
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_state_replay_updates_last_action_without_processing_actions():
+    # Importing the replay entry point launches Isaac Sim. Compile just this
+    # pure buffer helper so the regression can run in the shared CPU environment.
+    path = ROOT / "scripts" / "demo_tools" / "create_demo_files_sequential.py"
+    tree = ast.parse(path.read_text())
+    helper = next(node for node in tree.body if isinstance(node, ast.FunctionDef) and node.name == "_set_last_action")
+    namespace = {"torch": torch}
+    exec(compile(ast.Module(body=[helper], type_ignores=[]), str(path), "exec"), namespace)
+    update = namespace["_set_last_action"]
+    manager = SimpleNamespace(device="cpu", _action=torch.zeros(1, 3), _prev_action=torch.zeros(1, 3))
+    env = SimpleNamespace(action_manager=manager)
+    current_buffer, previous_buffer = manager._action, manager._prev_action
+    first = torch.tensor([[0.2, -0.4, 0.6]])
+    second = torch.tensor([[-0.1, 0.3, -0.5]])
+    update(env, first)
+    torch.testing.assert_close(manager._action, first)
+    torch.testing.assert_close(manager._prev_action, torch.zeros_like(first))
+    update(env, second)
+    torch.testing.assert_close(manager._action, second)
+    torch.testing.assert_close(manager._prev_action, first)
+    assert manager._action is current_buffer and manager._prev_action is previous_buffer
+    second.zero_()
+    torch.testing.assert_close(manager._action, torch.tensor([[-0.1, 0.3, -0.5]]))
+    update(SimpleNamespace(), first)
+
+
+@pytest.mark.parametrize(
+    "needs_cameras,strip_cameras,expected", [(True, True, True), (False, False, True), (False, True, False)]
+)
+def test_replay_enables_camera_support_when_sensors_are_retained(needs_cameras, strip_cameras, expected):
+    path = ROOT / "scripts" / "demo_tools" / "create_demo_files_sequential.py"
+    tree = ast.parse(path.read_text())
+    condition = next(
+        node for node in tree.body if isinstance(node, ast.If) and "_NEEDS_CAMERAS" in ast.unparse(node.test)
+    )
+    args = SimpleNamespace(strip_cameras=strip_cameras, enable_cameras=False)
+    namespace = {"_NEEDS_CAMERAS": needs_cameras, "args_cli": args}
+    exec(compile(ast.Module(body=[condition], type_ignores=[]), str(path), "exec"), namespace)
+    assert args.enable_cameras is expected
+
+
+def test_task_state_restores_goals_and_categorical_choice_without_aliasing():
+    command = SimpleNamespace(
+        pose_command_b=torch.arange(14.0).reshape(2, 7),
+        pose_command_w=torch.arange(14.0).reshape(2, 7).clone(),
+        cfg=SimpleNamespace(use_world_frame=True),
+    )
+    env = SimpleNamespace(
+        device="cpu",
+        num_envs=2,
+        cfg=SimpleNamespace(events=SimpleNamespace(face=SimpleNamespace(params={"buffer_name": "face"}))),
+        face=torch.tensor([2, 5]),
+        command_manager=SimpleNamespace(active_terms=["object_pose"], get_term=lambda _: command),
+    )
+    snapshot = capture_episode_task_state(env, env_index=1)
+    env.face[1] = 0
+    command.pose_command_b[1].zero_()
+    command.pose_command_w[1].zero_()
+    assert snapshot["env_buffers"]["face"].item() == 5
+    assert restore_episode_task_state(env, snapshot, env_index=1) == []
+    assert env.face.tolist() == [2, 5]
+    torch.testing.assert_close(command.pose_command_b[1], torch.arange(7.0, 14.0))
+    torch.testing.assert_close(command.pose_command_w[1], command.pose_command_b[1])
+    torch.testing.assert_close(command.pose_command_b[0], torch.arange(7.0))
+
+
+def test_legacy_goal_and_missing_task_terms():
+    command = SimpleNamespace(
+        pose_command_b=torch.zeros(1, 7), pose_command_w=torch.zeros(1, 7), cfg=SimpleNamespace(use_world_frame=True)
+    )
+
+    def get_term(name):
+        if name != "object_pose":
+            raise KeyError(name)
+        return command
+
+    env = SimpleNamespace(device="cpu", num_envs=1, command_manager=SimpleNamespace(get_term=get_term))
+    goal = [1.0, 2.0, 3.0, 1.0, 0.0, 0.0, 0.0]
+    assert restore_episode_task_state(env, None, legacy_goal_pose=goal) == []
+    torch.testing.assert_close(command.pose_command_w[0], torch.tensor(goal))
+    assert restore_episode_task_state(env, {"commands": {"retired": {"command": [1.0]}}}) == ["command:retired"]
+
+
+def _session(revision):
+    return {
+        "format": "dexverse_trajectory",
+        "schema_version": 5,
+        "task": "Dexverse-PushT-v1",
+        "env_name": "Dexverse-PushT-v1",
+        "robot_type": "floating_shadow_right",
+        "benchmark_revision": revision,
+        "task_version": 1,
+        "task_source_revision": "4f7262f",
+        "action_layout": {"dimension": 2},
+        "seed": 42,
+        "sim_device": "cpu",
+        "episodes": [
+            {
+                "episode_index": 0,
+                "actions": np.ones((2, 2), dtype=np.float32),
+                "initial_state": {},
+                "task_state": {"env_buffers": {"face": 4}},
+            }
+        ],
+    }
+
+
+@pytest.mark.parametrize("mismatch,value", [("benchmark_revision", None), ("action_layout", None),
+                                            ("sim_device", None), ("sim_device", "cuda:0")])
+def test_mergers_reject_incompatible_recording_identity(tmp_path, mismatch, value):
+    a = _session(BENCHMARK_REVISION)
+    b = _session(BENCHMARK_REVISION)
+    b[mismatch] = value
+    paths = [tmp_path / "a.pkl", tmp_path / "b.pkl"]
+    for path, payload in zip(paths, [a, b]):
+        with path.open("wb") as stream:
+            pickle.dump(payload, stream)
+    merger = _script("merge_demos")
+    with pytest.raises(ValueError, match="mismatch"):
+        merger.merge_trajectory_pickles([str(p) for p in paths], str(tmp_path / "batch.pkl"))
+    sessions = _script("merge_session_pickles")
+    with pytest.raises(ValueError):
+        sessions._merge_one_task(tmp_path, paths, "merged.pkl", False)
+    assert not (tmp_path / "batch.pkl").exists()
+    assert not (tmp_path / "merged.pkl").exists()
+    tree = ast.parse((ROOT / "scripts/demo_tools/create_demo_files_sequential.py").read_text())
+    helper = next(node for node in tree.body if isinstance(node, ast.FunctionDef)
+                  and node.name == "_merge_trajectory_payloads")
+    namespace = {"Path": Path, "_load_trajectory_pickle": lambda path: a if Path(path) == paths[0] else b}
+    exec(compile(ast.Module(body=[helper], type_ignores=[]), "<replay-merge-test>", "exec"), namespace)
+    with pytest.raises(ValueError, match="mismatch"):
+        namespace[helper.name](paths)
+
+
+def test_merge_preserves_task_state_and_revision(tmp_path):
+    paths = [tmp_path / "a.pkl", tmp_path / "b.pkl"]
+    for path in paths:
+        with path.open("wb") as stream:
+            pickle.dump(_session(BENCHMARK_REVISION), stream)
+    batch = _script("merge_demos").merge_trajectory_pickles([str(p) for p in paths], str(tmp_path / "batch.pkl"))
+    assert batch["benchmark_revision"] == BENCHMARK_REVISION
+    assert batch["sim_device"] == "cpu"
+    assert batch["task_version"] == 1 and batch["task_source_revision"] == "4f7262f"
+    assert batch["action_layout"] == {"dimension": 2}
+    assert [state["env_buffers"]["face"] for state in batch["task_states"]] == [4, 4]
+    output, count, status = _script("merge_session_pickles")._merge_one_task(tmp_path, paths, "merged.pkl", False)
+    assert (count, status) == (2, "written")
+    with output.open("rb") as stream:
+        merged = pickle.load(stream)
+    assert merged["benchmark_revision"] == BENCHMARK_REVISION
+    assert merged["sim_device"] == "cpu"
+    assert merged["task_version"] == 1
+    assert merged["episodes"][1]["task_state"]["env_buffers"]["face"] == 4
+
+
+def test_baseline_manifest_agrees_with_catalog():
+    path = ROOT / "source" / "dexverse" / "demonstrations" / "baseline_manifest.txt"
+    tasks = [line.split("/")[-1] for line in path.read_text().splitlines() if line and not line.startswith("#")]
+    assert tasks == list(BASELINE_TASKS)
+    assert len(tasks) == len(set(tasks)) == 20
+    path = path.with_name("baseline_manifest_v1.txt")
+    tasks = [line.split("/")[-1] for line in path.read_text().splitlines() if line and not line.startswith("#")]
+    assert tasks == list(BASELINE_V1_TASKS)
+    assert len(BASELINE_PAIRS) == len(V1_CONFIGS) == 20
+    assert set(baseline_tasks("all")) == set(BASELINE_TASKS + BASELINE_V1_TASKS)
+    assert all(a.removesuffix("-v0") == b.removesuffix("-v1") for a, b in BASELINE_PAIRS.items())
+    for module, class_name in V1_CONFIGS.values():
+        path = ROOT / "source/dexverse/dexverse/baseline_v1/config" / (module.replace(".", "/") + ".py")
+        assert class_name in {n.name for n in ast.parse(path.read_text()).body if isinstance(n, ast.ClassDef)}
+
+
+def test_original_task_and_robot_sources_are_preserved():
+    # The preservation contract is the official source snapshot, not the dirty
+    # main worktree or private recordings labelled v0. Skip outside a git checkout.
+    if subprocess.run(["git", "cat-file", "-e", "30cc673^{commit}"], cwd=ROOT, capture_output=True).returncode:
+        pytest.skip("Official preservation commit is not available")
+    paths = (
+        subprocess.check_output(
+            [
+                "git",
+                "ls-tree",
+                "-r",
+                "--name-only",
+                "30cc673",
+                "source/dexverse/dexverse/tasks",
+                "source/dexverse/dexverse/robot_agents/shadow",
+                "source/dexverse/dexverse/visual_purpose.py",
+            ],
+            cwd=ROOT,
+        )
+        .decode()
+        .splitlines()
+    )
+    for path in paths:
+        original = subprocess.check_output(["git", "show", f"30cc673:{path}"], cwd=ROOT)
+        if path == "source/dexverse/dexverse/tasks/__init__.py":
+            # The sole discovery change imports the sibling upgrade package;
+            # retain every byte of the original task-registration implementation.
+            original += (
+                b"\n# Keep the established task-discovery entry point registering both versions.\n"
+                b"# Only baseline upgrades live in this sibling package; original tasks stay here.\n"
+                b"from dexverse import baseline_v1  # noqa: E402, F401\n"
+            )
+        assert (ROOT / path).read_bytes() == original, path
+
+
+@pytest.mark.parametrize("version,revision", [(0, V0_BENCHMARK_REVISION), (1, BENCHMARK_REVISION)])
+def test_task_metadata_uses_selected_version(version, revision):
+    task = f"Dexverse-OpenLaptop-v{version}"
+    identity = task_identity(task)
+    assert identity["task_version"] == version
+    assert identity["benchmark_revision"] == revision
+    validate_replay_identity({"task": task, **identity}, task)
+    assert task_identity("Dexverse-OpenDrawer-v0")["task_version"] == 0
+
+
+def test_legacy_upgrade_recordings_require_explicit_mapping():
+    task = "Dexverse-OpenLaptop-v0"
+    payload = {"task": task, "benchmark_revision": LEGACY_UPGRADE_REVISION}
+    with pytest.raises(ValueError, match="provenance"):
+        validate_replay_identity(payload, task)
+    validate_replay_identity(payload, "Dexverse-OpenLaptop-v1", explicit_override=True)
+    # Unlabelled old official recordings retain v0 compatibility.
+    validate_replay_identity({"task": task}, task)
+    for old, new in LEGACY_UPGRADE_TASKS.items():
+        with pytest.raises(ValueError, match="provenance"):
+            validate_replay_identity({"task": old}, old)
+        validate_replay_identity({"task": old}, new, explicit_override=True)
+
+
+def test_restoring_initial_laptop_pose_recaptures_only_selected_references():
+    path = ROOT / "source/dexverse/dexverse/baseline_v1/mdp/terminations.py"
+    node = next(
+        n
+        for n in ast.parse(path.read_text()).body
+        if isinstance(n, ast.ClassDef) and n.name == "root_pose_displacement_exceeds"
+    )
+
+    class ManagerBase:
+        def __init__(self, cfg, env):
+            self.cfg = cfg
+
+    namespace = {
+        "torch": torch,
+        "ManagerTermBase": ManagerBase,
+        "ManagerBasedRLEnv": object,
+        "SceneEntityCfg": lambda name: SimpleNamespace(name=name),
+    }
+    exec(compile(ast.Module(body=[node], type_ignores=[]), str(path), "exec"), namespace)
+    asset = SimpleNamespace(data=SimpleNamespace(root_pos_w=torch.zeros(2, 3)))
+    env = SimpleNamespace(scene={"articulation": asset})
+    term = namespace["root_pose_displacement_exceeds"](SimpleNamespace(params={}), env)
+    term.reset()
+    asset.data.root_pos_w[0, 0] = 0.10
+    assert term(env).tolist() == [True, False]
+    env.termination_manager = SimpleNamespace(active_terms=["base"], get_term_cfg=lambda _: SimpleNamespace(func=term))
+    reset_managers_after_state_restore(env, env_ids=torch.tensor([0]))
+    assert term(env).tolist() == [False, False]
+    asset.data.root_pos_w[0, 2] = -0.02  # downward settling is not lifting
+    assert not term(env, max_upward_z=0.005).any()
+    asset.data.root_pos_w[1, 2] = 0.006
+    assert term(env, max_upward_z=0.005).tolist() == [False, True]
+
+
+def test_procedural_assets_build_and_reuse_matching_parameters(tmp_path):
+    from pxr import Usd
+    from dexverse.assets.rack_builder import ensure_rack_asset
+    from dexverse.assets.shelf_builder import ensure_slot_shelf_asset
+    from dexverse.assets.small_table_builder import ensure_small_table_asset
+    from dexverse.assets.cut_props_builder import ensure_taped_seam_workpiece_asset, ensure_strip_stand_asset
+    from dexverse.assets.desk_props_builder import ensure_dispenser_asset
+
+    for index, builder in enumerate(
+        (
+            ensure_rack_asset,
+            ensure_slot_shelf_asset,
+            ensure_small_table_asset,
+            ensure_taped_seam_workpiece_asset,
+            ensure_strip_stand_asset,
+            ensure_dispenser_asset,
+        )
+    ):
+        directory = tmp_path / str(index)
+        path, manifest = builder(out_dir=directory)
+        stage = Usd.Stage.Open(str(path))
+        assert stage and stage.GetDefaultPrim()
+        before = path.stat().st_mtime_ns
+        same_path, same_manifest = builder(out_dir=directory)
+        assert same_path == path and same_manifest == manifest
+        assert path.stat().st_mtime_ns == before
+
+
+def test_v1_dispenser_grey_materials_preserve_green_target_and_geometry(tmp_path):
+    from pxr import Usd, UsdShade
+    from dexverse.assets.desk_props_builder import ensure_dispenser_asset
+
+    config = ROOT / "source/dexverse/dexverse/baseline_v1/config/functional/place_cup_under_dispenser_cfg.py"
+    tree = ast.parse(config.read_text())
+    assignment = next(
+        node for node in tree.body if isinstance(node, ast.Assign)
+        and any(isinstance(target, ast.Name) and target.id == "DISPENSER_PARAMS" for target in node.targets)
+    )
+    params = {keyword.arg: ast.literal_eval(keyword.value) for keyword in assignment.value.keywords}
+    geometry = {key: value for key, value in params.items() if not key.endswith("_color")}
+    _, original = ensure_dispenser_asset(out_dir=tmp_path, **geometry)
+    path, updated = ensure_dispenser_asset(out_dir=tmp_path, **params)
+    assert {key: value for key, value in original.items() if key != "params"} == {
+        key: value for key, value in updated.items() if key != "params"
+    }
+    stage = Usd.Stage.Open(str(path))
+    for material, expected in (
+        ("BodyMat", (0.55, 0.55, 0.55)),
+        ("NozzleMat", (0.35, 0.35, 0.35)),
+        ("TargetMat", (0.15, 0.75, 0.25)),
+    ):
+        shader = UsdShade.Shader.Get(stage, f"/dispenser/Looks/{material}/PreviewSurface")
+        assert tuple(shader.GetInput("diffuseColor").Get()) == pytest.approx(expected)

--- a/scripts/list_envs.py
+++ b/scripts/list_envs.py
@@ -16,7 +16,50 @@ It prints the name of the environment, the entry point and the config file.
 
 All the environments are registered in the `dexverse` extension. They start
 with `Dexverse-` in their name.
+
+    python scripts/list_envs.py                        # full table
+    python scripts/list_envs.py --baseline             # only the baseline-manifest tasks
+    python scripts/list_envs.py --baseline --names_only  # bare ids, no simulator launch
 """
+
+"""Parse arguments (before the simulator, so the cheap paths need no Isaac)."""
+
+import argparse
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "source" / "dexverse"))
+
+parser = argparse.ArgumentParser(description="List the registered Dexverse-* environments.")
+parser.add_argument(
+    "--baseline",
+    action="store_true",
+    help="Only the curated baseline tasks (source/dexverse/demonstrations/baseline_manifest.txt).",
+)
+parser.add_argument(
+    "--names_only",
+    action="store_true",
+    help="Print bare task ids, one per line (script-friendly). With --baseline this needs no simulator launch.",
+)
+parser.add_argument(
+    "--version",
+    choices=["v0", "v1", "all"],
+    default=None,
+    help="Task version; --baseline defaults to v0, the full listing defaults to all.",
+)
+args_cli = parser.parse_args()
+
+
+def _baseline_task_ids() -> list[str]:
+    """Task ids from the versioned baseline catalogue."""
+    from dexverse.benchmark import baseline_tasks
+
+    return list(baseline_tasks(args_cli.version or "v0"))
+
+
+if args_cli.baseline and args_cli.names_only:
+    print("\n".join(_baseline_task_ids()))
+    raise SystemExit(0)
 
 """Launch Isaac Sim Simulator first."""
 
@@ -36,26 +79,38 @@ from prettytable import PrettyTable
 
 def main():
     """Print all environments registered in `dexverse` extension."""
+    baseline = set(_baseline_task_ids()) if args_cli.baseline else None
+    task_specs = [
+        s
+        for s in gym.registry.values()
+        if "Dexverse-" in s.id
+        and (baseline is None or s.id in baseline)
+        and (args_cli.version in (None, "all") or s.id.endswith("-" + args_cli.version))
+    ]
+    if args_cli.baseline:
+        missing = sorted(baseline - {s.id for s in task_specs})
+        if missing:
+            print(f"[list_envs] WARNING: baseline tasks not registered: {missing}", flush=True)
+        # keep manifest order
+        order = {tid: i for i, tid in enumerate(_baseline_task_ids())}
+        task_specs.sort(key=lambda s: order.get(s.id, 1e9))
+
+    if args_cli.names_only:
+        print("\n".join(s.id for s in task_specs), flush=True)
+        return
+
     # print all the available environments
     table = PrettyTable(["S. No.", "Task Name", "Entry Point", "Config"])
-    table.title = "Available Environments in Isaac Lab"
+    table.title = "Baseline Environments" if args_cli.baseline else "Available Environments in Isaac Lab"
     # set alignment of table columns
     table.align["Task Name"] = "l"
     table.align["Entry Point"] = "l"
     table.align["Config"] = "l"
 
-    # count of environments
-    index = 0
-    # acquire all Dexverse environment names
-    for task_spec in gym.registry.values():
-        # Filter for dexverse environments (Dexverse- prefix only).
-        if "Dexverse-" in task_spec.id:
-            # add details to table
-            table.add_row([index + 1, task_spec.id, task_spec.entry_point, task_spec.kwargs["env_cfg_entry_point"]])
-            # increment count
-            index += 1
+    for index, task_spec in enumerate(task_specs):
+        table.add_row([index + 1, task_spec.id, task_spec.entry_point, task_spec.kwargs["env_cfg_entry_point"]])
 
-    print(table)
+    print(table, flush=True)
 
 
 if __name__ == "__main__":

--- a/scripts/record_demos.py
+++ b/scripts/record_demos.py
@@ -14,7 +14,11 @@ This script allows users to record demonstrations operated by VR hand tracking f
 specified task. Each session is stored as a single pickle file containing the task
 name, optional object USD path / robot variant, the initial scene state captured
 via ``env.scene.get_state(is_relative=True)`` (robot + object + any other scene
-entity) and the per-step teleop actions. ``replay_demos.py`` can load this pickle
+entity) and the per-step teleop actions. For arm-mounted embodiments controlled via
+differential IK (e.g. ``fr3_sharpa_right``), the per-step commanded arm joint targets
+(``joint_pos_target``) are also recorded as ``arm_joint_actions``, since the IK
+action space itself is an EE pose rather than raw joint targets.
+``replay_demos.py`` can load this pickle
 to reconstruct the environment, restore the initial state and replay the actions
 to regenerate the corresponding observations.
 
@@ -32,6 +36,9 @@ Optional arguments:
     --record_state            Enable recording per-step scene states (T+1 snapshots per episode).
     --num_demos               Number of demonstrations to record. (default: 0, infinite)
     --num_success_steps       Number of continuous steps with task success for concluding a demo as successful. (default: 10)
+    --seed                    Seed for the environment's reset/spawn randomization. Default None keeps
+                              the task default (DexVerseBaseEnvCfg.seed = 42); -1 draws a random seed.
+                              The resolved seed is stored in the pickle metadata.
     --enable_pinocchio        Enable Pinocchio. Auto-enabled for handtracking / motion controllers
                               because dex-retargeting requires it.
 """
@@ -52,6 +59,8 @@ from pathlib import Path
 import numpy as np
 import torch
 from dexverse.demo_paths import DEXVERSE_DATA_DIR_ENV, get_dexverse_data_dir, resolve_demo_output_path
+from dexverse.benchmark import action_layout, task_identity
+from dexverse.teleop_utils.debug_visualization import add_debug_visualization_args, configure_v1_debug_visualization
 from isaaclab.app import AppLauncher
 
 logger = logging.getLogger(__name__)
@@ -96,6 +105,17 @@ parser.add_argument(
     help="Number of continuous steps with task success for concluding a demo as successful. Default is 10.",
 )
 parser.add_argument(
+    "--seed",
+    type=int,
+    default=None,
+    help=(
+        "Seed for the environment's reset/spawn randomization (object spawn poses, "
+        "goal sampling, multi-asset/multi-USD choice). Default None keeps the task "
+        "default seed (42); pass -1 to draw a random seed. Record with seeds disjoint "
+        "from the evaluation seeds so train and eval setups come from different draws."
+    ),
+)
+parser.add_argument(
     "--enable_pinocchio",
     action="store_true",
     default=False,
@@ -112,8 +132,9 @@ parser.add_argument(
     type=str,
     default=None,
     help=(
-        "Optional robot variant override for environments that expose 'robot_type' "
-        "(floating_shadow_right, floating_shadow_left, floating_shadow_bimanual)."
+        "Optional robot variant override for environments that expose 'robot_type'. "
+        "Supported variants: floating_shadow_right, floating_shadow_left, "
+        "floating_shadow_bimanual."
     ),
 )
 parser.add_argument(
@@ -126,14 +147,36 @@ parser.add_argument(
         "file (single-object mode) or a directory of USDs (object-pool mode)."
     ),
 )
+add_debug_visualization_args(parser, teleop=True)
 parser.add_argument(
-    "--enable_debug_vis",
-    action=argparse.BooleanOptionalAction,
-    default=None,
+    "--show_ranges",
+    action="store_true",
+    default=False,
     help=(
-        "Override the task's debug-visualization toggle (zone / reference-point "
-        "markers). Use --enable_debug_vis to force on, --no-enable_debug_vis to "
-        "force off; omit to use the task's default."
+        "Outline the task's randomization ranges -- object spawn envelopes and "
+        "goal sampling boxes -- as wireframe boxes, so the operator can see the "
+        "space the task samples from. Operator-only: the markers are tagged "
+        "purpose=guide and stay out of recorded camera observations."
+    ),
+)
+parser.add_argument(
+    "--show_stats",
+    action=argparse.BooleanOptionalAction,
+    default=False,
+    help=(
+        "After every recorded trajectory, re-score demonstration diversity and "
+        "show it as an in-headset panel (and a PNG/JSON beside the demos). "
+        "Off by default (it has crashed teleop sessions); pass --show_stats to enable."
+    ),
+)
+parser.add_argument(
+    "--stats_history",
+    action=argparse.BooleanOptionalAction,
+    default=True,
+    help=(
+        "Fold previously recorded pickles for this task into the statistics, so "
+        "the panel describes the whole dataset rather than just this session. "
+        "--no-stats_history scores only the current session."
     ),
 )
 parser.add_argument(
@@ -161,6 +204,13 @@ parser.add_argument(
 )
 
 AppLauncher.add_app_launcher_args(parser)
+# Demonstration recording is also a live teleoperation path, so prefer low
+# rendering latency by default. This affects the viewport / XR stream only;
+# it does not resize or remove scene-camera observations saved for replay.
+# Pass ``--rendering_mode balanced`` or ``quality`` when desired.
+# Match the historical XR collection default explicitly, including non-XR
+# recording. GPU rendering is independent; an explicit --device can override.
+parser.set_defaults(rendering_mode="performance", device="cpu")
 args_cli, unknown_args = parser.parse_known_args()
 
 # Support lightweight Hydra-style env override parity with teleop_agent.py.
@@ -177,6 +227,8 @@ for raw_arg in unknown_args:
         args_cli.retargeting_scheme = raw_arg.split("=", 1)[1]
     elif raw_arg.startswith("env.enable_debug_vis="):
         args_cli.enable_debug_vis = raw_arg.split("=", 1)[1].strip().lower() in ("1", "true", "yes")
+    elif raw_arg.startswith("env.seed="):
+        args_cli.seed = int(raw_arg.split("=", 1)[1])
     else:
         parser.error(f"unrecognized arguments: {raw_arg}")
 
@@ -235,6 +287,7 @@ from dexverse.tasks.utils import (  # noqa: E402
     prune_stale_obs_refs,
     strip_camera_cfgs,
 )
+from dexverse.teleop_utils.episode_task_state import capture_episode_task_state  # noqa: E402
 from isaaclab.devices.teleop_device_factory import create_teleop_device  # noqa: E402
 from isaaclab.envs import DirectRLEnvCfg, ManagerBasedRLEnvCfg  # noqa: E402
 
@@ -245,12 +298,17 @@ class TrajectoryPickleRecorder:
     Each recorded session is written to a single pickle file that contains the
     environment metadata (task name, object USD path, robot variant), the initial
     scene state captured via ``env.scene.get_state(is_relative=True)`` and the
-    per-step teleop actions. ``replay_demos.py`` consumes this pickle to rebuild
+    per-step teleop actions. When the robot exposes arm joints (via
+    ``robot_config.arm_joint_names_expr``), the per-step commanded arm joint
+    targets are additionally recorded as ``arm_joint_actions`` (indexed by
+    ``arm_joint_names`` in the pickle's top-level metadata) since the teleop
+    ``actions`` for IK-controlled arms are EE poses, not joint targets.
+    ``replay_demos.py`` consumes this pickle to rebuild
     the environment, restore the initial robot + object state and replay the
     actions to regenerate observations.
     """
 
-    SCHEMA_VERSION = 3
+    SCHEMA_VERSION = 5
     FORMAT_TAG = "dexverse_trajectory"
 
     def __init__(
@@ -263,12 +321,21 @@ class TrajectoryPickleRecorder:
         usd_path: str | None = None,
         robot_type: str | None = None,
         json_path: str | None = None,
+        arm_joint_names: list[str] | None = None,
+        seed: int | None = None,
+        action_layout_metadata: dict | None = None,
+        sim_device: str | None = None,
     ):
         self._output_file = output_file
         os.makedirs(os.path.dirname(output_file) or ".", exist_ok=True)
         self._episodes: list[dict] = []
         self._active_episode: dict | None = None
+        self._reset_attempts: list[dict] = []
+        self._active_reset_id: int | None = None
+        self._next_reset_id = 0
         self._record_state = bool(record_state)
+        self._arm_joint_names = list(arm_joint_names) if arm_joint_names else None
+        self._record_arm_joint_actions = self._arm_joint_names is not None
         self._metadata = {
             "format": self.FORMAT_TAG,
             "schema_version": self.SCHEMA_VERSION,
@@ -278,11 +345,80 @@ class TrajectoryPickleRecorder:
             "usd_path": usd_path,
             "robot_type": robot_type,
             "json_path": json_path,
+            "arm_joint_names": self._arm_joint_names,
+            "seed": seed,
+            "sim_device": sim_device,
+            **task_identity(env_name or task_name),
+            "action_layout": action_layout_metadata,
         }
 
     @property
     def num_episodes(self) -> int:
         return len(self._episodes)
+
+    @property
+    def episodes(self) -> list[dict]:
+        """Finalized episodes, in the schema the diversity metrics parse.
+
+        Exposed so the live stats panel can score the session straight from
+        memory instead of re-reading the pickle after every trajectory.
+        """
+        return self._episodes
+
+    @property
+    def current_reset_id(self) -> int | None:
+        return self._active_reset_id
+
+    @property
+    def num_reset_attempts(self) -> int:
+        return len(self._reset_attempts)
+
+    def start_reset_attempt(self) -> int:
+        """Open a ledger entry for the scene produced by one environment reset."""
+        if self._active_reset_id is not None:
+            raise RuntimeError(f"Reset {self._active_reset_id} is still active.")
+        reset_id = self._next_reset_id
+        self._next_reset_id += 1
+        self._active_reset_id = reset_id
+        return reset_id
+
+    def _finalize_reset_attempt(
+        self,
+        outcome: str,
+        *,
+        reason: str,
+        num_steps: int,
+        successful_episode_index: int | None = None,
+    ) -> None:
+        if self._active_reset_id is None:
+            return
+        if outcome not in {"success", "failed", "skipped"}:
+            raise ValueError(f"Unknown reset outcome: {outcome!r}")
+        entry = {
+            "reset_id": self._active_reset_id,
+            "outcome": outcome,
+            "reason": reason,
+            "num_steps": int(num_steps),
+        }
+        if successful_episode_index is not None:
+            entry["successful_episode_index"] = int(successful_episode_index)
+        self._reset_attempts.append(entry)
+        self._active_reset_id = None
+
+    def finish_reset_without_success(self, *, reason: str) -> str | None:
+        """Close the current reset as failed (actions exist) or skipped (none)."""
+        if self._active_reset_id is None:
+            return None
+        if self._active_episode is not None:
+            num_steps = len(self._active_episode.get("actions", []))
+            self._active_episode = None
+            outcome = "failed" if num_steps > 0 else "skipped"
+        else:
+            num_steps = 0
+            outcome = "skipped"
+        self._finalize_reset_attempt(outcome, reason=reason, num_steps=num_steps)
+        self.flush()
+        return outcome
 
     def has_active_episode(self) -> bool:
         return self._active_episode is not None
@@ -291,22 +427,30 @@ class TrajectoryPickleRecorder:
         self,
         initial_state,
         goal_pose=None,
+        task_state=None,
         multi_assets=None,
         multi_usds=None,
         active_object_metadata=None,
     ) -> None:
+        if self._active_reset_id is None:
+            raise RuntimeError("Cannot start an episode before starting a reset attempt.")
         initial_state_pkl = self._to_pickleable(initial_state)
         self._active_episode = {
             "episode_index": len(self._episodes),
             "episode_name": f"demo_{len(self._episodes)}",
+            "reset_id": self._active_reset_id,
             "initial_state": initial_state_pkl,
             "goal_pose": self._to_pickleable(goal_pose) if goal_pose is not None else None,
             "actions": [],
             "success": None,
         }
+        if task_state:
+            self._active_episode["task_state"] = self._to_pickleable(task_state)
         if self._record_state:
             # ``states`` always stores T+1 snapshots: initial state + one state per action step.
             self._active_episode["states"] = [initial_state_pkl]
+        if self._record_arm_joint_actions:
+            self._active_episode["arm_joint_actions"] = []
         if multi_assets is not None:
             self._active_episode["multi_assets"] = self._to_pickleable(multi_assets)
         if multi_usds is not None:
@@ -318,6 +462,22 @@ class TrajectoryPickleRecorder:
         if self._active_episode is None:
             return
         self._active_episode["actions"].append(self._to_pickleable(action))
+
+    def record_arm_joint_action(self, joint_pos_target) -> None:
+        """Record the post-step commanded arm joint targets (``joint_pos_target``).
+
+        This is separate from ``actions`` because the recorded action for
+        IK-controlled arms (e.g. FR3+Sharpa) is an absolute EE pose, not raw
+        joint targets. This field captures what the IK solve actually
+        commanded to the simulation for the arm joints, indexed per
+        ``arm_joint_names``.
+        """
+        if not self._record_arm_joint_actions or self._active_episode is None:
+            return
+        arm_joint_actions = self._active_episode.get("arm_joint_actions")
+        if not isinstance(arm_joint_actions, list):
+            return
+        arm_joint_actions.append(self._to_pickleable(joint_pos_target))
 
     def record_state(self, state) -> None:
         if not self._record_state or self._active_episode is None:
@@ -337,6 +497,19 @@ class TrajectoryPickleRecorder:
         else:
             self._active_episode["actions"] = np.zeros((0, 0), dtype=np.float32)
         self._active_episode["num_steps"] = int(self._active_episode["actions"].shape[0])
+        if self._record_arm_joint_actions:
+            arm_joint_actions = self._active_episode["arm_joint_actions"]
+            if len(arm_joint_actions) > 0:
+                stacked_arm = np.stack([np.asarray(a).reshape(-1) for a in arm_joint_actions], axis=0)
+                self._active_episode["arm_joint_actions"] = stacked_arm.astype(np.float32, copy=False)
+            else:
+                self._active_episode["arm_joint_actions"] = np.zeros((0, len(self._arm_joint_names)), dtype=np.float32)
+            if self._active_episode["arm_joint_actions"].shape[0] != self._active_episode["num_steps"]:
+                raise ValueError(
+                    "arm_joint_actions length mismatch: got "
+                    f"{self._active_episode['arm_joint_actions'].shape[0]}, expected "
+                    f"{self._active_episode['num_steps']}."
+                )
         if self._record_state:
             states = self._active_episode.get("states")
             if not isinstance(states, list):
@@ -348,8 +521,16 @@ class TrajectoryPickleRecorder:
                     "(must be T+1: initial + per-step post-state)."
                 )
         self._active_episode["success"] = bool(success)
+        episode_index = int(self._active_episode["episode_index"])
+        num_steps = int(self._active_episode["num_steps"])
         self._episodes.append(self._active_episode)
         self._active_episode = None
+        self._finalize_reset_attempt(
+            "success" if success else "failed",
+            reason="success" if success else "finalized_failure",
+            num_steps=num_steps,
+            successful_episode_index=episode_index if success else None,
+        )
         self.flush()
 
     def discard_episode(self) -> None:
@@ -359,6 +540,8 @@ class TrajectoryPickleRecorder:
         payload = dict(self._metadata)
         payload["num_episodes"] = len(self._episodes)
         payload["episodes"] = self._episodes
+        payload["num_reset_attempts"] = len(self._reset_attempts)
+        payload["reset_attempts"] = self._reset_attempts
         with open(self._output_file, "wb") as fp:
             pickle.dump(payload, fp, protocol=pickle.HIGHEST_PROTOCOL)
 
@@ -377,15 +560,16 @@ class TrajectoryPickleRecorder:
         return data
 
 
-def _get_goal_pose_from_env(env) -> torch.Tensor | None:
-    """Read the current goal pose command, if the task defines one."""
-    if not hasattr(env, "command_manager"):
-        return None
-    try:
-        goal_pose = env.command_manager.get_command("object_pose")
-    except (AttributeError, KeyError):
-        return None
-    return goal_pose[0].detach().clone()
+def _get_goal_pose_from_task_state(task_state: dict) -> torch.Tensor | None:
+    """Return the legacy single goal pose from the richer task-state snapshot."""
+    commands = task_state.get("commands", {})
+    ordered_names = ["object_pose", *(name for name in commands if name != "object_pose")]
+    for name in ordered_names:
+        buffers = commands.get(name, {})
+        pose = buffers.get("pose_command_b")
+        if isinstance(pose, torch.Tensor) and pose.numel() == 7:
+            return pose.detach().clone()
+    return None
 
 
 def _get_active_object_metadata_from_env(env, env_index: int = 0) -> dict | None:
@@ -624,7 +808,7 @@ def create_environment_config() -> tuple["ManagerBasedRLEnvCfg | DirectRLEnvCfg"
     try:
         env_cfg = parse_env_cfg(args_cli.task, device=args_cli.device, num_envs=1, json_path=args_cli.json_path)
     except Exception as e:
-        logger.error(f"Failed to parse environment configuration: {e}")
+        logger.exception(f"Failed to parse environment configuration: {e}")
         exit(1)
 
     override_kwargs: dict = {}
@@ -650,6 +834,14 @@ def create_environment_config() -> tuple["ManagerBasedRLEnvCfg | DirectRLEnvCfg"
         env_cfg.sim.device = args_cli.device if args_cli.device is not None else env_cfg.sim.device
         env_cfg.scene.num_envs = 1
     env_cfg.env_name = args_cli.task.split(":")[-1]
+
+    # Must come after the cfg_cls(**override_kwargs) rebuild above, which would
+    # otherwise reset the seed to the task default (42). ManagerBasedEnv consumes
+    # cfg.seed before scene construction, seeding python/numpy/torch/warp, so it
+    # also governs multi-asset/multi-USD random.choice spawn picks. A value of -1
+    # is resolved to a randomly drawn seed and written back into cfg.seed.
+    if args_cli.seed is not None:
+        env_cfg.seed = args_cli.seed
 
     if "TopDownGrasp" in args_cli.task or "Lift" in args_cli.task:
         if hasattr(env_cfg, "commands") and hasattr(env_cfg.commands, "object_pose"):
@@ -689,6 +881,7 @@ def create_environment_config() -> tuple["ManagerBasedRLEnvCfg | DirectRLEnvCfg"
         )
         apply_teleop_retargeting_scheme(env_cfg.teleop_devices, args_cli.retargeting_scheme)
 
+    configure_v1_debug_visualization(env_cfg, cues_in_rgb=args_cli.cues_in_rgb)
     return env_cfg, success_term
 
 
@@ -701,7 +894,7 @@ def create_environment(
                 return gym.make(args_cli.task, cfg=env_cfg).unwrapped
         return gym.make(args_cli.task, cfg=env_cfg).unwrapped
     except Exception as e:
-        logger.error(f"Failed to create environment: {e}")
+        logger.exception(f"Failed to create environment: {e}")
         exit(1)
 
 
@@ -787,14 +980,18 @@ def run_simulation_loop(
     trajectory_recorder: TrajectoryPickleRecorder,
     multi_assets: list[dict] | None = None,
     multi_usds: list[dict] | None = None,
+    arm_joint_ids: list[int] | None = None,
+    stats_panel: object | None = None,
 ) -> int:
     success_step_count = 0
     should_reset = False
+    reset_reason = "manual_reset"
     running = False  # Start inactive for VR (user activates with START gesture).
 
     def reset_recording_instance():
-        nonlocal should_reset
+        nonlocal should_reset, reset_reason
         should_reset = True
+        reset_reason = "manual_reset"
         print("Recording instance reset requested")
 
     def start_recording_instance():
@@ -821,7 +1018,9 @@ def run_simulation_loop(
 
     env.sim.reset()
     env.reset()
+    first_reset_id = trajectory_recorder.start_reset_attempt()
     teleop_interface.reset()
+    print(f"Reset ID: {first_reset_id}")
 
     print("=" * 60)
     print("VR Demo Recording Started")
@@ -830,6 +1029,8 @@ def run_simulation_loop(
     print(f"Teleop Device: {args_cli.teleop_device}")
     print(f"Trajectory pickle: {args_cli.dataset_file}")
     print(f"Record per-step states: {args_cli.record_state}")
+    print(f"Environment seed: {getattr(env_cfg, 'seed', None)}")
+    print(f"Physics simulation device: {env.device}")
     print(f"Target Demos: {'Infinite' if args_cli.num_demos == 0 else args_cli.num_demos}")
     print("=" * 60)
     print("\nVR Controls:")
@@ -878,13 +1079,30 @@ def run_simulation_loop(
                     pass
 
             action = teleop_interface.advance()
+            # RESET callbacks fire during ``advance``. Honor them before taking
+            # another action so an untouched setup is correctly logged as
+            # skipped rather than as a one-step failed attempt.
+            if should_reset:
+                outcome = trajectory_recorder.finish_reset_without_success(reason=reset_reason)
+                if outcome is not None:
+                    print(f"Reset attempt recorded as {outcome}.")
+                handle_reset(env)
+                next_reset_id = trajectory_recorder.start_reset_attempt()
+                teleop_interface.reset()
+                print(f"Reset ID: {next_reset_id}")
+                success_step_count = 0
+                should_reset = False
+                running = False
+                continue
             if running:
                 # On the first step of a new demo, capture the initial scene state.
                 if not trajectory_recorder.has_active_episode():
                     initial_scene_state = env.scene.get_state(is_relative=True)
+                    task_state = capture_episode_task_state(env)
                     trajectory_recorder.start_episode(
                         initial_state=initial_scene_state,
-                        goal_pose=_get_goal_pose_from_env(env),
+                        goal_pose=_get_goal_pose_from_task_state(task_state),
+                        task_state=task_state,
                         multi_assets=multi_assets,
                         multi_usds=multi_usds,
                         active_object_metadata=_get_active_object_metadata_from_env(env),
@@ -892,16 +1110,41 @@ def run_simulation_loop(
 
                 trajectory_recorder.record_action(action.detach().clone())
                 actions = action.repeat(env.num_envs, 1)
-                env.step(actions)
+                step_output = env.step(actions)
+                terminated = step_output[2]
+                truncated = step_output[3]
+                episode_done = bool(torch.logical_or(terminated, truncated)[0])
+                if episode_done:
+                    outcome = trajectory_recorder.finish_reset_without_success(reason="environment_termination")
+                    next_reset_id = trajectory_recorder.start_reset_attempt()
+                    teleop_interface.reset()
+                    success_step_count = 0
+                    should_reset = False
+                    running = False
+                    print(f"✗ Reset attempt recorded as {outcome}; auto-reset ID: {next_reset_id}")
+                    continue
                 if args_cli.record_state:
                     post_step_state = env.scene.get_state(is_relative=True)
                     trajectory_recorder.record_state(post_step_state)
+                if arm_joint_ids is not None:
+                    robot = env.scene["robot"]
+                    arm_joint_pos_target = robot.data.joint_pos_target[0, arm_joint_ids]
+                    trajectory_recorder.record_arm_joint_action(arm_joint_pos_target.detach().clone())
 
                 success_step_count, success_reached = check_success(env, success_term, success_step_count)
                 if success_reached:
+                    successful_reset_id = trajectory_recorder.current_reset_id
                     trajectory_recorder.finalize_episode(success=True)
-                    print(f"✓ Recorded {trajectory_recorder.num_episodes} successful demonstration(s).")
+                    print(
+                        f"✓ Recorded {trajectory_recorder.num_episodes} successful demonstration(s) "
+                        f"from reset ID {successful_reset_id}."
+                    )
+                    if stats_panel is not None:
+                        # ~110 ms (score + render), spent in the pause before the
+                        # reset, so the operator never feels it.
+                        stats_panel.publish(trajectory_recorder.episodes)
                     should_reset = True
+                    reset_reason = "after_success"
                     running = False
 
                 if args_cli.num_demos > 0 and trajectory_recorder.num_episodes >= args_cli.num_demos:
@@ -914,10 +1157,13 @@ def run_simulation_loop(
                 env.sim.render()
 
             if should_reset:
-                if trajectory_recorder.has_active_episode():
-                    trajectory_recorder.discard_episode()
+                outcome = trajectory_recorder.finish_reset_without_success(reason=reset_reason)
+                if outcome is not None:
+                    print(f"Reset attempt recorded as {outcome}.")
                 handle_reset(env)
+                next_reset_id = trajectory_recorder.start_reset_attempt()
                 teleop_interface.reset()
+                print(f"Reset ID: {next_reset_id}")
                 success_step_count = 0
                 should_reset = False
                 running = False
@@ -925,7 +1171,28 @@ def run_simulation_loop(
             if env.sim.is_stopped():
                 break
 
+    outcome = trajectory_recorder.finish_reset_without_success(reason="session_ended")
+    if outcome is not None:
+        print(f"Final reset attempt recorded as {outcome}.")
     return trajectory_recorder.num_episodes
+
+
+def _resolve_arm_joint_ids(env: gym.Env, env_cfg) -> tuple[list[int] | None, list[str] | None]:
+    """Resolve arm joint indices + names from ``env_cfg.robot_config.arm_joint_names_expr``.
+
+    Returns ``(None, None)`` if the task has no ``robot_config`` or no arm
+    joint expression configured (e.g. floating hand-only embodiments with no
+    separate arm).
+    """
+    robot_config = getattr(env_cfg, "robot_config", None)
+    arm_joint_names_expr = getattr(robot_config, "arm_joint_names_expr", None) if robot_config else None
+    if not arm_joint_names_expr:
+        return None, None
+    robot = env.scene["robot"]
+    joint_ids, joint_names = robot.find_joints(arm_joint_names_expr, preserve_order=True)
+    if not joint_ids:
+        return None, None
+    return joint_ids, joint_names
 
 
 def main() -> None:
@@ -937,8 +1204,19 @@ def main() -> None:
     multi_spawn_catalogs = _collect_multi_spawn_catalogs(env_cfg.scene)
     multi_spawn_trace = MultiSpawnTrace(multi_spawn_catalogs)
 
+    if args_cli.show_ranges:
+        # Must happen before create_environment: the term is registered on the
+        # cfg and instantiated when the observation manager is built.
+        from dexverse.teleop_utils.range_vis import attach_range_vis
+
+        attach_range_vis(env_cfg)
+
     env = create_environment(env_cfg, multi_spawn_trace=multi_spawn_trace)
     teleop_interface = setup_teleop_device(env_cfg, {})
+
+    arm_joint_ids, arm_joint_names = _resolve_arm_joint_ids(env, env_cfg)
+    if arm_joint_names is not None:
+        logger.info(f"Recording arm_joint_actions for joints: {arm_joint_names}")
 
     trajectory_recorder = TrajectoryPickleRecorder(
         output_file,
@@ -948,7 +1226,25 @@ def main() -> None:
         usd_path=getattr(env_cfg, "usd_path", None),
         robot_type=getattr(env_cfg, "robot_type", None),
         json_path=args_cli.json_path,
+        arm_joint_names=arm_joint_names,
+        # Read after create_environment so a -1 request has been resolved to the
+        # actually drawn seed (ManagerBasedEnv writes it back into cfg.seed).
+        seed=getattr(env_cfg, "seed", None),
+        action_layout_metadata=action_layout(env),
+        sim_device=str(env.device),
     )
+
+    stats_panel = None
+    if args_cli.show_stats:
+        from dexverse.teleop_utils.stats_panel import TeleopStatsPanel
+
+        stats_panel = TeleopStatsPanel(
+            task=args_cli.task,
+            robot_type=getattr(env_cfg, "robot_type", None),
+            session_file=output_file,
+            include_history=args_cli.stats_history,
+            xr=bool(getattr(args_cli, "xr", False)),
+        )
 
     episode_multi_assets = multi_spawn_trace.multi_assets if multi_spawn_trace.multi_assets else None
     episode_multi_usds = multi_spawn_trace.multi_usds if multi_spawn_trace.multi_usds else None
@@ -959,8 +1255,12 @@ def main() -> None:
         trajectory_recorder,
         multi_assets=episode_multi_assets,
         multi_usds=episode_multi_usds,
+        arm_joint_ids=arm_joint_ids,
+        stats_panel=stats_panel,
     )
 
+    if stats_panel is not None:
+        stats_panel.close()
     env.close()
     trajectory_recorder.flush()
     print(f"\nRecording session completed with {num_recorded} successful demonstration(s)")

--- a/scripts/run_local.py
+++ b/scripts/run_local.py
@@ -1,0 +1,39 @@
+# Copyright (c) 2025-2026, The DexVerse Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Run a repository script with this checkout's dexverse package.
+
+Example: python scripts/run_local.py scripts/list_envs.py --baseline --names_only
+Reuses the active interpreter and dependencies without changing editable installs.
+"""
+
+from __future__ import annotations
+
+import os
+import runpy
+import sys
+from pathlib import Path
+
+
+def main():
+    root = Path(__file__).resolve().parents[1]
+    if len(sys.argv) < 2:
+        raise SystemExit("Usage: python scripts/run_local.py <repository-script.py> [arguments...]")
+    script = (root / sys.argv[1]).resolve()
+    if not script.is_relative_to(root) or not script.is_file():
+        raise SystemExit(f"Expected a script inside {root}: {script}")
+    source = root / "source" / "dexverse"
+    sys.path[:0] = [str(source), str(script.parent)]
+    os.environ["PYTHONPATH"] = str(source) + os.pathsep + os.environ.get("PYTHONPATH", "")
+    import dexverse
+
+    if not Path(dexverse.__file__).resolve().is_relative_to(source):
+        raise SystemExit(f"Wrong dexverse source: {dexverse.__file__}")
+    sys.argv = [str(script), *sys.argv[2:]]
+    runpy.run_path(str(script), run_name="__main__")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/teleop_agent.py
+++ b/scripts/teleop_agent.py
@@ -19,6 +19,7 @@ import argparse
 from collections.abc import Callable
 
 from isaaclab.app import AppLauncher
+from dexverse.teleop_utils.debug_visualization import add_debug_visualization_args, configure_v1_debug_visualization
 
 # add argparse arguments
 parser = argparse.ArgumentParser(description="Teleoperation for DexVerse environments.")
@@ -34,12 +35,17 @@ parser.add_argument(
 )
 parser.add_argument("--task", type=str, default=None, help="Name of the task.")
 parser.add_argument(
+    "--seed", type=int, default=None,
+    help="Environment randomization seed; omitted keeps the task default, -1 draws a random seed.",
+)
+parser.add_argument(
     "--robot_type",
     type=str,
     default=None,
     help=(
-        "Optional robot variant override for environments that expose 'robot_type' "
-        "(floating_shadow_right, floating_shadow_left, floating_shadow_bimanual)."
+        "Optional robot variant override for environments that expose 'robot_type'. "
+        "Supported variants: floating_shadow_right, floating_shadow_left, "
+        "floating_shadow_bimanual."
     ),
 )
 parser.add_argument(
@@ -87,18 +93,26 @@ parser.add_argument(
     default=False,
     help="Enable Pinocchio (required for dex-retargeting and some IK controllers).",
 )
+add_debug_visualization_args(parser, teleop=True)
 parser.add_argument(
-    "--enable_debug_vis",
-    action=argparse.BooleanOptionalAction,
-    default=None,
+    "--show_ranges",
+    action="store_true",
+    default=False,
     help=(
-        "Override the task's debug-visualization toggle (zone / reference-point "
-        "markers). Use --enable_debug_vis to force on, --no-enable_debug_vis to "
-        "force off; omit to use the task's default."
+        "Outline the task's randomization ranges -- object spawn envelopes and "
+        "goal sampling boxes -- as wireframe boxes, so the operator can see the "
+        "space the task samples from instead of inferring it one episode at a "
+        "time. Operator-only: the markers are tagged purpose=guide and stay out "
+        "of recorded camera observations."
     ),
 )
 # append AppLauncher cli args
 AppLauncher.add_app_launcher_args(parser)
+# Live teleoperation favors latency over image quality. Isaac Lab's supported
+# performance preset disables expensive reflections / indirect lighting /
+# ambient occlusion / denoisers and uses DLSS Performance. A caller can still
+# override this with ``--rendering_mode balanced`` or ``quality``.
+parser.set_defaults(rendering_mode="performance")
 # parse the arguments
 args_cli, unknown_args = parser.parse_known_args()
 
@@ -247,7 +261,18 @@ def main() -> None:  # noqa: C901
         if args_cli.num_envs is not None:
             env_cfg.scene.num_envs = args_cli.num_envs
     _apply_hydra_env_overrides(env_cfg, hydra_env_overrides)
+    # Apply after the config rebuild and Hydra overrides, before scene spawning.
+    # An explicit CLI seed wins; omission preserves env.seed/task defaults.
+    if args_cli.seed is not None:
+        env_cfg.seed = args_cli.seed
     env_cfg.env_name = args_cli.task
+
+    if args_cli.show_ranges:
+        # Registered as a scene_vis observation term, which observation presets
+        # never null out, so the overlay survives whichever preset the task picks.
+        from dexverse.teleop_utils.range_vis import attach_range_vis
+
+        attach_range_vis(env_cfg)
 
     # Swap retargeter cfgs in place after the per-task __post_init__ has
     # fully built env_cfg.teleop_devices. Keeping this out of the env cfg
@@ -260,6 +285,7 @@ def main() -> None:  # noqa: C901
         )
         apply_teleop_retargeting_scheme(env_cfg.teleop_devices, args_cli.retargeting_scheme)
 
+    configure_v1_debug_visualization(env_cfg, cues_in_rgb=args_cli.cues_in_rgb)
     # Template environments consume json_path internally via parse_env_cfg.
 
     # modify configuration
@@ -297,6 +323,7 @@ def main() -> None:  # noqa: C901
     try:
         # create environment
         env = gym.make(args_cli.task, cfg=env_cfg).unwrapped
+        print(f"[teleop] Environment seed: {env.cfg.seed}")
         # check environment name (for reach, we don't allow the gripper)
         if "Reach" in args_cli.task:
             logger.warning(
@@ -304,7 +331,7 @@ def main() -> None:  # noqa: C901
                 " ignored."
             )
     except Exception as e:
-        logger.error(f"Failed to create environment: {e}")
+        logger.exception(f"Failed to create environment: {e}")
         simulation_app.close()
         return
 
@@ -489,8 +516,8 @@ def main() -> None:  # noqa: C901
                     should_reset_recording_instance = False
                     print("Environment reset complete")
 
-        except Exception as e:
-            logger.error(f"Error during simulation step: {e}")
+        except Exception:
+            logger.exception("Error during simulation step")
             break
 
     # close the simulator

--- a/scripts/zero_agent.py
+++ b/scripts/zero_agent.py
@@ -16,6 +16,7 @@ import argparse
 
 from isaaclab.app import AppLauncher
 from omegaconf import OmegaConf
+from dexverse.teleop_utils.debug_visualization import add_debug_visualization_args, configure_v1_debug_visualization
 
 # add argparse arguments
 parser = argparse.ArgumentParser(description="Zero agent for Isaac Lab environments.")
@@ -25,12 +26,17 @@ parser.add_argument(
 parser.add_argument("--num_envs", type=int, default=None, help="Number of environments to simulate.")
 parser.add_argument("--task", type=str, default=None, help="Name of the task.")
 parser.add_argument(
+    "--seed", type=int, default=None,
+    help="Environment randomization seed; omitted keeps the task default, -1 draws a random seed.",
+)
+parser.add_argument(
     "--robot_type",
     type=str,
     default=None,
     help=(
-        "Optional robot variant override for environments that expose 'robot_type' "
-        "(floating_shadow_right, floating_shadow_left, floating_shadow_bimanual)."
+        "Optional robot variant override for environments that expose 'robot_type'. "
+        "Supported variants: floating_shadow_right, floating_shadow_left, "
+        "floating_shadow_bimanual."
     ),
 )
 parser.add_argument(
@@ -121,9 +127,24 @@ parser.add_argument(
     ),
 )
 # append AppLauncher cli args
+add_debug_visualization_args(parser)
+parser.add_argument("--show_ranges", action="store_true", help="Opt-in spawn/goal range wireframes (independent of debug cues).")
 AppLauncher.add_app_launcher_args(parser)
 # parse known args so we can accept Hydra-style env overrides
 args_cli, hydra_args = parser.parse_known_args()
+# This flag affects terms created in __post_init__, not just a scalar field.
+# Remove it from the late Hydra patch and include it in the config rebuild.
+remaining_hydra_args = []
+for raw_arg in hydra_args:
+    key, separator, value = raw_arg.partition("=")
+    if separator and key.lstrip("+") == "env.enable_debug_vis":
+        if value.lower() not in ("true", "false", "1", "0", "yes", "no"):
+            parser.error("env.enable_debug_vis must be a boolean")
+        if args_cli.enable_debug_vis is None:
+            args_cli.enable_debug_vis = value.lower() in ("true", "1", "yes")
+    else:
+        remaining_hydra_args.append(raw_arg)
+hydra_args = remaining_hydra_args
 
 # launch omniverse app
 app_launcher = AppLauncher(args_cli)
@@ -216,6 +237,8 @@ def main():
     # These are fields that __post_init__ derives other values from, so they
     # must be set before __post_init__ runs rather than patched in afterwards.
     reinit_kwargs = {}
+    if args_cli.enable_debug_vis is not None:
+        reinit_kwargs["enable_debug_vis"] = args_cli.enable_debug_vis
     if args_cli.robot_type is not None:
         if not hasattr(env_cfg, "robot_type"):
             raise ValueError(
@@ -284,7 +307,17 @@ def main():
         set_robot_wrist_init_world_pos(env_cfg, **kwargs)
 
     # create environment
+    configure_v1_debug_visualization(env_cfg, cues_in_rgb=args_cli.cues_in_rgb)
+    if args_cli.show_ranges:
+        from dexverse.teleop_utils.range_vis import attach_range_vis
+
+        attach_range_vis(env_cfg)
+    # Apply last so config rebuilds cannot replace the requested seed with 42.
+    # An explicit CLI seed wins over env.seed; omission leaves it unchanged.
+    if args_cli.seed is not None:
+        env_cfg.seed = args_cli.seed
     env = gym.make(args_cli.task, cfg=env_cfg)
+    print(f"[zero_agent] Environment seed: {env.unwrapped.cfg.seed}")
 
     # print info (this is vectorized environment)
     print(f"[INFO]: Gym observation space: {env.observation_space}")

--- a/source/dexverse/config/extension.toml
+++ b/source/dexverse/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Semantic Versioning is used: https://semver.org/
-version = "0.1.0"
+version = "0.2.0"
 
 # Description
 category = "isaaclab"

--- a/source/dexverse/demonstrations/baseline_manifest.txt
+++ b/source/dexverse/demonstrations/baseline_manifest.txt
@@ -1,0 +1,21 @@
+# Original v0 baseline task listing. See baseline_manifest_v1.txt for upgrades.
+functional/Dexverse-GraspBleach-v0
+functional/Dexverse-GraspPan-v0
+functional/Dexverse-GraspKettle-v0
+functional/Dexverse-GraspCup-v0
+functional/Dexverse-RemoveCupFromRack-v0
+functional/Dexverse-FunctionalPourCan-v0
+functional/Dexverse-FunctionalPourMug-v0
+functional/Dexverse-FunctionalHammerStrike-v0
+articulation/Dexverse-OpenFaucet-v0
+articulation/Dexverse-OpenDoor-v0
+articulation/Dexverse-OpenLaptop-v0
+articulation/Dexverse-SqueezeScissors-v0
+articulation/Dexverse-SlideUtilityKnife-v0
+articulation/Dexverse-OpenStapler-v0
+articulation/Dexverse-OpenFlatFolder-v0
+bimanual/Dexverse-BimanualLiftTray-v0
+bimanual/Dexverse-BimanualLiftCarton-v0
+contact_rich/Dexverse-InsertPen-v0
+non_prehensile/Dexverse-PushSmallSphereObstacleSlope-v0
+non_prehensile/Dexverse-PushT-v0

--- a/source/dexverse/demonstrations/baseline_manifest_v1.txt
+++ b/source/dexverse/demonstrations/baseline_manifest_v1.txt
@@ -1,0 +1,21 @@
+# Upgraded v1 baseline task listing; not a public dataset inventory.
+functional/Dexverse-GraspBleach-v1
+functional/Dexverse-GraspPan-v1
+functional/Dexverse-GraspKettle-v1
+functional/Dexverse-GraspCup-v1
+functional/Dexverse-RemoveCupFromRack-v1
+functional/Dexverse-FunctionalPourCan-v1
+functional/Dexverse-FunctionalPourMug-v1
+functional/Dexverse-FunctionalHammerStrike-v1
+articulation/Dexverse-OpenFaucet-v1
+articulation/Dexverse-OpenDoor-v1
+articulation/Dexverse-OpenLaptop-v1
+articulation/Dexverse-SqueezeScissors-v1
+articulation/Dexverse-SlideUtilityKnife-v1
+articulation/Dexverse-OpenStapler-v1
+articulation/Dexverse-OpenFlatFolder-v1
+bimanual/Dexverse-BimanualLiftTray-v1
+bimanual/Dexverse-BimanualLiftCarton-v1
+contact_rich/Dexverse-InsertPen-v1
+non_prehensile/Dexverse-PushSmallSphereObstacleSlope-v1
+non_prehensile/Dexverse-PushT-v1

--- a/source/dexverse/dexverse/analysis/__init__.py
+++ b/source/dexverse/dexverse/analysis/__init__.py
@@ -1,0 +1,38 @@
+# Copyright (c) 2025-2026, The DexVerse Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Offline (simulator-free) analysis utilities.
+
+* :mod:`~dexverse.analysis.reset_audit` -- statistics, flags, plots and the
+  markdown report for the reset-distribution audit produced by
+  ``scripts/env_tools/sample_reset_distributions.py``. Pure numpy/matplotlib;
+  importable without Isaac Sim so results can be re-plotted anywhere.
+"""
+
+from .reset_audit import (
+    BASELINE_TASKS,
+    TASK_ROLES,
+    analyze_task_dir,
+    compute_stats,
+    flag_task,
+    load_task_dir,
+    plot_grid,
+    plot_task,
+    resolve_roles,
+    write_report,
+)
+
+__all__ = [
+    "BASELINE_TASKS",
+    "TASK_ROLES",
+    "analyze_task_dir",
+    "compute_stats",
+    "flag_task",
+    "load_task_dir",
+    "plot_grid",
+    "plot_task",
+    "resolve_roles",
+    "write_report",
+]

--- a/source/dexverse/dexverse/analysis/reset_audit.py
+++ b/source/dexverse/dexverse/analysis/reset_audit.py
@@ -1,0 +1,1099 @@
+# Copyright (c) 2025-2026, The DexVerse Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Reset-distribution audit: statistics, flags, plots and report.
+
+The Isaac-side sampler (``scripts/env_tools/sample_reset_distributions.py``)
+resets a task many times and dumps, per task directory:
+
+* ``samples.npz`` -- stacked per-sample arrays (see :func:`load_task_dir` for the
+  key layout), all positions **env-relative** (metres) and quaternions ``(w,x,y,z)``.
+* ``meta.json``   -- task id, entity lists, declared randomization boxes,
+  termination-term parameters, reset-event order, defaults, ...
+
+Everything in this module is simulator-free (numpy + matplotlib) so the numbers
+can be re-analysed and re-plotted anywhere:
+
+* :func:`resolve_roles`  -- which entity is *the object*, which is *the goal*.
+* :func:`compute_stats`  -- spread / coverage / init->goal distance / settle-drift
+  / termination statistics.
+* :func:`flag_task`      -- turns stats into a list of named problems.
+* :func:`plot_task`      -- one PNG per task (XY scatter + histograms + text).
+* :func:`write_report`   -- aggregates every task directory into ``report.md``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import math
+from pathlib import Path
+
+import numpy as np
+
+from dexverse.teleop_utils.diversity_core import _circular_std_deg, quat_yaw
+from dexverse.benchmark import BASELINE_TASKS, BASELINE_PAIRS, LEGACY_UPGRADE_TASKS
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Task catalogue
+# ---------------------------------------------------------------------------
+
+#: Per-task role hints. ``goal`` is either a scene entity name or
+#: ``"command:<term>"``. Anything not listed here goes through the generic
+#: fallback in :func:`resolve_roles`. ``extra`` lists props worth plotting even
+#: when they do not move (context for the operator's eye).
+TASK_ROLES: dict[str, dict] = {
+    "Dexverse-GraspBleach-v0": {"object": "object", "goal": "success_marker"},
+    "Dexverse-GraspPan-v0": {"object": "object", "goal": "success_marker", "extra": ["stove"]},
+    "Dexverse-GraspKettle-v0": {"object": "object", "goal": "success_marker", "extra": ["mug"]},
+    "Dexverse-GraspCup-v0": {"object": "object", "goal": "success_marker"},
+    "Dexverse-RemoveCupFromRack-v0": {"object": "object", "goal": "command:object_pose", "extra": ["cup_holder"]},
+    "Dexverse-FunctionalPourCan-v0": {"object": "object", "goal": "success_marker", "extra": ["bowl"]},
+    "Dexverse-FunctionalPourMug-v0": {"object": "object", "goal": "success_marker"},
+    "Dexverse-FunctionalHammerStrike-v0": {"object": "object", "goal": "hammer_target", "extra": ["hammer_stand"]},
+    "Dexverse-OpenFaucet-v0": {"object": "articulation", "goal": None, "extra": ["sink", "faucet_support"]},
+    "Dexverse-OpenLaptop-v0": {"object": "articulation", "goal": None},
+    "Dexverse-SqueezeScissors-v0": {"object": "articulation", "goal": None},
+    "Dexverse-SlideUtilityKnife-v0": {"object": "articulation", "goal": None},
+    "Dexverse-OpenStapler-v0": {"object": "articulation", "goal": None},
+    "Dexverse-OpenFlatFolder-v0": {"object": "articulation", "goal": None},
+    "Dexverse-BimanualLiftTray-v0": {"object": "object", "goal": None, "extra": ["food"]},
+    "Dexverse-BimanualLiftCarton-v0": {"object": "object", "goal": None},
+    "Dexverse-InsertPen-v0": {"object": "pen", "goal": "pen_holder"},
+    "Dexverse-PushSmallSphereObstacleSlope-v0": {"object": "object", "goal": "command:object_pose"},
+    "Dexverse-PushT-v0": {"object": "object", "goal": "goal_tee"},
+    "Dexverse-BimanualRetrieveTrayFromRack-v0": {"object": "object", "goal": "goal_pad", "extra": ["rack", "food"]},
+    "Dexverse-CloseFolderInsertShelf-v0": {"object": "articulation", "goal": "shelf", "extra": []},
+    "Dexverse-BimanualCartonRegrasp-v0": {"object": "object", "goal": "goal_frame"},
+    "Dexverse-CutSeamUtilityKnife-v0": {"object": "articulation", "goal": "workpiece"},
+    "Dexverse-CutStripScissors-v0": {"object": "articulation", "goal": "strip_stand"},
+    "Dexverse-ReloadStapler-v0": {"object": "articulation", "goal": "stapler_goal"},
+    "Dexverse-PlaceCupUnderDispenser-v0": {"object": "object", "goal": "dispenser"},
+    "Dexverse-OpenTiltedDoor-v0": {"object": "articulation", "goal": None},
+}
+
+# Preserve legacy-role hints for offline private data, but canonical v1 roles
+# follow the upgraded implementation rather than the original task's name.
+for _v0, _v1 in BASELINE_PAIRS.items():
+    TASK_ROLES[_v1] = dict(TASK_ROLES[_v0])
+for _legacy, _v1 in LEGACY_UPGRADE_TASKS.items():
+    TASK_ROLES[_v1] = dict(TASK_ROLES[_legacy])
+# These props were added only by v1.
+TASK_ROLES["Dexverse-FunctionalHammerStrike-v0"] = {"object": "object", "goal": "hammer_target"}
+TASK_ROLES["Dexverse-OpenFaucet-v0"] = {"object": "articulation", "goal": None}
+
+_GOAL_NAME_HINTS = ("goal", "success_marker", "target", "holder", "bowl", "mug")
+_STATIC_NAME_HINTS = ("table", "plane", "leg", "wall", "light", "camera")
+
+#: Termination-term parameter names that denote a *distance* threshold, in
+#: order of preference. ``kind`` says which distance the threshold applies to.
+_DISTANCE_PARAM_KEYS: tuple[tuple[str, str], ...] = (
+    ("position_threshold", "3d"),
+    ("goal_xy_threshold", "xy"),
+    ("xy_threshold", "xy"),
+    ("center_dist_thresh", "xy"),
+    ("threshold", "3d"),
+)
+#: ``threshold`` is only a distance for these success functions (for
+#: articulation ``joint_*`` terms it is radians/metres of joint travel).
+_DISTANCE_THRESHOLD_FUNCS = (
+    "object_at_goal_position",
+    "object_at_goal_pose",
+    "success_no_forbidden_contact",
+    "success_with_contact_zones",
+    "insert_peg_success",
+    "plug_charger_pose_success",
+)
+
+#: Default flag thresholds (metres / degrees / fractions). Override via
+#: ``flag_task(..., thresholds={...})``.
+DEFAULT_THRESHOLDS: dict[str, float] = {
+    "degenerate_xy_std_m": 0.01,
+    "degenerate_yaw_std_deg": 2.0,
+    "one_d_axis_extent_m": 0.01,
+    "one_d_other_axis_min_m": 0.05,
+    "narrow_extent_m": 0.10,
+    "overlap_dist_multiplier": 2.0,
+    "overlap_frac": 0.05,
+    "trivial_frac": 0.01,
+    "broken_frac": 0.02,
+    "drift_pos_m": 0.03,
+    "drift_yaw_deg": 10.0,
+    "palm_drift_m": 0.02,
+    "table_half_m": 0.75,
+    "step1_spurious_frac": 0.5,
+}
+
+# ---------------------------------------------------------------------------
+# Loading
+# ---------------------------------------------------------------------------
+
+
+def load_task_dir(task_dir: str | Path) -> tuple[dict[str, np.ndarray], dict]:
+    """Load ``samples.npz`` + ``meta.json`` from one task directory.
+
+    ``samples.npz`` keys (``N`` = number of recorded samples):
+
+    * ``rigid_object/<name>/root_pose`` (N,7), ``articulation/<name>/root_pose`` (N,7),
+      ``articulation/<name>/joint_pos`` (N,J)
+    * ``commands/<name>/pose_w`` (N,7) env-relative goal pose, ``commands/<name>/command`` (N,C)
+    * ``palm/<label>/pos`` (N,3)
+    * ``settled/...`` -- same keys, state after the settle steps (NaN where the env
+      terminated and was auto-reset before the snapshot)
+    * ``term_first_step/<term>`` (N,) int, first settle step at which the term fired, -1 = never
+    * ``done_step`` (N,) int, first settle step at which the env was done, -1 = never
+    * ``probe/success_step1`` (P,) bool -- raw env behaviour on the first step after reset
+    * ``env_origin`` (N,3), ``env_index`` (N,)
+    """
+    task_dir = Path(task_dir)
+    with np.load(task_dir / "samples.npz") as data:
+        samples = {k: data[k] for k in data.files}
+    meta = json.loads((task_dir / "meta.json").read_text())
+    return samples, meta
+
+
+# ---------------------------------------------------------------------------
+# Roles
+# ---------------------------------------------------------------------------
+
+
+def _entity_kinds(meta: dict) -> dict[str, str]:
+    """``{entity_name: "rigid_object" | "articulation"}`` from meta."""
+    out = {}
+    for kind in ("rigid_object", "articulation"):
+        for name in meta.get("entities", {}).get(kind, []):
+            out[name] = kind
+    return out
+
+
+def _pose_key(samples: dict, meta: dict, entity: str, settled: bool = False) -> str | None:
+    kind = _entity_kinds(meta).get(entity)
+    if kind is None:
+        return None
+    key = f"{kind}/{entity}/root_pose"
+    if settled:
+        key = "settled/" + key
+    return key if key in samples else None
+
+
+def resolve_roles(samples: dict, meta: dict) -> dict:
+    """Decide object / goal / extra entities for a task.
+
+    Uses :data:`TASK_ROLES` when the task is listed, otherwise a generic guess:
+    the ``object`` scene key (or the single articulation), the first command
+    term as goal, else the first entity whose name looks like a goal.
+    """
+    task = meta.get("task", "")
+    kinds = _entity_kinds(meta)
+    commands = list(meta.get("commands", {}).keys())
+    hint = dict(TASK_ROLES.get(task, {}))
+
+    obj = hint.get("object")
+    if obj not in kinds:
+        if "object" in kinds:
+            obj = "object"
+        elif "articulation" in kinds:
+            obj = "articulation"
+        else:
+            arts = [n for n, k in kinds.items() if k == "articulation"]
+            obj = arts[0] if arts else next(iter(kinds), None)
+
+    goal = hint.get("goal", "auto")
+    if goal == "auto":
+        goal = None
+        if commands:
+            goal = f"command:{commands[0]}"
+        else:
+            for name in kinds:
+                if name != obj and any(h in name.lower() for h in _GOAL_NAME_HINTS):
+                    goal = name
+                    break
+    elif goal is not None and not goal.startswith("command:") and goal not in kinds:
+        logger.warning("reset_audit: goal entity '%s' not in scene for %s; ignoring", goal, task)
+        goal = None
+    elif goal is not None and goal.startswith("command:") and goal.split(":", 1)[1] not in commands:
+        logger.warning("reset_audit: goal command '%s' not active for %s; ignoring", goal, task)
+        goal = None
+
+    extra = [e for e in hint.get("extra", []) if e in kinds]
+    # Also plot every entity that actually moves between resets (spread > 2 mm).
+    for name, kind in kinds.items():
+        if name in (obj, goal) or name in extra:
+            continue
+        if any(h in name.lower() for h in _STATIC_NAME_HINTS):
+            continue
+        key = f"{kind}/{name}/root_pose"
+        if key in samples and np.nanmax(np.nanstd(samples[key][:, :2], axis=0)) > 0.002:
+            extra.append(name)
+
+    dist = _distance_threshold(meta)
+    return {"object": obj, "goal": goal, "extra": extra, **dist}
+
+
+def _distance_threshold(meta: dict) -> dict:
+    """Pull the success distance threshold (if any) out of the termination params."""
+    terms = meta.get("termination_terms", {})
+    succ = terms.get("success")
+    if not succ:
+        return {"distance_threshold_m": None, "distance_kind": None, "success_func": None}
+    func = succ.get("func", "")
+    params = succ.get("params", {})
+    for key, kind in _DISTANCE_PARAM_KEYS:
+        if key not in params:
+            continue
+        if key == "threshold" and func not in _DISTANCE_THRESHOLD_FUNCS:
+            continue
+        val = params[key]
+        if isinstance(val, (int, float)):
+            return {"distance_threshold_m": float(val), "distance_kind": kind, "success_func": func}
+    return {"distance_threshold_m": None, "distance_kind": None, "success_func": func}
+
+
+# ---------------------------------------------------------------------------
+# Statistics
+# ---------------------------------------------------------------------------
+
+
+def _finite_rows(arr: np.ndarray) -> np.ndarray:
+    return arr[np.all(np.isfinite(arr.reshape(arr.shape[0], -1)), axis=1)]
+
+
+def _yaw_deg(quat: np.ndarray) -> np.ndarray:
+    return np.degrees(quat_yaw(quat))
+
+
+def _wrap_deg(a: np.ndarray) -> np.ndarray:
+    return (a + 180.0) % 360.0 - 180.0
+
+
+def _pose_stats(pose: np.ndarray, xy_bin_m: float = 0.02, yaw_bin_deg: float = 30.0) -> dict:
+    """Spread / coverage of an (N,7) env-relative pose array."""
+    pose = _finite_rows(np.asarray(pose, dtype=np.float64))
+    if pose.shape[0] == 0:
+        return {"n": 0}
+    xyz = pose[:, :3]
+    yaw = _yaw_deg(pose[:, 3:7])
+    lo, hi = xyz.min(axis=0), xyz.max(axis=0)
+    xy_bins = {tuple(np.floor(p / xy_bin_m).astype(int)) for p in xyz[:, :2]}
+    yaw_bins = {int(math.floor(((y % 360.0)) / yaw_bin_deg)) for y in yaw}
+    return {
+        "n": int(pose.shape[0]),
+        "mean": [float(v) for v in xyz.mean(axis=0)],
+        "std": [float(v) for v in xyz.std(axis=0)],
+        "min": [float(v) for v in lo],
+        "max": [float(v) for v in hi],
+        "extent": [float(v) for v in (hi - lo)],
+        "yaw_mean_deg": float(np.degrees(np.angle(np.exp(1j * np.radians(yaw)).mean()))),
+        "yaw_std_deg": _circular_std_deg(yaw),
+        "yaw_min_deg": float(yaw.min()),
+        "yaw_max_deg": float(yaw.max()),
+        "xy_bins_occupied": len(xy_bins),
+        "yaw_bins_occupied": len(yaw_bins),
+    }
+
+
+def _drift_stats(before: np.ndarray, after: np.ndarray) -> dict:
+    """Position / yaw change between the reset snapshot and the settled snapshot."""
+    before = np.asarray(before, dtype=np.float64)
+    after = np.asarray(after, dtype=np.float64)
+    ok = np.all(np.isfinite(after.reshape(after.shape[0], -1)), axis=1) & np.all(
+        np.isfinite(before.reshape(before.shape[0], -1)), axis=1
+    )
+    if ok.sum() == 0:
+        return {"n": 0}
+    dpos = np.linalg.norm(after[ok, :3] - before[ok, :3], axis=1)
+    dyaw = np.abs(_wrap_deg(_yaw_deg(after[ok, 3:7]) - _yaw_deg(before[ok, 3:7])))
+    return {
+        "n": int(ok.sum()),
+        "pos_mean_m": float(dpos.mean()),
+        "pos_p95_m": float(np.percentile(dpos, 95)),
+        "pos_max_m": float(dpos.max()),
+        "yaw_mean_deg": float(dyaw.mean()),
+        "yaw_p95_deg": float(np.percentile(dyaw, 95)),
+        "yaw_max_deg": float(dyaw.max()),
+        "_dpos": dpos,
+        "_dyaw": dyaw,
+    }
+
+
+def _goal_positions(samples: dict, meta: dict, roles: dict) -> np.ndarray | None:
+    goal = roles.get("goal")
+    if goal is None:
+        return None
+    if goal.startswith("command:"):
+        key = f"commands/{goal.split(':', 1)[1]}/pose_w"
+        return samples[key] if key in samples else None
+    key = _pose_key(samples, meta, goal)
+    return samples[key] if key else None
+
+
+def _declared_box(meta: dict, entity: str | None, kind: str | None = None) -> dict | None:
+    """First declared range box for ``entity`` (optionally of ``kind``)."""
+    if entity is None:
+        return None
+    for box in meta.get("range_boxes", []):
+        if box.get("entity") == entity and (kind is None or box.get("kind") == kind):
+            return box
+    return None
+
+
+def _boxes_overlap_xy(a: dict | None, b: dict | None) -> float | None:
+    """xy overlap area / area of the smaller box (0..1); None if not computable."""
+    if a is None or b is None:
+        return None
+    ac, ah = np.asarray(a["center"][:2]), np.asarray(a["half_extent"][:2])
+    bc, bh = np.asarray(b["center"][:2]), np.asarray(b["half_extent"][:2])
+    lo = np.maximum(ac - ah, bc - bh)
+    hi = np.minimum(ac + ah, bc + bh)
+    inter = float(np.prod(np.clip(hi - lo, 0.0, None)))
+    area_a, area_b = float(np.prod(2 * ah)), float(np.prod(2 * bh))
+    smaller = min(area_a, area_b)
+    if smaller <= 1e-8:
+        # Degenerate box (a fixed point / line): overlap = point inside the other box.
+        inside = np.all(hi - lo >= -1e-9)
+        return 1.0 if inside else 0.0
+    return inter / smaller
+
+
+def compute_stats(samples: dict, meta: dict, roles: dict | None = None) -> dict:
+    """Compute every number the flags and the report need. JSON-safe output."""
+    roles = roles or resolve_roles(samples, meta)
+    kinds = _entity_kinds(meta)
+    n = int(meta.get("num_samples", 0)) or next((v.shape[0] for k, v in samples.items() if k.startswith("rigid")), 0)
+    stats: dict = {"task": meta.get("task"), "num_samples": n, "roles": roles, "entities": {}, "drift": {}}
+
+    # -- per-entity spread + drift ------------------------------------------
+    for name, kind in kinds.items():
+        key = f"{kind}/{name}/root_pose"
+        if key not in samples:
+            continue
+        stats["entities"][name] = _pose_stats(samples[key])
+        stats["entities"][name]["kind"] = kind
+        skey = "settled/" + key
+        if skey in samples:
+            d = _drift_stats(samples[key], samples[skey])
+            stats["drift"][name] = {k: v for k, v in d.items() if not k.startswith("_")}
+            if d.get("n"):
+                dp, dy = d["_dpos"], d["_dyaw"]
+                stats["drift"][name]["frac_moved"] = float(
+                    np.mean((dp > DEFAULT_THRESHOLDS["drift_pos_m"]) | (dy > DEFAULT_THRESHOLDS["drift_yaw_deg"]))
+                )
+        jkey = f"{kind}/{name}/joint_pos"
+        if jkey in samples and samples[jkey].size:
+            jp = _finite_rows(samples[jkey])
+            defaults = np.asarray(meta.get("default_joint_pos", {}).get(name, [0.0] * jp.shape[1]), dtype=np.float64)
+            if defaults.shape[0] != jp.shape[1]:
+                defaults = np.zeros(jp.shape[1])
+            rel = jp - defaults[None, :]
+            stats["entities"][name]["joint_names"] = meta.get("joint_names", {}).get(name, [])
+            stats["entities"][name]["joint_init_mean"] = [float(v) for v in jp.mean(axis=0)]
+            stats["entities"][name]["joint_init_std"] = [float(v) for v in jp.std(axis=0)]
+            stats["entities"][name]["joint_init_rel_extent"] = [float(v) for v in (rel.max(axis=0) - rel.min(axis=0))]
+
+    # -- palm ------------------------------------------------------------------
+    stats["palm"] = {}
+    for key, arr in samples.items():
+        if key.startswith("palm/") and key.endswith("/pos"):
+            label = key.split("/")[1]
+            arr = _finite_rows(arr)
+            entry = {"mean": [float(v) for v in arr.mean(axis=0)]} if arr.size else {}
+            skey = "settled/" + key
+            if skey in samples:
+                s = samples[skey]
+                ok = np.all(np.isfinite(s), axis=1) & np.all(np.isfinite(samples[key]), axis=1)
+                if ok.any():
+                    dp = np.linalg.norm(s[ok] - samples[key][ok], axis=1)
+                    entry["drift_mean_m"] = float(dp.mean())
+                    entry["drift_max_m"] = float(dp.max())
+            stats["palm"][label] = entry
+
+    # -- hand <-> object clearance at reset ------------------------------------------
+    obj_key = _pose_key(samples, meta, roles["object"]) if roles.get("object") else None
+    stats["hand_object"] = None
+    if obj_key and "robot/body_pos" in samples:
+        bp = samples["robot/body_pos"]  # (N, B, 3)
+        op = samples[obj_key][:, None, :3]
+        ok = np.all(np.isfinite(op[:, 0, :]), axis=1)
+        if ok.any():
+            d3 = np.linalg.norm(bp[ok] - op[ok], axis=2)  # (N, B)
+            dxy = np.linalg.norm(bp[ok][:, :, :2] - op[ok][:, :, :2], axis=2)
+            names = meta.get("robot_body_names", [])
+            closest = int(np.argmin(d3.min(axis=0)))
+            stats["hand_object"] = {
+                "min_3d_m": float(d3.min()),
+                "p05_3d_m": float(np.percentile(d3.min(axis=1), 5)),
+                "median_3d_m": float(np.median(d3.min(axis=1))),
+                "min_xy_m": float(dxy.min()),
+                "median_xy_m": float(np.median(dxy.min(axis=1))),
+                "closest_body": names[closest] if closest < len(names) else str(closest),
+                "frac_within_8cm": float(np.mean(d3.min(axis=1) < 0.08)),
+                "frac_xy_within_5cm": float(np.mean(dxy.min(axis=1) < 0.05)),
+            }
+            stats["_hand_d3"] = d3.min(axis=1)
+
+    # -- goal ------------------------------------------------------------------
+    goal_pos = _goal_positions(samples, meta, roles)
+    stats["goal"] = None
+    if goal_pos is not None:
+        gstats = _pose_stats(goal_pos)
+        gstats["source"] = roles["goal"]
+        gxy = _finite_rows(goal_pos)[:, :2]
+        half = DEFAULT_THRESHOLDS["table_half_m"]
+        gstats["frac_off_table"] = float(np.mean(np.any(np.abs(gxy) > half, axis=1))) if gxy.size else 0.0
+        stats["goal"] = gstats
+
+    # -- init -> goal distance ---------------------------------------------------
+    stats["init_goal"] = None
+    if obj_key and goal_pos is not None:
+        obj = samples[obj_key]
+        ok = np.all(np.isfinite(obj[:, :3]), axis=1) & np.all(np.isfinite(goal_pos[:, :3]), axis=1)
+        if ok.any():
+            d3 = np.linalg.norm(obj[ok, :3] - goal_pos[ok, :3], axis=1)
+            dxy = np.linalg.norm(obj[ok, :2] - goal_pos[ok, :2], axis=1)
+            dyaw = np.abs(_wrap_deg(_yaw_deg(obj[ok, 3:7]) - _yaw_deg(goal_pos[ok, 3:7])))
+            thr = roles.get("distance_threshold_m")
+            kind = roles.get("distance_kind") or "3d"
+            dsel = dxy if kind == "xy" else d3
+            ig = {
+                "n": int(ok.sum()),
+                "xy_min": float(dxy.min()),
+                "xy_p05": float(np.percentile(dxy, 5)),
+                "xy_median": float(np.median(dxy)),
+                "xy_max": float(dxy.max()),
+                "d3_min": float(d3.min()),
+                "d3_median": float(np.median(d3)),
+                "yaw_diff_median_deg": float(np.median(dyaw)),
+                "yaw_diff_min_deg": float(dyaw.min()),
+                "distance_threshold_m": thr,
+                "distance_kind": kind,
+            }
+            if thr is not None:
+                ig["frac_within_threshold"] = float(np.mean(dsel < thr))
+                ig["frac_within_2x_threshold"] = float(np.mean(dsel < DEFAULT_THRESHOLDS["overlap_dist_multiplier"] * thr))
+            stats["init_goal"] = ig
+            stats["_dxy"] = dxy
+            stats["_d3"] = d3
+
+    # -- declared boxes overlap ------------------------------------------------
+    obj_box = _declared_box(meta, roles.get("object"), "spawn") or _declared_box(meta, roles.get("object"))
+    goal_box = None
+    if roles.get("goal"):
+        if roles["goal"].startswith("command:"):
+            gname = roles["goal"].split(":", 1)[1]
+            goal_box = next((b for b in meta.get("range_boxes", []) if b.get("name") == gname), None)
+        else:
+            goal_box = _declared_box(meta, roles["goal"])
+    stats["declared_overlap_xy"] = _boxes_overlap_xy(obj_box, goal_box)
+
+    # -- min-distance constraints -----------------------------------------------
+    stats["min_dist_checks"] = []
+    for ev in meta.get("reset_events", []):
+        min_d = ev.get("min_xy_distance")
+        ref = ev.get("reference_entity")
+        ent = ev.get("entity")
+        if min_d is None or ref is None or ent is None:
+            continue
+        ka, kb = _pose_key(samples, meta, ent), _pose_key(samples, meta, ref)
+        if not ka or not kb:
+            continue
+        a, b = samples[ka], samples[kb]
+        ok = np.all(np.isfinite(a[:, :2]), axis=1) & np.all(np.isfinite(b[:, :2]), axis=1)
+        dxy = np.linalg.norm(a[ok, :2] - b[ok, :2], axis=1)
+        stats["min_dist_checks"].append(
+            {
+                "event": ev.get("name"),
+                "entity": ent,
+                "reference": ref,
+                "min_xy_distance": float(min_d),
+                "observed_min": float(dxy.min()) if dxy.size else None,
+                "frac_violated": float(np.mean(dxy < float(min_d) - 1e-6)) if dxy.size else 0.0,
+            }
+        )
+
+    # -- terminations during settle -----------------------------------------------
+    stats["terminations"] = {}
+    for key, arr in samples.items():
+        if not key.startswith("term_first_step/"):
+            continue
+        term = key.split("/", 1)[1]
+        fired = arr >= 0
+        entry = {
+            "frac_fired": float(fired.mean()) if arr.size else 0.0,
+            "frac_fired_step1": float(np.mean(arr == 1)) if arr.size else 0.0,
+            "frac_fired_after_step1": float(np.mean(arr >= 2)) if arr.size else 0.0,
+        }
+        if fired.any():
+            entry["first_step_median"] = float(np.median(arr[fired]))
+        stats["terminations"][term] = entry
+    if "done_step" in samples:
+        stats["frac_done_during_settle"] = float(np.mean(samples["done_step"] >= 0))
+    probe = samples.get("probe/success_step1")
+    probe_any = samples.get("probe/success_any")
+    stats["probe"] = {
+        "n": int(probe.shape[0]) if probe is not None else 0,
+        "steps": int(meta.get("probe_steps", 1)),
+        "success_step1_rate": float(np.mean(probe)) if probe is not None and probe.size else None,
+        "success_any_rate": float(np.mean(probe_any)) if probe_any is not None and probe_any.size else None,
+    }
+
+    # -- multi-env sanity ---------------------------------------------------------
+    stats["multi_env"] = None
+    if "env_origin" in samples and meta.get("num_envs", 1) > 1 and goal_pos is not None and roles["goal"].startswith("command:"):
+        origins = samples["env_origin"]
+        far = np.linalg.norm(origins[:, :2], axis=1) > 1e-6
+        if far.any():
+            gxy = goal_pos[far, :2]
+            stats["multi_env"] = {
+                "n_far_env_samples": int(far.sum()),
+                "goal_xy_abs_mean_far_envs": float(np.mean(np.linalg.norm(gxy, axis=1))),
+                "goal_xy_abs_mean_origin_env": float(
+                    np.mean(np.linalg.norm(goal_pos[~far, :2], axis=1)) if (~far).any() else float("nan")
+                ),
+            }
+    return stats
+
+
+# ---------------------------------------------------------------------------
+# Flags
+# ---------------------------------------------------------------------------
+
+
+def flag_task(stats: dict, thresholds: dict | None = None) -> list[dict]:
+    """Return ``[{"flag": NAME, "detail": str}, ...]`` for one task's stats."""
+    t = dict(DEFAULT_THRESHOLDS)
+    if thresholds:
+        t.update(thresholds)
+    flags: list[dict] = []
+    roles = stats.get("roles", {})
+    obj = roles.get("object")
+    es = stats.get("entities", {}).get(obj, {}) if obj else {}
+
+    def add(flag: str, detail: str) -> None:
+        flags.append({"flag": flag, "detail": detail})
+
+    if es.get("n"):
+        sx, sy = es["std"][0], es["std"][1]
+        ex, ey = es["extent"][0], es["extent"][1]
+        ys = es["yaw_std_deg"]
+        if max(sx, sy) < t["degenerate_xy_std_m"] and ys < t["degenerate_yaw_std_deg"]:
+            add("DEGENERATE_INIT", f"{obj}: xy std ({sx:.3f},{sy:.3f}) m, yaw std {ys:.1f} deg -- effectively fixed")
+        else:
+            if (ex < t["one_d_axis_extent_m"] and ey > t["one_d_other_axis_min_m"]) or (
+                ey < t["one_d_axis_extent_m"] and ex > t["one_d_other_axis_min_m"]
+            ):
+                add("ONE_D_INIT", f"{obj}: extent x={ex:.3f} m, y={ey:.3f} m -- one axis pinned")
+            elif ex < t["narrow_extent_m"] and ey < t["narrow_extent_m"]:
+                add("NARROW_INIT", f"{obj}: extent x={ex:.3f} m, y={ey:.3f} m (< {t['narrow_extent_m']} m both)")
+
+    ig = stats.get("init_goal")
+    if ig:
+        f2 = ig.get("frac_within_2x_threshold")
+        if f2 is not None and f2 >= t["overlap_frac"]:
+            add(
+                "INIT_GOAL_OVERLAP",
+                f"{f2 * 100:.1f}% of resets start within {t['overlap_dist_multiplier']:.0f}x the success "
+                f"threshold ({ig['distance_threshold_m']:.3f} m {ig['distance_kind']}); min dist {ig['xy_min']:.3f} m",
+            )
+        elif f2 is None and ig.get("xy_min", 1.0) < 0.03:
+            add("INIT_GOAL_OVERLAP", f"object and goal can spawn on top of each other (min xy dist {ig['xy_min']:.3f} m)")
+        f1 = ig.get("frac_within_threshold")
+        if f1 is not None and f1 >= t["trivial_frac"]:
+            add("TRIVIAL_AT_RESET", f"{f1 * 100:.1f}% of resets already satisfy the goal-distance criterion")
+    ov = stats.get("declared_overlap_xy")
+    if ov is not None and ov > 0.3 and not any(f["flag"] == "INIT_GOAL_OVERLAP" for f in flags):
+        add("INIT_GOAL_OVERLAP", f"declared object and goal boxes overlap ({ov * 100:.0f}% of the smaller box)")
+
+    succ = stats.get("terminations", {}).get("success")
+    if succ and succ.get("frac_fired_after_step1", 0.0) >= t["trivial_frac"]:
+        add("TRIVIAL_AT_RESET", f"success termination fires within the settle window in {succ['frac_fired_after_step1'] * 100:.1f}% of resets")
+    if succ and succ.get("frac_fired_step1", 0.0) >= t["step1_spurious_frac"]:
+        add("STEP1_SPURIOUS_SUCCESS", f"success fires on the first step after reset in {succ['frac_fired_step1'] * 100:.0f}% of resets (stale command metrics)")
+    probe = stats.get("probe", {})
+    if probe.get("success_step1_rate") is not None and probe["success_step1_rate"] >= t["step1_spurious_frac"]:
+        if not any(f["flag"] == "STEP1_SPURIOUS_SUCCESS" for f in flags):
+            add("STEP1_SPURIOUS_SUCCESS", f"raw probe: success on step 1 in {probe['success_step1_rate'] * 100:.0f}% of resets")
+
+    for term, entry in stats.get("terminations", {}).items():
+        if term in ("success", "time_out"):
+            continue
+        if entry.get("frac_fired", 0.0) >= t["broken_frac"]:
+            add("BROKEN_SPAWN", f"termination '{term}' fires during settle in {entry['frac_fired'] * 100:.1f}% of resets")
+    for name, d in stats.get("drift", {}).items():
+        if name == "robot" or any(h in name.lower() for h in _STATIC_NAME_HINTS):
+            continue
+        if d.get("n") and d.get("frac_moved", 0.0) >= t["broken_frac"]:
+            add(
+                "UNSETTLED_SPAWN",
+                f"{name} moves after reset (>{t['drift_pos_m']} m or >{t['drift_yaw_deg']} deg) in {d['frac_moved'] * 100:.1f}% of resets; "
+                f"pos p95 {d['pos_p95_m']:.3f} m, yaw p95 {d['yaw_p95_deg']:.1f} deg",
+            )
+    for label, p in stats.get("palm", {}).items():
+        if p.get("drift_max_m", 0.0) > t["palm_drift_m"]:
+            add("PALM_DRIFT", f"palm '{label}' moves up to {p['drift_max_m']:.3f} m during the hold -- hold action is not a hold")
+
+    ho = stats.get("hand_object")
+    if ho and ho.get("frac_within_8cm", 0.0) >= t["overlap_frac"]:
+        add(
+            "HAND_INIT_OVERLAP",
+            f"{ho['frac_within_8cm'] * 100:.1f}% of resets put the object within 8 cm of a hand body "
+            f"(closest: {ho['closest_body']}, min {ho['min_3d_m']:.3f} m, median {ho['median_3d_m']:.3f} m)",
+        )
+    g = stats.get("goal")
+    if g and g.get("frac_off_table", 0.0) > 0.0:
+        add("GOAL_OFF_TABLE", f"{g['frac_off_table'] * 100:.1f}% of goals outside the table footprint")
+    for c in stats.get("min_dist_checks", []):
+        if c.get("frac_violated", 0.0) > 0.0:
+            add("MIN_DIST_VIOLATED", f"{c['event']}: {c['frac_violated'] * 100:.1f}% closer than {c['min_xy_distance']} m to {c['reference']} (min {c['observed_min']:.3f} m)")
+    me = stats.get("multi_env")
+    if me and me["goal_xy_abs_mean_far_envs"] > t["table_half_m"]:
+        add(
+            "GOAL_NOT_ENV_RELATIVE",
+            f"for envs away from the origin the goal lies {me['goal_xy_abs_mean_far_envs']:.2f} m from their own table centre "
+            f"(origin env: {me['goal_xy_abs_mean_origin_env']:.2f} m) -- world-frame goal ranges are not offset by env_origins",
+        )
+    return flags
+
+
+# ---------------------------------------------------------------------------
+# Plotting
+# ---------------------------------------------------------------------------
+
+# Categorical palette (light surface), fixed order; marker shape is the
+# secondary encoding so identity never rides on colour alone.
+_SERIES = ["#2a78d6", "#eb6834", "#1baf7a", "#eda100", "#e87ba4", "#008300", "#4a3aa7", "#e34948"]
+_MARKERS = ["o", "s", "^", "D", "v", "P", "X", "*"]
+_INK = "#0b0b0b"
+_INK_2 = "#52514e"
+_GRID = "#e6e5e1"
+_SURFACE = "#fcfcfb"
+
+
+def _style(ax) -> None:
+    ax.set_facecolor(_SURFACE)
+    for side in ("top", "right"):
+        ax.spines[side].set_visible(False)
+    for side in ("left", "bottom"):
+        ax.spines[side].set_color(_GRID)
+    ax.tick_params(colors=_INK_2, labelsize=8)
+    ax.grid(True, color=_GRID, linewidth=0.6)
+    ax.set_axisbelow(True)
+
+
+def _bins(values: np.ndarray, lo: float | None = None, n: int = 30, min_span: float = 0.1) -> np.ndarray:
+    """Histogram edges that stay readable when all values are (nearly) identical."""
+    values = np.asarray(values, dtype=np.float64)
+    vmin = float(values.min()) if lo is None else lo
+    vmax = float(values.max())
+    if vmax - vmin < min_span:
+        pad = 0.5 * (min_span - (vmax - vmin))
+        vmin, vmax = (vmin - pad, vmax + pad) if lo is None else (lo, vmin + min_span)
+    return np.linspace(vmin, vmax, n + 1)
+
+
+def _draw_box(ax, box: dict, color: str, label: str | None) -> None:
+    from matplotlib.patches import Rectangle
+
+    c, h = box["center"], box["half_extent"]
+    if h[0] < 1e-4 and h[1] < 1e-4:
+        ax.plot([c[0]], [c[1]], marker="+", color=color, markersize=10, mew=1.5, linestyle="none", label=label)
+        return
+    ax.add_patch(
+        Rectangle(
+            (c[0] - h[0], c[1] - h[1]),
+            max(2 * h[0], 0.004),
+            max(2 * h[1], 0.004),
+            fill=False,
+            edgecolor=color,
+            linewidth=1.2,
+            linestyle="--",
+            label=label,
+        )
+    )
+
+
+def _series_for(samples: dict, meta: dict, roles: dict) -> tuple[list, np.ndarray | None]:
+    """Ordered (label, pose-array) list for object / goal / extras."""
+    series: list[tuple[str, np.ndarray | None]] = []
+    if roles.get("object"):
+        series.append((f"object: {roles['object']}", _pose_key(samples, meta, roles["object"])))
+    goal_pos = _goal_positions(samples, meta, roles)
+    if goal_pos is not None:
+        series.append((f"goal: {roles['goal']}", None))
+    for e in roles.get("extra", []):
+        series.append((e, _pose_key(samples, meta, e)))
+    return series, goal_pos
+
+
+def draw_xy_panel(ax, samples: dict, meta: dict, roles: dict, compact: bool = False, title: str | None = None):
+    """Top-down XY scatter of object / goal / extras with table outline, declared
+    boxes and palm markers. ``compact`` trims labels/legend for grid use.
+    Returns ``(series, goal_pos)`` for callers that plot the same entities elsewhere."""
+    from matplotlib.patches import Rectangle
+
+    half = float(meta.get("table_half_xy", [0.75, 0.75])[0]) if isinstance(meta.get("table_half_xy"), list) else 0.75
+    half_y = float(meta.get("table_half_xy", [0.75, 0.75])[1]) if isinstance(meta.get("table_half_xy"), list) else 0.75
+    ax.add_patch(Rectangle((-half, -half_y), 2 * half, 2 * half_y, fill=False, edgecolor=_INK_2, linewidth=1.0))
+    series, goal_pos = _series_for(samples, meta, roles)
+    n_pts = 0
+    slot = 0
+    for label, key in series:
+        if key is None and label.startswith("goal:"):
+            arr = goal_pos
+        elif key is not None:
+            arr = samples[key]
+        else:
+            continue
+        arr = _finite_rows(arr)
+        if arr.size == 0:
+            continue
+        n_pts = max(n_pts, arr.shape[0])
+        color, marker = _SERIES[slot % len(_SERIES)], _MARKERS[slot % len(_MARKERS)]
+        short = label if not compact else label.split(": ", 1)[-1][:14]
+        ax.scatter(arr[:, 0], arr[:, 1], s=8 if compact else 14, c=color, marker=marker, alpha=0.65, linewidths=0,
+                   label=short if compact else f"{label} (n={arr.shape[0]})")
+        # yaw ticks (heading of the body x-axis) for the object and goal only
+        if slot < 2 and arr.shape[0] <= 600:
+            yaw = quat_yaw(arr[:, 3:7])
+            L = 0.02
+            ax.plot(
+                np.stack([arr[:, 0], arr[:, 0] + L * np.cos(yaw)], axis=1).T,
+                np.stack([arr[:, 1], arr[:, 1] + L * np.sin(yaw)], axis=1).T,
+                color=color, linewidth=0.5, alpha=0.35,
+            )
+        slot += 1
+    drawn = set()
+    for box in meta.get("range_boxes", []):
+        color = "#4a3aa7" if box.get("kind") == "goal" else "#199e70"
+        label = None if compact else (f"declared {box.get('kind')} box" if box.get("kind") not in drawn else None)
+        drawn.add(box.get("kind"))
+        _draw_box(ax, box, color, label)
+    for key, arr in samples.items():
+        if key.startswith("palm/") and key.endswith("/pos"):
+            arr = _finite_rows(arr)
+            if arr.size:
+                ax.scatter(arr[:, 0], arr[:, 1], s=40 if compact else 60, c=_INK, marker="x", linewidths=1.5,
+                           label=None if compact else f"palm init ({key.split('/')[1]})")
+    ax.set_aspect("equal")
+    ax.set_xlim(-half - 0.1, half + 0.1)
+    ax.set_ylim(-half_y - 0.1, half_y + 0.1)
+    if compact:
+        ax.set_xticks([-0.5, 0.0, 0.5])
+        ax.set_yticks([-0.5, 0.0, 0.5])
+        ax.tick_params(labelsize=6)
+        ax.set_title(title or meta.get("task", ""), color=_INK, fontsize=8, loc="left")
+        ax.legend(loc="upper center", bbox_to_anchor=(0.5, -0.08), fontsize=5.5, frameon=False, handlelength=1.0, ncol=3, columnspacing=0.8)
+    else:
+        ax.set_xlabel("x (m, env frame; +x = away from robot)", color=_INK_2, fontsize=9)
+        ax.set_ylabel("y (m)", color=_INK_2, fontsize=9)
+        ax.set_title(title or "Reset positions (top-down)", color=_INK, fontsize=11, loc="left")
+        ax.legend(loc="upper center", fontsize=7, frameon=False, bbox_to_anchor=(0.5, -0.09), ncol=2)
+    return series, goal_pos
+
+
+def plot_grid(task_dirs: list[str | Path], out_png: str | Path, ncols: int = 5, title: str | None = None) -> Path:
+    """One compact XY panel per task directory, laid out in a grid."""
+    import matplotlib
+
+    matplotlib.use("Agg", force=False)
+    from matplotlib.figure import Figure
+    from matplotlib.backends.backend_agg import FigureCanvasAgg
+
+    dirs = [Path(d) for d in task_dirs if (Path(d) / "samples.npz").is_file()]
+    n = len(dirs)
+    nrows = int(math.ceil(n / ncols)) if n else 1
+    fig = Figure(figsize=(3.4 * ncols, 3.7 * nrows + 0.5), dpi=120)
+    FigureCanvasAgg(fig)
+    fig.patch.set_facecolor(_SURFACE)
+    gs = fig.add_gridspec(nrows, ncols, wspace=0.25, hspace=0.45, top=0.94, bottom=0.04, left=0.04, right=0.99)
+    for i, d in enumerate(dirs):
+        samples, meta = load_task_dir(d)
+        stats_path = d / "stats.json"
+        roles = json.loads(stats_path.read_text())["roles"] if stats_path.is_file() else resolve_roles(samples, meta)
+        flags = json.loads(stats_path.read_text()).get("flags", []) if stats_path.is_file() else []
+        ax = fig.add_subplot(gs[i // ncols, i % ncols])
+        _style(ax)
+        name = meta.get("task", d.name).replace("Dexverse-", "").replace("-v0", "")
+        sub = f"{name}  (n={meta.get('num_samples', '?')})"
+        draw_xy_panel(ax, samples, meta, roles, compact=True, title=sub)
+        if flags:
+            ax.text(0.99, 0.99, "\n".join(f["flag"] for f in flags), ha="right", va="top", fontsize=5.5, color="#e34948", transform=ax.transAxes)
+    key = "blue = object, orange = goal, other colours = props;  X = palm at reset;  dashed = declared spawn (green) / goal (violet) box;  ticks = heading"
+    fig.suptitle((title or "Reset positions (top-down) -- all tasks") + "\n" + key, color=_INK, fontsize=11, x=0.04, y=0.995, ha="left", va="top")
+    out_png = Path(out_png)
+    out_png.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(out_png, facecolor=_SURFACE, bbox_inches="tight")
+    return out_png
+
+
+
+def plot_task(samples: dict, meta: dict, stats: dict, out_png: str | Path, flags: list[dict] | None = None) -> Path:
+    """Render the per-task audit figure and return its path."""
+    import matplotlib
+
+    matplotlib.use("Agg", force=False)
+    from matplotlib.figure import Figure
+    from matplotlib.backends.backend_agg import FigureCanvasAgg
+
+    roles = stats["roles"]
+    kinds = _entity_kinds(meta)
+    task = meta.get("task", "?")
+    flags = flags if flags is not None else []
+
+    fig = Figure(figsize=(16, 9), dpi=110)
+    FigureCanvasAgg(fig)
+    fig.patch.set_facecolor(_SURFACE)
+    gs = fig.add_gridspec(2, 3, width_ratios=[1.35, 1, 1], height_ratios=[1, 1], wspace=0.28, hspace=0.32)
+    ax_xy = fig.add_subplot(gs[:, 0])
+    ax_yaw = fig.add_subplot(gs[0, 1])
+    ax_dist = fig.add_subplot(gs[0, 2])
+    ax_aux = fig.add_subplot(gs[1, 1])
+    ax_txt = fig.add_subplot(gs[1, 2])
+    for ax in (ax_xy, ax_yaw, ax_dist, ax_aux):
+        _style(ax)
+    ax_txt.set_axis_off()
+
+    # ---- (1) top-down scatter --------------------------------------------------
+    series, goal_pos = draw_xy_panel(ax_xy, samples, meta, roles, compact=False)
+
+    # ---- (2) yaw histograms ------------------------------------------------------
+    plotted = 0
+    for slot_i, (label, key) in enumerate(series[:4]):
+        arr = goal_pos if key is None and label.startswith("goal:") else (samples[key] if key else None)
+        if arr is None:
+            continue
+        arr = _finite_rows(arr)
+        if arr.size == 0:
+            continue
+        yaw = _yaw_deg(arr[:, 3:7])
+        if _circular_std_deg(yaw) < 0.5:
+            continue
+        ax_yaw.hist(yaw, bins=36, range=(-180, 180), color=_SERIES[slot_i % len(_SERIES)], alpha=0.6, label=label, histtype="stepfilled", edgecolor="none")
+        plotted += 1
+    ax_yaw.set_xlim(-180, 180)
+    ax_yaw.set_xlabel("yaw (deg)", color=_INK_2, fontsize=9)
+    ax_yaw.set_title("Yaw at reset" + ("" if plotted else " (no yaw randomisation)"), color=_INK, fontsize=11, loc="left")
+    if plotted:
+        ax_yaw.legend(fontsize=7, frameon=False)
+
+    # ---- (3) init -> goal distance -------------------------------------------------
+    ig = stats.get("init_goal")
+    if ig and "_dxy" in stats:
+        d = stats["_dxy"] if ig["distance_kind"] == "xy" else stats["_d3"]
+        ax_dist.hist(d, bins=_bins(d, lo=0.0, n=40, min_span=0.05), color=_SERIES[0], alpha=0.75, histtype="stepfilled", edgecolor="none")
+        thr = ig.get("distance_threshold_m")
+        if thr is not None:
+            ax_dist.axvline(thr, color="#e34948", linewidth=1.5, label=f"success threshold {thr:.3f} m")
+            ax_dist.axvline(2 * thr, color="#e34948", linewidth=1.0, linestyle=":", label="2x threshold")
+            ax_dist.legend(fontsize=7, frameon=False)
+        ax_dist.set_xlabel(f"object -> goal distance ({ig['distance_kind']}, m)", color=_INK_2, fontsize=9)
+        ax_dist.set_title(f"Init->goal distance (median {ig['xy_median']:.3f} m xy)", color=_INK, fontsize=11, loc="left")
+    else:
+        ax_dist.text(0.5, 0.5, "no spatial goal\n(lift / joint / overlap criterion)", ha="center", va="center", color=_INK_2, fontsize=9, transform=ax_dist.transAxes)
+        ax_dist.set_title("Init->goal distance", color=_INK, fontsize=11, loc="left")
+
+    # ---- (4) articulation joints or settle drift ------------------------------------
+    obj = roles.get("object")
+    jkey = f"articulation/{obj}/joint_pos" if obj and kinds.get(obj) == "articulation" else None
+    if jkey and jkey in samples and samples[jkey].size:
+        jp = _finite_rows(samples[jkey])
+        names = meta.get("joint_names", {}).get(obj, [f"j{i}" for i in range(jp.shape[1])])
+        varying = [i for i in range(jp.shape[1]) if jp[:, i].std() > 1e-4] or list(range(min(jp.shape[1], 3)))
+        for k, i in enumerate(varying[:6]):
+            ax_aux.hist(jp[:, i], bins=_bins(jp[:, i], min_span=0.05), alpha=0.6, color=_SERIES[k % len(_SERIES)], label=names[i] if i < len(names) else f"j{i}", histtype="stepfilled", edgecolor="none")
+        ax_aux.set_xlabel("joint position at reset (rad / m)", color=_INK_2, fontsize=9)
+        ax_aux.set_title("Articulation init joints" + ("" if any(jp[:, i].std() > 1e-4 for i in range(jp.shape[1])) else " (fixed)"), color=_INK, fontsize=11, loc="left")
+        ax_aux.legend(fontsize=7, frameon=False)
+    else:
+        drift_any = False
+        k = 0
+        for name in stats.get("drift", {}):
+            if name == "robot" or any(h in name.lower() for h in _STATIC_NAME_HINTS):
+                continue
+            key = f"{kinds[name]}/{name}/root_pose"
+            skey = "settled/" + key
+            if skey not in samples:
+                continue
+            dd = _drift_stats(samples[key], samples[skey])
+            if not dd.get("n") or dd["pos_max_m"] < 1e-4:
+                continue
+            ax_aux.hist(dd["_dpos"] * 100.0, bins=_bins(dd["_dpos"] * 100.0, lo=0.0, min_span=0.5), alpha=0.5, color=_SERIES[k % len(_SERIES)], label=name, histtype="stepfilled", edgecolor="none")
+            drift_any = True
+            k += 1
+        ax_aux.set_xlabel(f"position change during {meta.get('settle_steps', '?')} hold steps (cm)", color=_INK_2, fontsize=9)
+        ax_aux.set_title("Settle drift" + ("" if drift_any else " (nothing moved > 0.1 mm)"), color=_INK, fontsize=11, loc="left")
+        ax_aux.ticklabel_format(axis="x", useOffset=False, style="plain")
+        if drift_any:
+            ax_aux.set_xlim(left=0.0)
+        if drift_any:
+            ax_aux.legend(fontsize=7, frameon=False)
+
+    # ---- (5) text ----------------------------------------------------------------
+    lines = [f"{task}", f"robot: {meta.get('robot_type', '?')}   samples: {stats.get('num_samples')}   settle: {meta.get('settle_steps', '?')} steps"]
+    if obj and obj in stats["entities"] and stats["entities"][obj].get("n"):
+        e = stats["entities"][obj]
+        lines.append(f"object {obj}: xy extent ({e['extent'][0]:.2f}, {e['extent'][1]:.2f}) m, xy std ({e['std'][0]:.3f}, {e['std'][1]:.3f}) m")
+        lines.append(f"    yaw std {e['yaw_std_deg']:.1f} deg, 2cm-bins {e['xy_bins_occupied']}, 30deg-bins {e['yaw_bins_occupied']}")
+    g = stats.get("goal")
+    if g and g.get("n"):
+        lines.append(f"goal {roles['goal']}: xy extent ({g['extent'][0]:.2f}, {g['extent'][1]:.2f}) m, off-table {g['frac_off_table'] * 100:.0f}%")
+    if ig:
+        thr = ig.get("distance_threshold_m")
+        s = f"init->goal xy dist: min {ig['xy_min']:.3f}, p5 {ig['xy_p05']:.3f}, median {ig['xy_median']:.3f} m"
+        if thr is not None:
+            s += f"; within thr {ig['frac_within_threshold'] * 100:.1f}%, within 2x {ig['frac_within_2x_threshold'] * 100:.1f}%"
+        lines.append(s)
+    ho = stats.get("hand_object")
+    if ho:
+        lines.append(f"hand->object at reset: min {ho['min_3d_m']:.3f} m 3D ({ho['closest_body']}), median {ho['median_3d_m']:.3f} m; within 8 cm {ho['frac_within_8cm'] * 100:.0f}%")
+    succ = stats.get("terminations", {}).get("success")
+    if succ:
+        lines.append(f"success fired in settle: step1 {succ['frac_fired_step1'] * 100:.0f}%, later {succ['frac_fired_after_step1'] * 100:.1f}%")
+    pr = stats.get("probe", {})
+    if pr.get("success_step1_rate") is not None:
+        lines.append(
+            f"raw probe ({pr['n']} resets x {pr.get('steps', 1)} steps): success on step 1 = {pr['success_step1_rate'] * 100:.0f}%, "
+            f"within window = {(pr.get('success_any_rate') or 0.0) * 100:.0f}%"
+        )
+    other = [f"{k} {v['frac_fired'] * 100:.1f}%" for k, v in stats.get("terminations", {}).items() if k not in ("success", "time_out") and v["frac_fired"] > 0]
+    if other:
+        lines.append("other terminations: " + ", ".join(other))
+    for c in stats.get("min_dist_checks", []):
+        lines.append(f"min-dist {c['entity']}-{c['reference']} >= {c['min_xy_distance']}: observed min {c['observed_min']:.3f} m, violated {c['frac_violated'] * 100:.1f}%")
+    lines.append("")
+    lines.append("FLAGS: " + (", ".join(f["flag"] for f in flags) if flags else "none"))
+    for f in flags:
+        lines.append(f"  - {f['flag']}: {f['detail']}")
+    ax_txt.text(0.0, 1.0, "\n".join(lines), ha="left", va="top", fontsize=7.5, family="monospace", color=_INK, transform=ax_txt.transAxes, wrap=True)
+
+    fig.suptitle(f"Reset-distribution audit -- {task}", color=_INK, fontsize=13, x=0.01, ha="left")
+    out_png = Path(out_png)
+    out_png.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(out_png, facecolor=_SURFACE, bbox_inches="tight")
+    return out_png
+
+
+# ---------------------------------------------------------------------------
+# Report
+# ---------------------------------------------------------------------------
+
+
+def _json_safe(obj):
+    if isinstance(obj, dict):
+        return {k: _json_safe(v) for k, v in obj.items() if not str(k).startswith("_")}
+    if isinstance(obj, (list, tuple)):
+        return [_json_safe(v) for v in obj]
+    if isinstance(obj, np.ndarray):
+        return obj.tolist()
+    if isinstance(obj, (np.floating,)):
+        return float(obj)
+    if isinstance(obj, (np.integer,)):
+        return int(obj)
+    if isinstance(obj, float) and not math.isfinite(obj):
+        return None
+    return obj
+
+
+def analyze_task_dir(task_dir: str | Path, thresholds: dict | None = None, plot: bool = True) -> dict:
+    """Load one task directory, compute stats + flags, write ``stats.json`` and the PNG."""
+    task_dir = Path(task_dir)
+    samples, meta = load_task_dir(task_dir)
+    roles = resolve_roles(samples, meta)
+    stats = compute_stats(samples, meta, roles)
+    flags = flag_task(stats, thresholds)
+    stats["flags"] = flags
+    if plot:
+        png = plot_task(samples, meta, stats, task_dir / f"{meta.get('task', task_dir.name)}.png", flags)
+        stats["png"] = png.name
+    (task_dir / "stats.json").write_text(json.dumps(_json_safe(stats), indent=2))
+    return stats
+
+
+def _fmt(v, nd=3, dash="--"):
+    if v is None:
+        return dash
+    try:
+        if isinstance(v, float) and not math.isfinite(v):
+            return dash
+        return f"{v:.{nd}f}"
+    except (TypeError, ValueError):
+        return str(v)
+
+
+def write_report(task_dirs: list[str | Path], out_md: str | Path, failures: dict[str, str] | None = None) -> Path:
+    """Aggregate ``stats.json`` of every task dir into one markdown report."""
+    out_md = Path(out_md)
+    rows = []
+    for d in task_dirs:
+        d = Path(d)
+        sp = d / "stats.json"
+        if not sp.is_file():
+            continue
+        rows.append((d, json.loads(sp.read_text())))
+
+    lines = ["# Reset-distribution audit", ""]
+    lines.append(f"{len(rows)} task(s) audited. Positions are env-relative metres; the table is 1.5 x 1.5 m centred at the origin, +x away from the robot.")
+    lines.append("")
+    lines.append("Flags: `DEGENERATE_INIT` fixed init pose · `ONE_D_INIT` one xy axis pinned · `NARROW_INIT` both xy extents < 10 cm · "
+                 "`INIT_GOAL_OVERLAP` object can start (almost) at the goal · `TRIVIAL_AT_RESET` success criterion met at reset · "
+                 "`BROKEN_SPAWN` a non-success termination fires while holding still · `UNSETTLED_SPAWN` an entity moves >3 cm / >10 deg while holding still (spawned above / inside its support) · `GOAL_OFF_TABLE` · `MIN_DIST_VIOLATED` · "
+                 "`STEP1_SPURIOUS_SUCCESS` success fires on the first step because command metrics are stale · `HAND_INIT_OVERLAP` object spawns within 8 cm of a hand body · `PALM_DRIFT` hold action moved the hand.")
+    lines.append("")
+    lines.append("| task | object | obj xy extent (m) | obj yaw std (deg) | goal | goal xy extent (m) | init->goal xy min / median (m) | thr (m) | hand->obj min / med (m) | success@reset | step1 raw | flags |")
+    lines.append("|---|---|---|---|---|---|---|---|---|---|---|---|")
+    for d, s in rows:
+        roles = s.get("roles", {})
+        obj = roles.get("object")
+        e = s.get("entities", {}).get(obj, {}) if obj else {}
+        g = s.get("goal") or {}
+        ig = s.get("init_goal") or {}
+        succ = s.get("terminations", {}).get("success", {})
+        probe = s.get("probe", {})
+        flags = ", ".join(f["flag"] for f in s.get("flags", [])) or "-"
+        ext = f"{_fmt(e['extent'][0], 2)} x {_fmt(e['extent'][1], 2)}" if e.get("extent") else "--"
+        gext = f"{_fmt(g['extent'][0], 2)} x {_fmt(g['extent'][1], 2)}" if g.get("extent") else "--"
+        igs = f"{_fmt(ig.get('xy_min'))} / {_fmt(ig.get('xy_median'))}" if ig else "--"
+        s_at_reset = _fmt(ig.get("frac_within_threshold") * 100, 1) + "%" if ig and ig.get("frac_within_threshold") is not None else (
+            _fmt(succ.get("frac_fired_after_step1", 0.0) * 100, 1) + "%*" if succ else "--"
+        )
+        step1 = _fmt(probe.get("success_step1_rate") * 100, 0) + "%" if probe.get("success_step1_rate") is not None else "--"
+        ho = s.get("hand_object") or {}
+        hos = f"{_fmt(ho.get('min_3d_m'))} / {_fmt(ho.get('median_3d_m'))}" if ho else "--"
+        lines.append(
+            f"| {s.get('task')} | {obj} | {ext} | {_fmt(e.get('yaw_std_deg'), 1)} | {roles.get('goal') or '-'} | {gext} | {igs} | "
+            f"{_fmt(ig.get('distance_threshold_m'))} | {hos} | {s_at_reset} | {step1} | {flags} |"
+        )
+    lines.append("")
+    lines.append("`success@reset`: fraction of resets whose object->goal distance is already below the success threshold "
+                 "(or, `*`, the fraction where the env's `success` termination fired during the hold after step 1). "
+                 "`step1 raw`: fraction of raw resets where `success` fired on the very first step (stale command metrics bug).")
+    lines.append("")
+    if failures:
+        lines.append("## Failed tasks")
+        lines.append("")
+        for t, why in failures.items():
+            lines.append(f"- `{t}`: {why}")
+        lines.append("")
+    lines.append("## Per-task figures")
+    lines.append("")
+    for d, s in rows:
+        lines.append(f"### {s.get('task')}")
+        lines.append("")
+        for f in s.get("flags", []):
+            lines.append(f"- **{f['flag']}** -- {f['detail']}")
+        if not s.get("flags"):
+            lines.append("- no flags")
+        for c in s.get("min_dist_checks", []):
+            lines.append(f"- min-distance constraint `{c['event']}`: {c['entity']} vs {c['reference']} >= {c['min_xy_distance']} m, observed min {_fmt(c['observed_min'])} m")
+        png = s.get("png")
+        if png:
+            rel = Path(d).relative_to(out_md.parent) if str(Path(d).resolve()).startswith(str(out_md.parent.resolve())) else Path(d)
+            lines.append("")
+            lines.append(f"![{s.get('task')}]({rel / png})")
+        lines.append("")
+    out_md.parent.mkdir(parents=True, exist_ok=True)
+    out_md.write_text("\n".join(lines))
+    return out_md

--- a/source/dexverse/dexverse/assets/cut_props_builder.py
+++ b/source/dexverse/dexverse/assets/cut_props_builder.py
@@ -1,0 +1,256 @@
+# Copyright (c) 2025-2026, The DexVerse Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Procedural props for the "cut" tasks (utility knife seam, scissors strip).
+
+Two generators, both one kinematic rigid body of box prims:
+
+- :func:`build_taped_seam_workpiece` -- a "mimicked taped box" for the
+  utility-knife cut task: two cuboid blocks separated by a thin open slot
+  (the seam), covered by a thin ``tape`` prim. The tape prim is authored as a
+  normal collider; at env setup the task collision-filters it against the
+  knife's *blade* link only, so the extended blade phantoms through the tape
+  into the slot (as if cutting) while the knife body, fingers and table still
+  collide with it. The slot walls are unfiltered and physically guide the
+  blade along the seam. The slot has no floor -- standing on the table, the
+  tabletop bounds the blade's dip.
+
+- :func:`build_strip_stand` -- a stand (base + post + clamp) holding a
+  cantilevered paper ``strip`` for the scissors cut task. The strip is its own
+  colliding prim, so the complete scissors and the paper exchange contact
+  forces; the cut point on the strip is exported analytically.
+
+Local frames: origin at the centre of the footprint on the *bottom* face
+(z = 0 where the prop stands); +z up. The seam runs along local **+y**
+(matching the knife's long-axis convention); the strip cantilevers along
+local **-x** (the "open" side to present to the robot).
+
+Task configs call the ``ensure_*`` helpers at construction time, which build
+the files on first use (the assets tree is not tracked by git; this module
+is).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+_AUTHORED_DIR = Path(__file__).resolve().parent / "core_assets" / "dexverse_authored"
+CUT_WORKPIECE_ASSET_DIR = _AUTHORED_DIR / "cut_workpiece"
+STRIP_STAND_ASSET_DIR = _AUTHORED_DIR / "strip_stand"
+
+
+def _new_stage(usd_path: Path, name: str, mass: float):
+    from pxr import Sdf, Usd, UsdGeom, UsdPhysics
+
+    stage = Usd.Stage.CreateNew(str(usd_path))
+    UsdGeom.SetStageUpAxis(stage, UsdGeom.Tokens.z)
+    UsdGeom.SetStageMetersPerUnit(stage, 1.0)
+    root = UsdGeom.Xform.Define(stage, f"/{name}")
+    stage.SetDefaultPrim(root.GetPrim())
+    UsdPhysics.RigidBodyAPI.Apply(root.GetPrim())
+    UsdPhysics.MassAPI.Apply(root.GetPrim()).CreateMassAttr(mass)
+    root.GetPrim().CreateAttribute("physics:rigidBodyEnabled", Sdf.ValueTypeNames.Bool).Set(True)
+    UsdGeom.Scope.Define(stage, f"/{name}/Looks")
+    return stage
+
+
+def _make_material(stage, name: str, mname: str, rgb: tuple[float, float, float]):
+    from pxr import Gf, Sdf, UsdShade
+
+    mat = UsdShade.Material.Define(stage, f"/{name}/Looks/{mname}")
+    sh = UsdShade.Shader.Define(stage, f"/{name}/Looks/{mname}/PreviewSurface")
+    sh.CreateIdAttr("UsdPreviewSurface")
+    sh.CreateInput("diffuseColor", Sdf.ValueTypeNames.Color3f).Set(Gf.Vec3f(*rgb))
+    sh.CreateInput("roughness", Sdf.ValueTypeNames.Float).Set(0.85)
+    sh.CreateInput("metallic", Sdf.ValueTypeNames.Float).Set(0.0)
+    mat.CreateSurfaceOutput().ConnectToSource(sh.ConnectableAPI(), "surface")
+    return mat
+
+
+def _add_box(stage, name: str, prim_name: str, center, size, mat):
+    from pxr import Gf, Sdf, UsdGeom, UsdPhysics, UsdShade
+
+    cube = UsdGeom.Cube.Define(stage, f"/{name}/{prim_name}")
+    cube.CreateSizeAttr(1.0)
+    xf = UsdGeom.Xformable(cube.GetPrim())
+    xf.AddTranslateOp().Set(Gf.Vec3d(*center))
+    xf.AddScaleOp().Set(Gf.Vec3f(*size))
+    UsdPhysics.CollisionAPI.Apply(cube.GetPrim())
+    cube.GetPrim().CreateAttribute("physics:collisionEnabled", Sdf.ValueTypeNames.Bool).Set(True)
+    UsdShade.MaterialBindingAPI.Apply(cube.GetPrim()).Bind(mat)
+
+
+def build_taped_seam_workpiece(
+    out_dir: Path,
+    name: str = "taped_seam_workpiece",
+    seam_length: float = 0.15,
+    slot_width: float = 0.012,
+    block_width: float = 0.07,
+    block_height: float = 0.045,
+    tape_thickness: float = 0.0025,
+    tape_width: float = 0.05,
+    block_color: tuple[float, float, float] = (0.72, 0.55, 0.34),
+    tape_color: tuple[float, float, float] = (0.93, 0.78, 0.18),
+) -> tuple[Path, Path]:
+    """Write ``<name>.usda`` + ``<name>_manifest.json`` and return their paths."""
+    out_dir.mkdir(parents=True, exist_ok=True)
+    usd_path = out_dir / f"{name}.usda"
+    manifest_path = out_dir / f"{name}_manifest.json"
+
+    stage = _new_stage(usd_path, name, mass=4.0)
+    mat_block = _make_material(stage, name, "BlockMat", block_color)
+    mat_tape = _make_material(stage, name, "TapeMat", tape_color)
+
+    bx = (slot_width + block_width) / 2.0
+    _add_box(stage, name, "block_left", (bx, 0.0, block_height / 2.0), (block_width, seam_length, block_height), mat_block)
+    _add_box(stage, name, "block_right", (-bx, 0.0, block_height / 2.0), (block_width, seam_length, block_height), mat_block)
+    _add_box(
+        stage,
+        name,
+        "tape",
+        (0.0, 0.0, block_height + tape_thickness / 2.0),
+        (tape_width, seam_length, tape_thickness),
+        mat_tape,
+    )
+    stage.GetRootLayer().Save()
+
+    x_half = slot_width / 2.0 + block_width
+    manifest = {
+        "name": name,
+        "usd": usd_path.name,
+        "frame": "origin at footprint centre on the bottom face; seam along +y, +z up",
+        "params": {
+            "seam_length": seam_length,
+            "slot_width": slot_width,
+            "block_width": block_width,
+            "block_height": block_height,
+            "tape_thickness": tape_thickness,
+            "tape_width": tape_width,
+            "block_color": list(block_color),
+            "tape_color": list(tape_color),
+        },
+        "footprint": {"x_half": x_half, "y_half": seam_length / 2.0, "height": block_height + tape_thickness},
+        "seam": {
+            "start": [0.0, -seam_length / 2.0, block_height],
+            "end": [0.0, seam_length / 2.0, block_height],
+            "axis_local": [0.0, 1.0, 0.0],
+            "length": seam_length,
+        },
+        "slot": {
+            "center": [0.0, 0.0, block_height / 2.0],
+            "half_extents": [slot_width / 2.0, seam_length / 2.0, block_height / 2.0],
+        },
+        "z_block_top": block_height,
+        "z_tape_top": block_height + tape_thickness,
+        "tape_prim": "tape",
+    }
+    manifest_path.write_text(json.dumps(manifest, indent=2))
+    return usd_path, manifest_path
+
+
+def build_strip_stand(
+    out_dir: Path,
+    name: str = "strip_stand",
+    base_size: float = 0.12,
+    base_height: float = 0.02,
+    post_size: float = 0.03,
+    post_height: float = 0.115,
+    clamp_size: tuple[float, float, float] = (0.04, 0.035, 0.015),
+    strip_length: float = 0.14,
+    strip_width: float = 0.03,
+    strip_thickness: float = 0.0015,
+    cut_point_inset: float = 0.025,
+    stand_color: tuple[float, float, float] = (0.45, 0.45, 0.48),
+    strip_color: tuple[float, float, float] = (0.95, 0.95, 0.92),
+) -> tuple[Path, Path]:
+    """Write ``<name>.usda`` + ``<name>_manifest.json`` and return their paths."""
+    out_dir.mkdir(parents=True, exist_ok=True)
+    usd_path = out_dir / f"{name}.usda"
+    manifest_path = out_dir / f"{name}_manifest.json"
+
+    stage = _new_stage(usd_path, name, mass=2.0)
+    mat_stand = _make_material(stage, name, "StandMat", stand_color)
+    mat_strip = _make_material(stage, name, "StripMat", strip_color)
+
+    post_top = base_height + post_height
+    clamp_cx, clamp_cy, clamp_cz = clamp_size
+    z_strip = post_top + clamp_cz / 2.0  # strip is clamped at the clamp's mid-height
+    # Strip runs from inside the clamp footprint out along -x.
+    strip_x0 = clamp_cx / 2.0 - 0.01  # 1 cm of the strip inside the clamp
+    strip_center_x = strip_x0 - strip_length / 2.0
+    free_edge_x = strip_x0 - strip_length
+
+    _add_box(stage, name, "base", (0.0, 0.0, base_height / 2.0), (base_size, base_size, base_height), mat_stand)
+    _add_box(stage, name, "post", (0.0, 0.0, base_height + post_height / 2.0), (post_size, post_size, post_height), mat_stand)
+    _add_box(stage, name, "clamp", (0.0, 0.0, post_top + clamp_cz / 2.0), clamp_size, mat_stand)
+    _add_box(
+        stage,
+        name,
+        "strip",
+        (strip_center_x, 0.0, z_strip),
+        (strip_length, strip_width, strip_thickness),
+        mat_strip,
+    )
+    stage.GetRootLayer().Save()
+
+    manifest = {
+        "name": name,
+        "usd": usd_path.name,
+        "frame": "origin at footprint centre on the bottom face; strip cantilevers along -x, +z up",
+        "params": {
+            "base_size": base_size,
+            "base_height": base_height,
+            "post_size": post_size,
+            "post_height": post_height,
+            "clamp_size": list(clamp_size),
+            "strip_length": strip_length,
+            "strip_width": strip_width,
+            "strip_thickness": strip_thickness,
+            "cut_point_inset": cut_point_inset,
+            "stand_color": list(stand_color),
+            "strip_color": list(strip_color),
+        },
+        "footprint": {"x_half": base_size / 2.0, "y_half": base_size / 2.0, "height": post_top + clamp_cz},
+        "z_strip": z_strip,
+        "strip_axis_local": [-1.0, 0.0, 0.0],
+        "cut_point": [free_edge_x + cut_point_inset, 0.0, z_strip],
+        "free_edge_local": [free_edge_x, 0.0, z_strip],
+        "strip_prim": "strip",
+    }
+    manifest_path.write_text(json.dumps(manifest, indent=2))
+    return usd_path, manifest_path
+
+
+def _ensure_asset(build_fn, default_dir: Path, name: str, out_dir: Path | None, params: dict) -> tuple[Path, dict]:
+    out_dir = Path(out_dir) if out_dir is not None else default_dir
+    usd_path = out_dir / f"{name}.usda"
+    manifest_path = out_dir / f"{name}_manifest.json"
+    if usd_path.is_file() and manifest_path.is_file():
+        manifest = json.loads(manifest_path.read_text())
+        stored = manifest.get("params", {})
+
+        def _norm(v):
+            # JSON round-trips tuples as lists; compare like-for-like.
+            return list(v) if isinstance(v, tuple) else v
+
+        if all(k in stored and stored[k] == _norm(v) for k, v in params.items()):
+            return usd_path, manifest
+    usd_path, manifest_path = build_fn(out_dir, name=name, **params)
+    return usd_path, json.loads(manifest_path.read_text())
+
+
+def ensure_taped_seam_workpiece_asset(
+    name: str = "taped_seam_workpiece", out_dir: Path | None = None, **params
+) -> tuple[Path, dict]:
+    """Return ``(usd_path, manifest)`` for a taped-seam workpiece, generating it
+    if missing or if the stored parameters differ from ``params``."""
+    return _ensure_asset(build_taped_seam_workpiece, CUT_WORKPIECE_ASSET_DIR, name, out_dir, params)
+
+
+def ensure_strip_stand_asset(name: str = "strip_stand", out_dir: Path | None = None, **params) -> tuple[Path, dict]:
+    """Return ``(usd_path, manifest)`` for a strip-on-a-stand prop, generating
+    it if missing or if the stored parameters differ from ``params``."""
+    return _ensure_asset(build_strip_stand, STRIP_STAND_ASSET_DIR, name, out_dir, params)

--- a/source/dexverse/dexverse/assets/desk_props_builder.py
+++ b/source/dexverse/dexverse/assets/desk_props_builder.py
@@ -1,0 +1,257 @@
+# Copyright (c) 2025-2026, The DexVerse Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Procedural desk props: a staple strip and a counter-top dispenser.
+
+:func:`build_staple_strip` writes one *dynamic* rigid body whose visual is a
+single merged mesh of ``num_staples`` U-shaped staples (crown + two legs, wire
+cross-section) standing crown-up in a row along local **+x**, and whose
+collider is the convex hull of that mesh (effectively the strip's bounding box,
+so grasps are stable and no thin wire features touch PhysX). Local frame:
+origin at the centre of the row on the legs' bottom plane (z = 0 where the
+strip stands), +z up (crowns on top).
+
+Task configs call :func:`ensure_staple_strip_asset` at construction time,
+which builds the file on first use (the assets tree is not tracked by git;
+this module is).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from .cut_props_builder import _AUTHORED_DIR, _add_box, _ensure_asset, _make_material, _new_stage
+
+STAPLE_STRIP_ASSET_DIR = _AUTHORED_DIR / "staple_strip"
+DISPENSER_ASSET_DIR = _AUTHORED_DIR / "dispenser"
+
+
+def _make_metal_material(stage, name: str, mname: str, rgb: tuple[float, float, float]):
+    from pxr import Gf, Sdf, UsdShade
+
+    mat = UsdShade.Material.Define(stage, f"/{name}/Looks/{mname}")
+    sh = UsdShade.Shader.Define(stage, f"/{name}/Looks/{mname}/PreviewSurface")
+    sh.CreateIdAttr("UsdPreviewSurface")
+    sh.CreateInput("diffuseColor", Sdf.ValueTypeNames.Color3f).Set(Gf.Vec3f(*rgb))
+    sh.CreateInput("roughness", Sdf.ValueTypeNames.Float).Set(0.3)
+    sh.CreateInput("metallic", Sdf.ValueTypeNames.Float).Set(0.9)
+    mat.CreateSurfaceOutput().ConnectToSource(sh.ConnectableAPI(), "surface")
+    return mat
+
+
+def _box_geometry(points: list, counts: list, indices: list, center, size) -> None:
+    """Append an axis-aligned box (8 verts, 6 quads, outward winding) to the buffers."""
+    cx, cy, cz = center
+    hx, hy, hz = (s / 2.0 for s in size)
+    base = len(points)
+    corners = [
+        (cx - hx, cy - hy, cz - hz),
+        (cx + hx, cy - hy, cz - hz),
+        (cx + hx, cy + hy, cz - hz),
+        (cx - hx, cy + hy, cz - hz),
+        (cx - hx, cy - hy, cz + hz),
+        (cx + hx, cy - hy, cz + hz),
+        (cx + hx, cy + hy, cz + hz),
+        (cx - hx, cy + hy, cz + hz),
+    ]
+    points.extend(corners)
+    faces = [
+        (0, 3, 2, 1),  # bottom (-z)
+        (4, 5, 6, 7),  # top (+z)
+        (0, 1, 5, 4),  # -y
+        (2, 3, 7, 6),  # +y
+        (1, 2, 6, 5),  # +x
+        (3, 0, 4, 7),  # -x
+    ]
+    for face in faces:
+        counts.append(4)
+        indices.extend(base + i for i in face)
+
+
+def build_staple_strip(
+    out_dir: Path,
+    name: str = "staple_strip",
+    num_staples: int = 100,
+    crown_width: float = 0.012,
+    leg_height: float = 0.008,
+    wire: float = 0.0006,
+    pitch: float = 0.0006,
+    mass: float = 0.01,
+    color: tuple[float, float, float] = (0.78, 0.79, 0.82),
+) -> tuple[Path, Path]:
+    """Write ``<name>.usda`` + ``<name>_manifest.json`` and return their paths.
+
+    ``num_staples`` staples of ``pitch`` spacing form a row of length
+    ``num_staples * pitch`` along +x; each staple is a crown bar of width
+    ``crown_width`` (along y) at height ``leg_height`` and two legs down to
+    z = 0, all with a ``wire`` square cross-section (default 26/6-like staples,
+    slightly fat wire for visibility: 100 staples = 6 cm).
+    """
+    from pxr import Gf, Sdf, UsdGeom, UsdPhysics, UsdShade
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    usd_path = out_dir / f"{name}.usda"
+    manifest_path = out_dir / f"{name}_manifest.json"
+    stage = _new_stage(usd_path, name, mass=mass)
+    mat = _make_metal_material(stage, name, "StapleMat", color)
+
+    length = num_staples * pitch
+    points: list = []
+    counts: list = []
+    indices: list = []
+    t = wire * 0.92  # slightly thinner than the pitch so individual staples read as separate wires
+    leg_y = (crown_width - wire) / 2.0
+    for i in range(num_staples):
+        x = -length / 2.0 + (i + 0.5) * pitch
+        _box_geometry(points, counts, indices, (x, 0.0, leg_height - wire / 2.0), (t, crown_width, wire))
+        for sy in (-1.0, 1.0):
+            _box_geometry(
+                points, counts, indices, (x, sy * leg_y, (leg_height - wire) / 2.0), (t, wire, leg_height - wire)
+            )
+    mesh = UsdGeom.Mesh.Define(stage, f"/{name}/staples")
+    mesh.CreatePointsAttr([Gf.Vec3f(*p) for p in points])
+    mesh.CreateFaceVertexCountsAttr(counts)
+    mesh.CreateFaceVertexIndicesAttr(indices)
+    mesh.CreateSubdivisionSchemeAttr(UsdGeom.Tokens.none)
+    mesh.CreateDoubleSidedAttr(True)
+    mesh.CreateExtentAttr([Gf.Vec3f(-length / 2.0, -crown_width / 2.0, 0.0), Gf.Vec3f(length / 2.0, crown_width / 2.0, leg_height)])
+    prim = mesh.GetPrim()
+    UsdPhysics.CollisionAPI.Apply(prim)
+    prim.CreateAttribute("physics:collisionEnabled", Sdf.ValueTypeNames.Bool).Set(True)
+    UsdPhysics.MeshCollisionAPI.Apply(prim).CreateApproximationAttr(UsdGeom.Tokens.convexHull if hasattr(UsdGeom.Tokens, "convexHull") else "convexHull")
+    UsdShade.MaterialBindingAPI.Apply(prim).Bind(mat)
+    stage.GetRootLayer().Save()
+
+    manifest = {
+        "name": name,
+        "usd": usd_path.name,
+        "frame": "origin at the row centre on the legs' bottom plane; row along +x, crowns up (+z)",
+        "params": {
+            "num_staples": num_staples,
+            "crown_width": crown_width,
+            "leg_height": leg_height,
+            "wire": wire,
+            "pitch": pitch,
+            "mass": mass,
+            "color": list(color),
+        },
+        "length": length,
+        "half_extents": [length / 2.0, crown_width / 2.0, leg_height / 2.0],
+        "center_local": [0.0, 0.0, leg_height / 2.0],
+        "row_axis_local": [1.0, 0.0, 0.0],
+        "crown_axis_local": [0.0, 0.0, 1.0],
+        "mesh_prim": "staples",
+    }
+    manifest_path.write_text(json.dumps(manifest, indent=2))
+    return usd_path, manifest_path
+
+
+def ensure_staple_strip_asset(name: str = "staple_strip", out_dir: Path | None = None, **params) -> tuple[Path, dict]:
+    """Return ``(usd_path, manifest)`` for a staple strip, generating it if
+    missing or if the stored parameters differ from ``params``."""
+    return _ensure_asset(build_staple_strip, STAPLE_STRIP_ASSET_DIR, name, out_dir, params)
+
+
+def _add_cylinder(stage, name: str, prim_name: str, center, radius: float, height: float, mat, collide: bool = True):
+    from pxr import Gf, Sdf, UsdGeom, UsdPhysics, UsdShade
+
+    cyl = UsdGeom.Cylinder.Define(stage, f"/{name}/{prim_name}")
+    cyl.CreateRadiusAttr(float(radius))
+    cyl.CreateHeightAttr(float(height))
+    cyl.CreateAxisAttr(UsdGeom.Tokens.z)
+    cyl.CreateExtentAttr([Gf.Vec3f(-radius, -radius, -height / 2.0), Gf.Vec3f(radius, radius, height / 2.0)])
+    UsdGeom.Xformable(cyl.GetPrim()).AddTranslateOp().Set(Gf.Vec3d(*center))
+    if collide:
+        UsdPhysics.CollisionAPI.Apply(cyl.GetPrim())
+        cyl.GetPrim().CreateAttribute("physics:collisionEnabled", Sdf.ValueTypeNames.Bool).Set(True)
+    UsdShade.MaterialBindingAPI.Apply(cyl.GetPrim()).Bind(mat)
+
+
+def build_dispenser(
+    out_dir: Path,
+    name: str = "dispenser",
+    tray_size: tuple[float, float, float] = (0.16, 0.16, 0.012),
+    column_size: tuple[float, float, float] = (0.06, 0.06, 0.26),
+    arm_section: tuple[float, float] = (0.03, 0.03),
+    arm_overhang: float = 0.02,
+    nozzle_radius: float = 0.008,
+    nozzle_length: float = 0.03,
+    spout_height: float = 0.16,
+    target_disk_radius: float = 0.045,
+    body_color: tuple[float, float, float] = (0.55, 0.57, 0.60),
+    nozzle_color: tuple[float, float, float] = (0.20, 0.45, 0.85),
+    target_color: tuple[float, float, float] = (0.15, 0.75, 0.25),
+) -> tuple[Path, Path]:
+    """Write ``<name>.usda`` + ``<name>_manifest.json`` for a counter-top dispenser.
+
+    One kinematic body: a drip **tray** on the table, a **column** at its back
+    (+x), an **arm** from the column top forward over the tray, and a
+    **nozzle** hanging from the arm's front end whose bottom sits
+    ``spout_height`` above the tray top, exactly over the tray centre -- the
+    **spot** (``manifest["spot_local"]``) where a cup is to be placed. A green
+    visual-only **target disk** on the tray marks the spot (a camera-visible
+    landmark). Local frame: origin at the tray centre on the table (z = 0),
+    +z up, the open side (where a cup comes in) faces **-x**.
+    """
+    out_dir.mkdir(parents=True, exist_ok=True)
+    usd_path = out_dir / f"{name}.usda"
+    manifest_path = out_dir / f"{name}_manifest.json"
+    stage = _new_stage(usd_path, name, mass=4.0)
+    mat_body = _make_material(stage, name, "BodyMat", body_color)
+    mat_nozzle = _make_material(stage, name, "NozzleMat", nozzle_color)
+    mat_target = _make_material(stage, name, "TargetMat", target_color)
+    tx, ty, tz = tray_size
+    cx, cy, cz = column_size
+    ax, az = arm_section
+    tray_top = tz
+    column_x = tx / 2.0 - cx / 2.0  # column flush with the tray's back edge
+    _add_box(stage, name, "tray", (0.0, 0.0, tz / 2.0), tray_size, mat_body)
+    _add_box(stage, name, "column", (column_x, 0.0, tray_top + cz / 2.0), column_size, mat_body)
+    # arm: from the column's front face to just past the nozzle (at x = 0)
+    arm_x0 = column_x - cx / 2.0
+    arm_x1 = -arm_overhang
+    arm_len = arm_x0 - arm_x1
+    arm_z = tray_top + spout_height + nozzle_length + az / 2.0
+    _add_box(stage, name, "arm", ((arm_x0 + arm_x1) / 2.0, 0.0, arm_z), (arm_len, ax, az), mat_body)
+    nozzle_z = tray_top + spout_height + nozzle_length / 2.0
+    _add_cylinder(stage, name, "nozzle", (0.0, 0.0, nozzle_z), nozzle_radius, nozzle_length, mat_nozzle)
+    # visual-only target disk on the tray (no collision: a cup stands on the tray)
+    _add_cylinder(stage, name, "target_disk", (0.0, 0.0, tray_top + 0.0005), target_disk_radius, 0.001, mat_target, collide=False)
+    stage.GetRootLayer().Save()
+    manifest = {
+        "name": name,
+        "usd": usd_path.name,
+        "frame": "origin at the tray centre on the table; +z up; open side faces -x (column at +x)",
+        "params": {
+            "tray_size": list(tray_size),
+            "column_size": list(column_size),
+            "arm_section": list(arm_section),
+            "arm_overhang": arm_overhang,
+            "nozzle_radius": nozzle_radius,
+            "nozzle_length": nozzle_length,
+            "spout_height": spout_height,
+            "target_disk_radius": target_disk_radius,
+            "body_color": list(body_color),
+            "nozzle_color": list(nozzle_color),
+            "target_color": list(target_color),
+        },
+        "tray_top": tray_top,
+        "spot_local": [0.0, 0.0, tray_top],
+        "spout_bottom_local": [0.0, 0.0, tray_top + spout_height],
+        "arm_bottom_z": tray_top + spout_height + nozzle_length,
+        "footprint_half": [tx / 2.0, ty / 2.0],
+        "column_front_x": arm_x0,
+        "height": tray_top + cz,
+        "target_disk_radius": target_disk_radius,
+    }
+    manifest_path.write_text(json.dumps(manifest, indent=2))
+    return usd_path, manifest_path
+
+
+def ensure_dispenser_asset(name: str = "dispenser", out_dir: Path | None = None, **params) -> tuple[Path, dict]:
+    """Return ``(usd_path, manifest)`` for a dispenser prop, generating it if
+    missing or if the stored parameters differ from ``params``."""
+    return _ensure_asset(build_dispenser, DISPENSER_ASSET_DIR, name, out_dir, params)

--- a/source/dexverse/dexverse/assets/rack_builder.py
+++ b/source/dexverse/dexverse/assets/rack_builder.py
@@ -1,0 +1,144 @@
+# Copyright (c) 2025-2026, The DexVerse Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Procedural multi-level rack (shelf unit) generator.
+
+The rack is one kinematic rigid body made of box prims -- four slim corner
+posts plus ``levels`` shelf boards -- open at the front and on both sides so two
+hands can take a tray by its side edges. Next to the ``.usda`` a manifest JSON
+records every level's frame (shelf-top height, usable x/y extents, clearance to
+the level above) in the rack's local frame, so task configs can place objects
+on a chosen level analytically.
+
+Rack local frame: origin at the centre of the footprint on the *bottom* face
+(z = 0 is where the rack stands on the table); +x = depth (the open front is the
+-x face, i.e. facing the robot when the rack stands at +x on the table); +y =
+width; +z = up.
+
+Task configs call :func:`ensure_rack_asset` at construction time, which builds
+the files on first use (the assets tree is not tracked by git). The CLI wrapper
+is ``scripts/asset_tools/build_rack_usd.py``.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+RACK_ASSET_DIR = Path(__file__).resolve().parent / "core_assets" / "dexverse_authored" / "rack"
+
+
+def build_rack(
+    out_dir: Path,
+    name: str = "rack_3level",
+    levels: int = 3,
+    spacing: float = 0.18,
+    depth: float = 0.40,
+    width: float = 0.55,
+    board_thickness: float = 0.02,
+    post_size: float = 0.03,
+    bottom_gap: float = 0.10,
+    top_margin: float = 0.03,
+    color: tuple[float, float, float] = (0.55, 0.42, 0.28),
+) -> tuple[Path, Path]:
+    """Write ``<name>.usda`` + ``<name>_manifest.json`` and return their paths."""
+    from pxr import Gf, Sdf, Usd, UsdGeom, UsdPhysics, UsdShade
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    usd_path = out_dir / f"{name}.usda"
+    manifest_path = out_dir / f"{name}_manifest.json"
+
+    # Level k shelf board occupies [z_k - t, z_k] with z_k its top face.
+    level_tops = [bottom_gap + k * spacing for k in range(levels)]
+    # Posts run from the table to a little above the top shelf.
+    post_height = level_tops[-1] + top_margin
+
+    stage = Usd.Stage.CreateNew(str(usd_path))
+    UsdGeom.SetStageUpAxis(stage, UsdGeom.Tokens.z)
+    UsdGeom.SetStageMetersPerUnit(stage, 1.0)
+    root = UsdGeom.Xform.Define(stage, f"/{name}")
+    stage.SetDefaultPrim(root.GetPrim())
+    UsdPhysics.RigidBodyAPI.Apply(root.GetPrim())
+    mass_api = UsdPhysics.MassAPI.Apply(root.GetPrim())
+    mass_api.CreateMassAttr(5.0)
+    root.GetPrim().CreateAttribute("physics:rigidBodyEnabled", Sdf.ValueTypeNames.Bool).Set(True)
+
+    # material
+    UsdGeom.Scope.Define(stage, f"/{name}/Looks")
+    mat = UsdShade.Material.Define(stage, f"/{name}/Looks/RackMat")
+    shader = UsdShade.Shader.Define(stage, f"/{name}/Looks/RackMat/PreviewSurface")
+    shader.CreateIdAttr("UsdPreviewSurface")
+    shader.CreateInput("diffuseColor", Sdf.ValueTypeNames.Color3f).Set(Gf.Vec3f(*color))
+    shader.CreateInput("roughness", Sdf.ValueTypeNames.Float).Set(0.8)
+    shader.CreateInput("metallic", Sdf.ValueTypeNames.Float).Set(0.0)
+    mat.CreateSurfaceOutput().ConnectToSource(shader.ConnectableAPI(), "surface")
+
+    def add_box(prim_name: str, center: tuple[float, float, float], size: tuple[float, float, float]) -> None:
+        cube = UsdGeom.Cube.Define(stage, f"/{name}/{prim_name}")
+        cube.CreateSizeAttr(1.0)
+        xf = UsdGeom.Xformable(cube.GetPrim())
+        xf.AddTranslateOp().Set(Gf.Vec3d(*center))
+        xf.AddScaleOp().Set(Gf.Vec3f(*size))
+        UsdPhysics.CollisionAPI.Apply(cube.GetPrim())
+        cube.GetPrim().CreateAttribute("physics:collisionEnabled", Sdf.ValueTypeNames.Bool).Set(True)
+        UsdShade.MaterialBindingAPI.Apply(cube.GetPrim()).Bind(mat)
+
+    hx, hy = depth / 2.0, width / 2.0
+    p = post_size / 2.0
+    for i, (sx, sy) in enumerate(((1, 1), (1, -1), (-1, 1), (-1, -1))):
+        add_box(f"post_{i}", (sx * (hx - p), sy * (hy - p), post_height / 2.0), (post_size, post_size, post_height))
+    for k, z_top in enumerate(level_tops):
+        add_box(
+            f"shelf_{k}",
+            (0.0, 0.0, z_top - board_thickness / 2.0),
+            (depth - 2 * post_size, width - 2 * post_size, board_thickness),
+        )
+    stage.GetRootLayer().Save()
+
+    manifest = {
+        "name": name,
+        "usd": usd_path.name,
+        "frame": "origin at footprint centre on the bottom face; +x depth (open front is -x), +y width, +z up",
+        "params": {
+            "levels": levels,
+            "spacing": spacing,
+            "depth": depth,
+            "width": width,
+            "board_thickness": board_thickness,
+            "post_size": post_size,
+            "bottom_gap": bottom_gap,
+            "top_margin": top_margin,
+        },
+        "footprint": {"x_half": hx, "y_half": hy, "height": post_height},
+        "levels": [
+            {
+                "index": k,
+                "z_top": z_top,
+                "clearance": (level_tops[k + 1] - board_thickness - z_top) if k + 1 < levels else None,
+                "x_range": [-(hx - post_size), (hx - post_size)],
+                "y_range": [-(hy - post_size), (hy - post_size)],
+            }
+            for k, z_top in enumerate(level_tops)
+        ],
+    }
+    manifest_path.write_text(json.dumps(manifest, indent=2))
+    return usd_path, manifest_path
+
+
+
+
+def ensure_rack_asset(name: str = "rack_3level", out_dir: Path | None = None, **params) -> tuple[Path, dict]:
+    """Return ``(usd_path, manifest)`` for a rack, generating it if missing or
+    if the stored parameters differ from ``params``."""
+    out_dir = Path(out_dir) if out_dir is not None else RACK_ASSET_DIR
+    usd_path = out_dir / f"{name}.usda"
+    manifest_path = out_dir / f"{name}_manifest.json"
+    if usd_path.is_file() and manifest_path.is_file():
+        manifest = json.loads(manifest_path.read_text())
+        stored = manifest.get("params", {})
+        if all(abs(float(stored.get(k, float("nan"))) - float(v)) < 1e-9 for k, v in params.items()):
+            return usd_path, manifest
+    usd_path, manifest_path = build_rack(out_dir, name=name, **params)
+    return usd_path, json.loads(manifest_path.read_text())

--- a/source/dexverse/dexverse/assets/shelf_builder.py
+++ b/source/dexverse/dexverse/assets/shelf_builder.py
@@ -1,0 +1,253 @@
+# Copyright (c) 2025-2026, The DexVerse Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Procedural single-slot shelf ("cubby with one gap") generator.
+
+A minimalist shelf for insertion tasks: base + back + two side walls, plus the
+slot-forming blocks. Two orientations:
+
+- ``slot_orientation="vertical"`` (default): two filler regions flank a single
+  vertical slot. They can be solid blocks, or short individual folder props
+  when ``vertical_filler_style="folder_props"``. In both cases the centre slot
+  remains the intended opening and the object stands in it like a file.
+- ``slot_orientation="horizontal"``: one solid block fills the cavity from the
+  base up to ``slot_bottom_height``; its top face is the slot floor (the slot's
+  only, *bottom* limit -- there is deliberately no upper board), and the object
+  is laid flat on it through the open front / top.
+
+Open at the front (-x) and, by default, at the top. One kinematic rigid USD;
+``<name>_manifest.json`` records the slot frame in the shelf's local frame so a
+task can test "object inside the slot" analytically (``width_axis_local`` is
+the shelf-local axis the inserted object's thickness axis must align with:
+``+y`` for the vertical slot, ``+z`` -- i.e. lying flat -- for the horizontal).
+
+Shelf local frame: origin at the centre of the footprint on the *bottom* face
+(z = 0 where it stands), +x depth (open front is -x), +y width, +z up.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from pathlib import Path
+
+SHELF_ASSET_DIR = Path(__file__).resolve().parent / "core_assets" / "dexverse_authored" / "shelf"
+
+
+def build_slot_shelf(
+    out_dir: Path,
+    name: str = "slot_shelf",
+    inner_depth: float = 0.30,
+    slot_width: float = 0.09,
+    filler_width: float = 0.20,
+    height: float = 0.32,
+    panel_thickness: float = 0.02,
+    top_closed: bool = False,
+    slot_orientation: str = "vertical",
+    vertical_filler_style: str = "solid",
+    slot_bottom_height: float = 0.10,
+    color: tuple[float, float, float] = (0.55, 0.42, 0.28),
+    filler_color: tuple[float, float, float] = (0.36, 0.30, 0.26),
+) -> tuple[Path, Path]:
+    """Write ``<name>.usda`` + ``<name>_manifest.json`` and return their paths."""
+    from pxr import Gf, Sdf, Usd, UsdGeom, UsdPhysics, UsdShade
+
+    if slot_orientation not in ("vertical", "horizontal"):
+        raise ValueError(f"slot_orientation must be 'vertical' or 'horizontal', got {slot_orientation!r}")
+    if vertical_filler_style not in ("solid", "folder_props"):
+        raise ValueError(
+            "vertical_filler_style must be 'solid' or 'folder_props', "
+            f"got {vertical_filler_style!r}"
+        )
+    out_dir.mkdir(parents=True, exist_ok=True)
+    usd_path = out_dir / f"{name}.usda"
+    manifest_path = out_dir / f"{name}_manifest.json"
+
+    t = panel_thickness
+    depth = inner_depth + t  # + back panel
+    width = 2 * t + 2 * filler_width + slot_width
+    hx, hy = depth / 2.0, width / 2.0
+    inner_h = height - t  # above the base board
+
+    stage = Usd.Stage.CreateNew(str(usd_path))
+    UsdGeom.SetStageUpAxis(stage, UsdGeom.Tokens.z)
+    UsdGeom.SetStageMetersPerUnit(stage, 1.0)
+    root = UsdGeom.Xform.Define(stage, f"/{name}")
+    stage.SetDefaultPrim(root.GetPrim())
+    UsdPhysics.RigidBodyAPI.Apply(root.GetPrim())
+    UsdPhysics.MassAPI.Apply(root.GetPrim()).CreateMassAttr(8.0)
+    root.GetPrim().CreateAttribute("physics:rigidBodyEnabled", Sdf.ValueTypeNames.Bool).Set(True)
+
+    UsdGeom.Scope.Define(stage, f"/{name}/Looks")
+
+    def make_material(mname, rgb):
+        mat = UsdShade.Material.Define(stage, f"/{name}/Looks/{mname}")
+        sh = UsdShade.Shader.Define(stage, f"/{name}/Looks/{mname}/PreviewSurface")
+        sh.CreateIdAttr("UsdPreviewSurface")
+        sh.CreateInput("diffuseColor", Sdf.ValueTypeNames.Color3f).Set(Gf.Vec3f(*rgb))
+        sh.CreateInput("roughness", Sdf.ValueTypeNames.Float).Set(0.85)
+        sh.CreateInput("metallic", Sdf.ValueTypeNames.Float).Set(0.0)
+        mat.CreateSurfaceOutput().ConnectToSource(sh.ConnectableAPI(), "surface")
+        return mat
+
+    mat_frame = make_material("ShelfMat", color)
+    mat_fill = make_material("FillerMat", filler_color)
+    if vertical_filler_style == "folder_props":
+        folder_materials = (
+            make_material("FolderBlue", (0.24, 0.39, 0.58)),
+            make_material("FolderRust", (0.62, 0.30, 0.22)),
+            make_material("FolderGreen", (0.28, 0.48, 0.36)),
+        )
+        mat_label = make_material("FolderLabel", (0.84, 0.81, 0.68))
+    else:
+        folder_materials = ()
+        mat_label = None
+
+    def add_box(prim_name, center, size, mat, parent_path=None, collision=True):
+        parent_path = parent_path or f"/{name}"
+        cube = UsdGeom.Cube.Define(stage, f"{parent_path}/{prim_name}")
+        cube.CreateSizeAttr(1.0)
+        xf = UsdGeom.Xformable(cube.GetPrim())
+        xf.AddTranslateOp().Set(Gf.Vec3d(*center))
+        xf.AddScaleOp().Set(Gf.Vec3f(*size))
+        if collision:
+            UsdPhysics.CollisionAPI.Apply(cube.GetPrim())
+            cube.GetPrim().CreateAttribute("physics:collisionEnabled", Sdf.ValueTypeNames.Bool).Set(True)
+        UsdShade.MaterialBindingAPI.Apply(cube.GetPrim()).Bind(mat)
+
+    def add_folder_prop(prim_name, center, size, lean_x_deg, mat):
+        """Add one collidable file folder plus a small visual front label."""
+        if mat_label is None:
+            raise RuntimeError("Folder props require the folder-prop materials")
+        folder_path = f"/{name}/{prim_name}"
+        folder = UsdGeom.Xform.Define(stage, folder_path)
+        folder_xf = UsdGeom.Xformable(folder.GetPrim())
+        folder_xf.AddTranslateOp().Set(Gf.Vec3d(*center))
+        folder_xf.AddRotateXYZOp().Set(Gf.Vec3f(lean_x_deg, 0.0, 0.0))
+        depth, thickness, folder_height = size
+        add_box("body", (0.0, 0.0, 0.0), size, mat, parent_path=folder_path)
+        # A recessed paper label on the visible front edge makes the cuboid read
+        # as a stored folder without adding another collision surface.
+        add_box(
+            "label",
+            (-depth / 2.0 - 0.0011, 0.0, -folder_height / 2.0 + 0.065),
+            (0.002, thickness * 0.68, 0.045),
+            mat_label,
+            parent_path=folder_path,
+            collision=False,
+        )
+
+    # frame
+    add_box("base", (0.0, 0.0, t / 2.0), (depth, width, t), mat_frame)
+    add_box("back", (hx - t / 2.0, 0.0, height / 2.0), (t, width, height), mat_frame)
+    add_box("side_left", (0.0, hy - t / 2.0, height / 2.0), (depth, t, height), mat_frame)
+    add_box("side_right", (0.0, -(hy - t / 2.0), height / 2.0), (depth, t, height), mat_frame)
+    if top_closed:
+        add_box("top", (0.0, 0.0, height - t / 2.0), (depth, width, t), mat_frame)
+    fx = -t / 2.0  # centred on the inner cavity (front face at -hx, back panel inner face at hx - t)
+    if slot_orientation == "vertical":
+        fz = t + inner_h / 2.0
+        if vertical_filler_style == "solid":
+            # Solid fillers run from each side wall to the slot edge.
+            fy = slot_width / 2.0 + filler_width / 2.0
+            add_box("filler_left", (fx, fy, fz), (inner_depth, filler_width, inner_h), mat_fill)
+            add_box("filler_right", (fx, -fy, fz), (inner_depth, filler_width, inner_h), mat_fill)
+        else:
+            # Three recognisable folders per side. They are shorter and
+            # shallower than the cavity, with small gaps and one leaning folder
+            # in each group. The innermost upright folder starts 3 mm beyond
+            # the nominal slot edge, preserving the configured opening.
+            prop_specs = (
+                # y from slot centre, depth, thickness, height, outward lean
+                (0.054, 0.235, 0.022, 0.270, 0.0),
+                (0.089, 0.250, 0.024, 0.255, 5.0),
+                (0.137, 0.225, 0.030, 0.280, 0.0),
+            )
+            back_inner_x = hx - t
+            for side_name, side_sign in (("left", 1.0), ("right", -1.0)):
+                for index, (y_offset, prop_depth, prop_thickness, prop_height, lean_deg) in enumerate(prop_specs):
+                    lean_x_deg = -side_sign * lean_deg  # top leans away from the slot
+                    lean_rad = abs(lean_deg) * math.pi / 180.0
+                    rotated_half_height = 0.5 * (
+                        prop_height * math.cos(lean_rad) + prop_thickness * math.sin(lean_rad)
+                    )
+                    center = (
+                        back_inner_x - prop_depth / 2.0,
+                        side_sign * y_offset,
+                        t + rotated_half_height,
+                    )
+                    add_folder_prop(
+                        f"folder_{side_name}_{index}",
+                        center,
+                        (prop_depth, prop_thickness, prop_height),
+                        lean_x_deg,
+                        folder_materials[index],
+                    )
+        slot = {
+            "center": [fx, 0.0, fz],
+            "half_extents": [inner_depth / 2.0, slot_width / 2.0, inner_h / 2.0],
+            "width_axis_local": [0.0, 1.0, 0.0],
+            "base_top_z": t,
+            "front_x": -hx,
+        }
+    else:
+        # bottom limit: one solid block from the base to the slot floor, full inner
+        # width and depth. Its top face is the slot's only limit -- no upper board,
+        # so the slot region runs from the floor up to the (open) shelf top and the
+        # object is laid flat on the block.
+        inner_w = width - 2 * t
+        slot_floor = t + slot_bottom_height
+        add_box("bottom_limit", (fx, 0.0, t + slot_bottom_height / 2.0), (inner_depth, inner_w, slot_bottom_height), mat_fill)
+        slot = {
+            "center": [fx, 0.0, (slot_floor + height) / 2.0],
+            "half_extents": [inner_depth / 2.0, inner_w / 2.0, (height - slot_floor) / 2.0],
+            "width_axis_local": [0.0, 0.0, 1.0],
+            "base_top_z": slot_floor,
+            "front_x": -hx,
+        }
+    stage.GetRootLayer().Save()
+
+    manifest = {
+        "name": name,
+        "usd": usd_path.name,
+        "frame": "origin at footprint centre on the bottom face; +x depth (open front is -x), +y width, +z up",
+        "params": {
+            "inner_depth": inner_depth,
+            "slot_width": slot_width,
+            "filler_width": filler_width,
+            "height": height,
+            "panel_thickness": panel_thickness,
+            "top_closed": top_closed,
+            "slot_orientation": slot_orientation,
+            "vertical_filler_style": vertical_filler_style,
+            "slot_bottom_height": slot_bottom_height,
+            "color": list(color),
+            "filler_color": list(filler_color),
+        },
+        "footprint": {"x_half": hx, "y_half": hy, "height": height},
+        "slot": slot,
+    }
+    manifest_path.write_text(json.dumps(manifest, indent=2))
+    return usd_path, manifest_path
+
+
+def ensure_slot_shelf_asset(name: str = "slot_shelf", out_dir: Path | None = None, **params) -> tuple[Path, dict]:
+    """Return ``(usd_path, manifest)`` for a slot shelf, generating it if missing or
+    if the stored parameters differ from ``params``."""
+    out_dir = Path(out_dir) if out_dir is not None else SHELF_ASSET_DIR
+    usd_path = out_dir / f"{name}.usda"
+    manifest_path = out_dir / f"{name}_manifest.json"
+    if usd_path.is_file() and manifest_path.is_file():
+        manifest = json.loads(manifest_path.read_text())
+        stored = manifest.get("params", {})
+
+        def _norm(v):
+            # JSON round-trips tuples as lists; compare like-for-like.
+            return list(v) if isinstance(v, tuple) else v
+
+        if all(k in stored and stored[k] == _norm(v) for k, v in params.items()):
+            return usd_path, manifest
+    usd_path, manifest_path = build_slot_shelf(out_dir, name=name, **params)
+    return usd_path, json.loads(manifest_path.read_text())

--- a/source/dexverse/dexverse/assets/small_table_builder.py
+++ b/source/dexverse/dexverse/assets/small_table_builder.py
@@ -1,0 +1,133 @@
+# Copyright (c) 2025-2026, The DexVerse Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Procedural small side-table generator.
+
+The table is one kinematic rigid body made of box prims -- a rectangular top
+slab on four corner legs -- used as an object stand (e.g. the hammer-strike
+hammer stand) so an episode starts with a furniture affordance rather than the
+object lying on the main tabletop. Next to the ``.usda`` a manifest JSON
+records the top-face height (``z_top``) and usable top extents in the table's
+local frame, so task configs can seat objects on the top analytically.
+
+Table local frame: origin at the centre of the footprint on the *bottom* face
+(z = 0 is where the table stands on the main tabletop); +x = depth, +y = width,
++z = up. ``z_top`` equals the overall ``height``.
+
+Task configs call :func:`ensure_small_table_asset` at construction time, which
+builds the files on first use (the assets tree is not tracked by git).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+SMALL_TABLE_ASSET_DIR = Path(__file__).resolve().parent / "core_assets" / "dexverse_authored" / "small_table"
+
+
+def _param_values_match(stored, requested) -> bool:
+    """Compare cached scalar or sequence-valued builder parameters."""
+    if isinstance(requested, (list, tuple)):
+        return (
+            isinstance(stored, (list, tuple))
+            and len(stored) == len(requested)
+            and all(_param_values_match(old, new) for old, new in zip(stored, requested, strict=True))
+        )
+    try:
+        return abs(float(stored) - float(requested)) < 1e-9
+    except (TypeError, ValueError):
+        return stored == requested
+
+
+def build_small_table(
+    out_dir: Path,
+    name: str = "small_table",
+    depth: float = 0.40,
+    width: float = 0.40,
+    height: float = 0.06,
+    top_thickness: float = 0.012,
+    leg_size: float = 0.022,
+    color: tuple[float, float, float] = (0.55, 0.42, 0.28),
+) -> tuple[Path, Path]:
+    """Write ``<name>.usda`` + ``<name>_manifest.json`` and return their paths."""
+    from pxr import Gf, Sdf, Usd, UsdGeom, UsdPhysics, UsdShade
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    usd_path = out_dir / f"{name}.usda"
+    manifest_path = out_dir / f"{name}_manifest.json"
+
+    leg_height = height - top_thickness
+
+    stage = Usd.Stage.CreateNew(str(usd_path))
+    UsdGeom.SetStageUpAxis(stage, UsdGeom.Tokens.z)
+    UsdGeom.SetStageMetersPerUnit(stage, 1.0)
+    root = UsdGeom.Xform.Define(stage, f"/{name}")
+    stage.SetDefaultPrim(root.GetPrim())
+    UsdPhysics.RigidBodyAPI.Apply(root.GetPrim())
+    mass_api = UsdPhysics.MassAPI.Apply(root.GetPrim())
+    mass_api.CreateMassAttr(3.0)
+    root.GetPrim().CreateAttribute("physics:rigidBodyEnabled", Sdf.ValueTypeNames.Bool).Set(True)
+
+    # material
+    UsdGeom.Scope.Define(stage, f"/{name}/Looks")
+    mat = UsdShade.Material.Define(stage, f"/{name}/Looks/TableMat")
+    shader = UsdShade.Shader.Define(stage, f"/{name}/Looks/TableMat/PreviewSurface")
+    shader.CreateIdAttr("UsdPreviewSurface")
+    shader.CreateInput("diffuseColor", Sdf.ValueTypeNames.Color3f).Set(Gf.Vec3f(*color))
+    shader.CreateInput("roughness", Sdf.ValueTypeNames.Float).Set(0.8)
+    shader.CreateInput("metallic", Sdf.ValueTypeNames.Float).Set(0.0)
+    mat.CreateSurfaceOutput().ConnectToSource(shader.ConnectableAPI(), "surface")
+
+    def add_box(prim_name: str, center: tuple[float, float, float], size: tuple[float, float, float]) -> None:
+        cube = UsdGeom.Cube.Define(stage, f"/{name}/{prim_name}")
+        cube.CreateSizeAttr(1.0)
+        xf = UsdGeom.Xformable(cube.GetPrim())
+        xf.AddTranslateOp().Set(Gf.Vec3d(*center))
+        xf.AddScaleOp().Set(Gf.Vec3f(*size))
+        UsdPhysics.CollisionAPI.Apply(cube.GetPrim())
+        cube.GetPrim().CreateAttribute("physics:collisionEnabled", Sdf.ValueTypeNames.Bool).Set(True)
+        UsdShade.MaterialBindingAPI.Apply(cube.GetPrim()).Bind(mat)
+
+    hx, hy = depth / 2.0, width / 2.0
+    p = leg_size / 2.0
+    for i, (sx, sy) in enumerate(((1, 1), (1, -1), (-1, 1), (-1, -1))):
+        add_box(f"leg_{i}", (sx * (hx - p), sy * (hy - p), leg_height / 2.0), (leg_size, leg_size, leg_height))
+    add_box("top", (0.0, 0.0, height - top_thickness / 2.0), (depth, width, top_thickness))
+    stage.GetRootLayer().Save()
+
+    manifest = {
+        "name": name,
+        "usd": usd_path.name,
+        "frame": "origin at footprint centre on the bottom face; +x depth, +y width, +z up",
+        "params": {
+            "depth": depth,
+            "width": width,
+            "height": height,
+            "top_thickness": top_thickness,
+            "leg_size": leg_size,
+            "color": color,
+        },
+        "footprint": {"x_half": hx, "y_half": hy, "height": height},
+        "z_top": height,
+        "top": {"x_range": [-hx, hx], "y_range": [-hy, hy]},
+    }
+    manifest_path.write_text(json.dumps(manifest, indent=2))
+    return usd_path, manifest_path
+
+
+def ensure_small_table_asset(name: str = "small_table", out_dir: Path | None = None, **params) -> tuple[Path, dict]:
+    """Return ``(usd_path, manifest)`` for a small table, generating it if
+    missing or if the stored parameters differ from ``params``."""
+    out_dir = Path(out_dir) if out_dir is not None else SMALL_TABLE_ASSET_DIR
+    usd_path = out_dir / f"{name}.usda"
+    manifest_path = out_dir / f"{name}_manifest.json"
+    if usd_path.is_file() and manifest_path.is_file():
+        manifest = json.loads(manifest_path.read_text())
+        stored = manifest.get("params", {})
+        if all(k in stored and _param_values_match(stored[k], v) for k, v in params.items()):
+            return usd_path, manifest
+    usd_path, manifest_path = build_small_table(out_dir, name=name, **params)
+    return usd_path, json.loads(manifest_path.read_text())

--- a/source/dexverse/dexverse/baseline_v1/__init__.py
+++ b/source/dexverse/dexverse/baseline_v1/__init__.py
@@ -1,0 +1,8 @@
+"""Version-one implementations of the 20 baseline tasks, not a benchmark-wide fork."""
+
+from dexverse.benchmark import V1_CONFIGS
+
+from dexverse.tasks.utils.registration import register_env
+
+for _task, (_module, _class) in V1_CONFIGS.items():
+    register_env(f"{__name__}.config", _task, _module, _class)

--- a/source/dexverse/dexverse/baseline_v1/adr_curriculum.py
+++ b/source/dexverse/dexverse/baseline_v1/adr_curriculum.py
@@ -1,0 +1,127 @@
+# Copyright (c) 2025-2026, The DexVerse Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# Copyright (c) 2022-2025, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+from isaaclab.managers import CurriculumTermCfg as CurrTerm
+from isaaclab.utils import configclass
+
+from . import mdp
+
+
+@configclass
+class CurriculumCfg:
+    """Curriculum terms for the MDP."""
+
+    # adr stands for automatic/adaptive domain randomization
+    adr = CurrTerm(
+        func=mdp.DifficultyScheduler, params={"init_difficulty": 0, "min_difficulty": 0, "max_difficulty": 10}
+    )
+
+    joint_pos_unoise_min_adr = CurrTerm(
+        func=mdp.modify_term_cfg,
+        params={
+            "address": "observations.proprio.joint_pos.noise.n_min",
+            "modify_fn": mdp.initial_final_interpolate_fn,
+            "modify_params": {"initial_value": 0.0, "final_value": -0.1, "difficulty_term_str": "adr"},
+        },
+    )
+
+    joint_pos_unoise_max_adr = CurrTerm(
+        func=mdp.modify_term_cfg,
+        params={
+            "address": "observations.proprio.joint_pos.noise.n_max",
+            "modify_fn": mdp.initial_final_interpolate_fn,
+            "modify_params": {"initial_value": 0.0, "final_value": 0.1, "difficulty_term_str": "adr"},
+        },
+    )
+
+    joint_vel_unoise_min_adr = CurrTerm(
+        func=mdp.modify_term_cfg,
+        params={
+            "address": "observations.proprio.joint_vel.noise.n_min",
+            "modify_fn": mdp.initial_final_interpolate_fn,
+            "modify_params": {"initial_value": 0.0, "final_value": -0.2, "difficulty_term_str": "adr"},
+        },
+    )
+
+    joint_vel_unoise_max_adr = CurrTerm(
+        func=mdp.modify_term_cfg,
+        params={
+            "address": "observations.proprio.joint_vel.noise.n_max",
+            "modify_fn": mdp.initial_final_interpolate_fn,
+            "modify_params": {"initial_value": 0.0, "final_value": 0.2, "difficulty_term_str": "adr"},
+        },
+    )
+
+    hand_tips_pos_unoise_min_adr = CurrTerm(
+        func=mdp.modify_term_cfg,
+        params={
+            "address": "observations.proprio.hand_tips_state_b.noise.n_min",
+            "modify_fn": mdp.initial_final_interpolate_fn,
+            "modify_params": {"initial_value": 0.0, "final_value": -0.01, "difficulty_term_str": "adr"},
+        },
+    )
+
+    hand_tips_pos_unoise_max_adr = CurrTerm(
+        func=mdp.modify_term_cfg,
+        params={
+            "address": "observations.proprio.hand_tips_state_b.noise.n_max",
+            "modify_fn": mdp.initial_final_interpolate_fn,
+            "modify_params": {"initial_value": 0.0, "final_value": 0.01, "difficulty_term_str": "adr"},
+        },
+    )
+
+    object_quat_unoise_min_adr = CurrTerm(
+        func=mdp.modify_term_cfg,
+        params={
+            "address": "observations.policy.object_quat_b.noise.n_min",
+            "modify_fn": mdp.initial_final_interpolate_fn,
+            "modify_params": {"initial_value": 0.0, "final_value": -0.03, "difficulty_term_str": "adr"},
+        },
+    )
+
+    object_quat_unoise_max_adr = CurrTerm(
+        func=mdp.modify_term_cfg,
+        params={
+            "address": "observations.policy.object_quat_b.noise.n_max",
+            "modify_fn": mdp.initial_final_interpolate_fn,
+            "modify_params": {"initial_value": 0.0, "final_value": 0.03, "difficulty_term_str": "adr"},
+        },
+    )
+
+    object_obs_unoise_min_adr = CurrTerm(
+        func=mdp.modify_term_cfg,
+        params={
+            "address": "observations.perception.object_point_cloud.noise.n_min",
+            "modify_fn": mdp.initial_final_interpolate_fn,
+            "modify_params": {"initial_value": 0.0, "final_value": -0.01, "difficulty_term_str": "adr"},
+        },
+    )
+
+    object_obs_unoise_max_adr = CurrTerm(
+        func=mdp.modify_term_cfg,
+        params={
+            "address": "observations.perception.object_point_cloud.noise.n_max",
+            "modify_fn": mdp.initial_final_interpolate_fn,
+            "modify_params": {"initial_value": 0.0, "final_value": -0.01, "difficulty_term_str": "adr"},
+        },
+    )
+
+    gravity_adr = CurrTerm(
+        func=mdp.modify_term_cfg,
+        params={
+            "address": "events.variable_gravity.params.gravity_distribution_params",
+            "modify_fn": mdp.initial_final_interpolate_fn,
+            "modify_params": {
+                "initial_value": ((0.0, 0.0, 0.0), (0.0, 0.0, 0.0)),
+                "final_value": ((0.0, 0.0, -9.81), (0.0, 0.0, -9.81)),
+                "difficulty_term_str": "adr",
+            },
+        },
+    )

--- a/source/dexverse/dexverse/baseline_v1/config/__init__.py
+++ b/source/dexverse/dexverse/baseline_v1/config/__init__.py
@@ -1,0 +1,1 @@
+"""Version-one baseline task implementation package."""

--- a/source/dexverse/dexverse/baseline_v1/config/articulation/__init__.py
+++ b/source/dexverse/dexverse/baseline_v1/config/articulation/__init__.py
@@ -1,0 +1,1 @@
+"""Version-one baseline task implementation package."""

--- a/source/dexverse/dexverse/baseline_v1/config/articulation/articulation_base/__init__.py
+++ b/source/dexverse/dexverse/baseline_v1/config/articulation/articulation_base/__init__.py
@@ -1,0 +1,34 @@
+# Copyright (c) 2025-2026, The DexVerse Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Base configuration for tabletop articulated-object manipulation tasks.
+
+Provides reusable config classes for tasks where an articulated object sits on
+the tabletop and the success condition is that one of its joints reaches a
+target value (angle for revolute, distance for prismatic).
+
+Child task modules subclass :class:`ArticulationBaseEnvFloatingDexHandRightCfg`,
+override the class attributes (USD path, scale, init pose, joint name, success
+threshold), and register the resulting class as a gym environment.
+
+This module does not register any gym environments itself.
+"""
+
+from .articulation_base_cfg import (  # noqa: F401
+    ArticulationBaseEnvCfg,
+    ArticulationBaseEnvFloatingDexHandRightCfg,
+    ArticulationBaseEventCfg,
+    ArticulationBaseObservationsCfg,
+    ArticulationBaseRewardsCfg,
+    ArticulationBaseSceneCfg,
+    ArticulationBaseTerminationsCfg,
+    make_articulation_cfg,
+    make_multi_articulation_cfg,
+)
+from .usd_helpers import (  # noqa: F401
+    collect_articulation_usds_from_dir,
+    ensure_single_articulation_root,
+    is_usd_file_path,
+)

--- a/source/dexverse/dexverse/baseline_v1/config/articulation/articulation_base/articulation_base_cfg.py
+++ b/source/dexverse/dexverse/baseline_v1/config/articulation/articulation_base/articulation_base_cfg.py
@@ -1,0 +1,578 @@
+# Copyright (c) 2025-2026, The DexVerse Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Base configuration classes for tabletop articulated-object tasks.
+
+The success criterion is that the articulation's target joint(s) reach a
+threshold position (angle for revolute joints, distance for prismatic joints).
+
+A child task overrides the class attributes prefixed with ``articulation_`` and
+``success_`` on a subclass of :class:`ArticulationBaseEnvFloatingDexHandRightCfg`,
+then registers that class as a gym environment.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import MISSING
+from typing import Any
+
+import isaaclab.sim as sim_utils
+from isaaclab.assets import ArticulationCfg
+from isaaclab.devices.openxr import XrCfg
+from isaaclab.managers import EventTermCfg as EventTerm
+from isaaclab.managers import ObservationGroupCfg as ObsGroup
+from isaaclab.managers import ObservationTermCfg as ObsTerm
+from isaaclab.managers import RewardTermCfg as RewTerm
+from isaaclab.managers import SceneEntityCfg
+from isaaclab.managers import TerminationTermCfg as DoneTerm
+from isaaclab.sensors import ContactSensorCfg
+from isaaclab.utils import configclass
+from isaaclab.utils.noise import UniformNoiseCfg as Unoise
+
+from .... import dexverse_base_env_cfg as dexverse_base_env
+from .... import mdp
+from ...floating_teleop import DEFAULT_FLOATING_SHADOW_XR_CFG, setup_floating_teleop
+from .usd_helpers import (
+    collect_articulation_usds_from_dir,
+    ensure_single_articulation_root,
+    is_usd_file_path,
+    make_floating_articulation_root,
+    normalize_joint_limits,
+    simplify_collision_approximation,
+)
+
+# Standardized scene field name used by all observation/reward/termination/event
+# entries below. Children should not change this — they swap the ArticulationCfg
+# stored at this key via the class attributes.
+ARTICULATION_KEY = "articulation"
+ARTICULATION_PRIM_PATH = "{ENV_REGEX_NS}/Articulation"
+
+
+# Shared implementation (also used by the bimanual tray task): the cfg carries
+# nullable per-collider offsets; the spawn func authors them after spawning.
+CollisionOffsetUsdFileCfg = dexverse_base_env.CollisionOffsetUsdFileCfg
+spawn_articulation_usd_with_collision_offsets = dexverse_base_env.spawn_usd_with_collision_offsets
+
+
+def _make_single_usd_spawn(
+    *,
+    usd_path: str,
+    scale: tuple[float, float, float],
+    fix_root_link: bool | None,
+    contact_offset: float | None = None,
+    rest_offset: float | None = None,
+) -> sim_utils.UsdFileCfg:
+    """Per-asset UsdFileCfg with the standard tabletop articulation physics props."""
+    kwargs = dict(
+        usd_path=usd_path,
+        scale=scale,
+        rigid_props=sim_utils.RigidBodyPropertiesCfg(disable_gravity=False),
+        joint_drive_props=sim_utils.JointDrivePropertiesCfg(
+            max_effort=0.0,
+            stiffness=0.0,
+            damping=0.0,
+        ),
+        articulation_props=sim_utils.ArticulationRootPropertiesCfg(
+            fix_root_link=fix_root_link,
+            enabled_self_collisions=False,
+            solver_position_iteration_count=16,
+            solver_velocity_iteration_count=1,
+        ),
+    )
+    if contact_offset is None and rest_offset is None:
+        return sim_utils.UsdFileCfg(**kwargs)
+    return CollisionOffsetUsdFileCfg(
+        func=spawn_articulation_usd_with_collision_offsets,
+        contact_offset=contact_offset,
+        rest_offset=rest_offset,
+        **kwargs,
+    )
+
+
+def make_articulation_cfg(
+    *,
+    usd_path: str,
+    scale: tuple[float, float, float] = (1.0, 1.0, 1.0),
+    init_pos: tuple[float, float, float] = (0.3, 0.0, 0.1),
+    init_rot: tuple[float, float, float, float] = (1.0, 0.0, 0.0, 0.0),
+    init_joint_pos: dict[str, float] | None = None,
+    fix_root_link: bool | None = True,
+    actuators: dict | None = None,
+    prim_path: str = ARTICULATION_PRIM_PATH,
+    collision_approximation: str | None = "convexDecomposition",
+    contact_offset: float | None = None,
+    rest_offset: float | None = None,
+) -> ArticulationCfg:
+    """Build a single-asset :class:`ArticulationCfg` with tabletop physics props.
+
+    The USD is run through :func:`ensure_single_articulation_root` so assets
+    that author multiple ``ArticulationRootAPI`` prims (e.g. some synthesis
+    USDs) load successfully, then through
+    :func:`simplify_collision_approximation` so expensive ``sdf`` colliders
+    don't stall / hang scene load (``collision_approximation=None`` disables).
+    """
+    usd_path = ensure_single_articulation_root(usd_path)
+    usd_path = simplify_collision_approximation(usd_path, replace_with=collision_approximation)
+    usd_path = normalize_joint_limits(usd_path)
+    # For free-root tasks, relocate the articulation root onto the root rigid
+    # body (fix_base assets author it on the world-fixed ``root_joint``, which
+    # PhysX rejects for a floating articulation).
+    if fix_root_link is False:
+        usd_path = make_floating_articulation_root(usd_path)
+    return ArticulationCfg(
+        prim_path=prim_path,
+        spawn=_make_single_usd_spawn(
+            usd_path=usd_path,
+            scale=scale,
+            fix_root_link=fix_root_link,
+            contact_offset=contact_offset,
+            rest_offset=rest_offset,
+        ),
+        init_state=ArticulationCfg.InitialStateCfg(
+            pos=init_pos,
+            rot=init_rot,
+            joint_pos=init_joint_pos or {},
+        ),
+        actuators=actuators or {},
+    )
+
+
+def make_multi_articulation_cfg(
+    *,
+    usd_paths: list[str],
+    random_choice: bool = False,
+    scale: tuple[float, float, float] = (1.0, 1.0, 1.0),
+    init_pos: tuple[float, float, float] = (0.3, 0.0, 0.1),
+    init_rot: tuple[float, float, float, float] = (1.0, 0.0, 0.0, 0.0),
+    init_joint_pos: dict[str, float] | None = None,
+    fix_root_link: bool | None = True,
+    actuators: dict | None = None,
+    prim_path: str = ARTICULATION_PRIM_PATH,
+    collision_approximation: str | None = "convexDecomposition",
+    contact_offset: float | None = None,
+    rest_offset: float | None = None,
+) -> ArticulationCfg:
+    """Build an :class:`ArticulationCfg` that spawns a different USD per env.
+
+    Uses :class:`sim_utils.MultiAssetSpawnerCfg` (not ``MultiUsdFileCfg``)
+    because articulations need per-asset ``ArticulationRootPropertiesCfg``.
+
+    With ``random_choice=False`` the assignment is deterministic round-robin
+    (``usd_paths[i % N]`` for env i), which lets us control the (env_idx ->
+    asset) mapping ourselves and randomise it manually if we want -- mirrors
+    the convention used in ``pickup_object/base_cfg.py``.
+
+    Each USD is repaired with :func:`ensure_single_articulation_root` and
+    :func:`simplify_collision_approximation` (see :func:`make_articulation_cfg`).
+    """
+    if not usd_paths:
+        raise ValueError("usd_paths must be a non-empty list")
+    cleaned = [ensure_single_articulation_root(p) for p in usd_paths]
+    cleaned = [simplify_collision_approximation(p, replace_with=collision_approximation) for p in cleaned]
+    cleaned = [normalize_joint_limits(p) for p in cleaned]
+    # See make_articulation_cfg: free-root tasks need the articulation root on
+    # the root rigid body, not the authored world-fixed ``root_joint``.
+    if fix_root_link is False:
+        cleaned = [make_floating_articulation_root(p) for p in cleaned]
+    assets_cfg = [
+        _make_single_usd_spawn(
+            usd_path=p,
+            scale=scale,
+            fix_root_link=fix_root_link,
+            contact_offset=contact_offset,
+            rest_offset=rest_offset,
+        )
+        for p in cleaned
+    ]
+    return ArticulationCfg(
+        prim_path=prim_path,
+        spawn=sim_utils.MultiAssetSpawnerCfg(
+            assets_cfg=assets_cfg,
+            random_choice=random_choice,
+        ),
+        init_state=ArticulationCfg.InitialStateCfg(
+            pos=init_pos,
+            rot=init_rot,
+            joint_pos=init_joint_pos or {},
+        ),
+        actuators=actuators or {},
+    )
+
+
+def _default_reset_pose_range() -> dict[str, list[float]]:
+    return {
+        "x": [0.0, 0.0],
+        "y": [-0.2, 0.2],
+        "z": [0.0, 0.0],
+        "roll": [0.0, 0.0],
+        "pitch": [0.0, 0.0],
+        "yaw": [0.0, 0.0],
+    }
+
+
+@configclass
+class ArticulationBaseObservationsCfg(dexverse_base_env.ObservationsCfg):
+    """Observation layout for tabletop articulated-object tasks.
+
+    Splits the articulation info across two groups:
+      - ``state`` (observable, deployable; no velocities): articulation link
+        poses, joint angles, and max-joint "open amount". The articulation is
+        placed at a randomized pose per episode, so its pose is essential state
+        for the policy.
+      - ``privileged`` (sim-only): articulation link velocities and joint
+        velocities (plus the inherited robot ``joint_vel`` / ``hand_tips``).
+
+    No ``goal`` group: the "open it" target is a per-task constant (uninformative
+    for imitation learning) and would otherwise have to be sourced from the
+    reward — the demonstrated motion teaches the target. ``proprio`` stays as the
+    base's joint-pos-only (robot) group.
+    """
+
+    @configclass
+    class StateObsCfg(ObsGroup):
+        articulation_pose_b = ObsTerm(
+            func=mdp.body_pose_b,
+            noise=Unoise(n_min=-0.0, n_max=0.0),
+            params={
+                "body_asset_cfg": SceneEntityCfg(ARTICULATION_KEY),
+                "base_asset_cfg": SceneEntityCfg("table"),
+            },
+        )
+        articulation_joint_pos = ObsTerm(
+            func=mdp.joint_pos,
+            noise=Unoise(n_min=-0.0, n_max=0.0),
+            params={"asset_cfg": SceneEntityCfg(ARTICULATION_KEY, joint_names=".*")},
+        )
+        articulation_open_amount = ObsTerm(
+            func=mdp.max_joint_pos,
+            noise=Unoise(n_min=-0.0, n_max=0.0),
+            params={"asset_cfg": SceneEntityCfg(ARTICULATION_KEY, joint_names=".*")},
+        )
+
+        def __post_init__(self):
+            self.enable_corruption = True
+            self.concatenate_terms = True
+            self.history_length = 0
+
+    @configclass
+    class PrivilegedObsCfg(dexverse_base_env.ObservationsCfg.PrivilegedObsCfg):
+        articulation_vel_b = ObsTerm(
+            func=mdp.body_vel_b,
+            noise=Unoise(n_min=-0.0, n_max=0.0),
+            params={
+                "body_asset_cfg": SceneEntityCfg(ARTICULATION_KEY),
+                "base_asset_cfg": SceneEntityCfg("table"),
+            },
+        )
+        articulation_joint_vel = ObsTerm(
+            func=mdp.joint_vel,
+            noise=Unoise(n_min=-0.0, n_max=0.0),
+            params={"asset_cfg": SceneEntityCfg(ARTICULATION_KEY, joint_names=".*")},
+        )
+
+    state: StateObsCfg = StateObsCfg()
+    privileged: PrivilegedObsCfg = PrivilegedObsCfg()
+
+
+@configclass
+class ArticulationBaseRewardsCfg(dexverse_base_env.RewardsCfg):
+    """Reward for driving the target joint past a threshold."""
+
+    open_amount = RewTerm(
+        func=mdp.joint_open_reward,
+        weight=5.0,
+        params={
+            "threshold_rad": MISSING,
+            "asset_cfg": SceneEntityCfg(ARTICULATION_KEY, joint_names=".*"),
+        },
+    )
+
+
+@configclass
+class ArticulationBaseTerminationsCfg(dexverse_base_env.TerminationsCfg):
+    """Success when the target joint crosses the threshold."""
+
+    success = DoneTerm(
+        func=mdp.joint_reach_threshold,
+        params={
+            "threshold": MISSING,
+            "asset_cfg": SceneEntityCfg(ARTICULATION_KEY, joint_names=".*"),
+        },
+    )
+
+
+@configclass
+class ArticulationBaseEventCfg(dexverse_base_env.EventCfg):
+    """Reset events for the articulated object."""
+
+    reset_articulation = EventTerm(
+        func=mdp.reset_root_pose_uniform,
+        mode="reset",
+        params={
+            "pose_range": _default_reset_pose_range(),
+            "asset_cfg": SceneEntityCfg(ARTICULATION_KEY),
+        },
+    )
+
+    reset_articulation_joints = EventTerm(
+        func=mdp.reset_joints_to_init,
+        mode="reset",
+        params={
+            "asset_cfg": SceneEntityCfg(ARTICULATION_KEY, joint_names=".*"),
+        },
+    )
+
+
+@configclass
+class ArticulationBaseSceneCfg(dexverse_base_env.SceneCfg):
+    """Scene with a single articulation slot. Child sets ``articulation`` via attrs."""
+
+    articulation: ArticulationCfg = MISSING
+    object = None
+
+
+@configclass
+class ArticulationBaseEnvCfg(dexverse_base_env.DexVerseBaseEnvCfg):
+    """Robot-agnostic base config for tabletop articulated-object manipulation.
+
+    Children override the ``articulation_*`` and ``success_*`` class attributes
+    to specify the asset and success condition.
+    """
+
+    # ---- Articulation parameters (children override) ----
+    # Path to a single USD file *or* a directory containing one
+    # ``<asset_id>/mobility.usd`` per asset (the layout produced by
+    # ``partnet_mobility_to_usd.py``). When a directory is given we spawn
+    # a different USD per parallel environment via ``MultiAssetSpawnerCfg``,
+    # mirroring the pattern used in ``pickup_object/base_cfg.py``.
+    articulation_usd_path: str = MISSING
+    articulation_scale: tuple[float, float, float] = (1.0, 1.0, 1.0)
+    articulation_init_pos: tuple[float, float, float] = (0.3, 0.0, 0.1)
+    articulation_init_rot: tuple[float, float, float, float] = (1.0, 0.0, 0.0, 0.0)
+    articulation_init_joint_pos: dict[str, float] | None = None
+    # Half-height estimate used to seat the articulation on top of the table.
+    articulation_half_height_est: float = 0.1
+    # True  -> IsaacLab adds a fixed joint between world and the articulation root
+    #          (root prim must have RigidBodyAPI; works for partnet-mobility assets).
+    # False -> IsaacLab disables any authored fixed joint (root is free).
+    # None  -> leave the USD's authored state alone (use this for assets whose
+    #          ArticulationRootAPI is on a non-rigid-body prim, e.g. synthesis assets).
+    articulation_fix_root_link: bool | None = True
+    # Collider approximation override applied to the asset at load time. Many
+    # synthesis USDs author every collider as ``sdf``; with no resolution set
+    # PhysX cooks them at a 256^3 default that stalls / hard-hangs scene load
+    # (before the first physics step) on a cold cooking cache. We rewrite them
+    # to a cheap, robust approximation. Set to ``None`` to keep the USD's
+    # authored colliders (e.g. ``sdf``) untouched.
+    articulation_collision_approximation: str | None = "convexDecomposition"
+    # Optional per-collider PhysX collision offsets authored on the asset at
+    # spawn (same pattern as the tray in ``retrieve_tray_from_rack_cfg``): a
+    # small positive rest_offset fattens the effective surface, a larger
+    # contact_offset engages finger contacts earlier -- stabilises grasps on
+    # thin parts. ``None`` (default) keeps the asset's authored offsets.
+    articulation_contact_offset: float | None = None
+    articulation_rest_offset: float | None = None
+    # Pose randomization applied at reset. None -> default y in [-0.2, 0.2].
+    articulation_reset_pose_range: dict[str, list[float]] | None = None
+
+    # ---- Multi-asset spawn (only used when articulation_usd_path is a dir) ----
+    # Optional substring filter over the discovered ``<asset_id>/mobility.usd``
+    # paths. None means "use everything found in the directory".
+    articulation_ids: list[str] | None = None
+    # Optional ``meta.json target_slot`` filter, e.g. ``"target_joint_prismatic"``.
+    articulation_target_slot_filter: str | None = None
+    # ``False`` (default) keeps the (env_idx -> asset) mapping deterministic
+    # round-robin, so we control randomisation ourselves; ``True`` lets
+    # IsaacLab pick randomly per spawn.
+    articulation_multi_random_choice: bool = False
+    # When ``True`` and the path is a directory, ``scene.num_envs`` is forced
+    # to the number of discovered USDs so every env gets a unique asset.
+    articulation_multi_auto_num_envs: bool = True
+
+    # ---- Success criterion (children override) ----
+    # Joint name(s) used for the success / reward / observation entries.
+    # May be a regex string ("joint_0", ".*") or list of names.
+    success_joint_names: Any = ".*"
+    # Threshold value the (max) joint position must reach to count as success.
+    # ``None`` means "not applicable" — typically because the leaf replaced
+    # the default ``open_amount`` reward and ``success`` termination with
+    # task-specific terms (e.g. ratio-mode ``joint_relative_move``). The
+    # wiring in ``__post_init__`` skips threshold patching when this is None.
+    success_threshold: float | None = None
+
+    # Body names of the moving link(s) the dense ``fingers_to_part`` reach
+    # reward should pull the fingertips toward (e.g. a laptop lid). ``None``
+    # targets the mean position over all articulation links — fine for small
+    # assets. Only read when the rewards preset defines ``fingers_to_part``.
+    dense_reach_body_names: list[str] | None = None
+
+    # ---- Standard config bundles ----
+    observations: ArticulationBaseObservationsCfg = ArticulationBaseObservationsCfg()
+    rewards: ArticulationBaseRewardsCfg = ArticulationBaseRewardsCfg()
+    terminations: ArticulationBaseTerminationsCfg = ArticulationBaseTerminationsCfg()
+    events: ArticulationBaseEventCfg = ArticulationBaseEventCfg()
+    scene: ArticulationBaseSceneCfg = ArticulationBaseSceneCfg(
+        num_envs=4096,
+        env_spacing=3,
+        replicate_physics=False,
+    )
+
+    def __post_init__(self):
+        # 1. Build the articulation from the class attributes. Decide between
+        #    single-USD spawn and multi-asset spawn by inspecting the path.
+        usd_path = self.articulation_usd_path
+        if usd_path is MISSING or usd_path is None:
+            raise ValueError("articulation_usd_path must be set (file or directory).")
+        if os.path.isdir(usd_path):
+            usd_paths = collect_articulation_usds_from_dir(
+                usd_path,
+                articulation_ids=self.articulation_ids,
+                target_slot=self.articulation_target_slot_filter,
+            )
+            if self.articulation_multi_auto_num_envs:
+                self.scene.num_envs = len(usd_paths)
+            self.scene.articulation = make_multi_articulation_cfg(
+                usd_paths=usd_paths,
+                random_choice=self.articulation_multi_random_choice,
+                scale=self.articulation_scale,
+                init_pos=self.articulation_init_pos,
+                init_rot=self.articulation_init_rot,
+                init_joint_pos=self.articulation_init_joint_pos,
+                fix_root_link=self.articulation_fix_root_link,
+                collision_approximation=self.articulation_collision_approximation,
+                contact_offset=self.articulation_contact_offset,
+                rest_offset=self.articulation_rest_offset,
+            )
+        elif os.path.isfile(usd_path) or is_usd_file_path(usd_path):
+            self.scene.articulation = make_articulation_cfg(
+                usd_path=usd_path,
+                scale=self.articulation_scale,
+                init_pos=self.articulation_init_pos,
+                init_rot=self.articulation_init_rot,
+                init_joint_pos=self.articulation_init_joint_pos,
+                fix_root_link=self.articulation_fix_root_link,
+                collision_approximation=self.articulation_collision_approximation,
+                contact_offset=self.articulation_contact_offset,
+                rest_offset=self.articulation_rest_offset,
+            )
+        else:
+            raise FileNotFoundError(f"articulation_usd_path is neither a USD file nor a directory: {usd_path}")
+
+        # 2. Wire the success joint names + threshold into obs/reward/termination.
+        # Observation wiring is unconditional because every subclass inherits
+        # ``ArticulationBaseObservationsCfg``. Reward / termination wiring is
+        # defensive: leaves may override these with task-specific terms
+        # (different reward function, different success criterion) that don't
+        # have ``open_amount`` / ``success`` fields, in which case we skip.
+        joint_names = self.success_joint_names
+        self.observations.state.articulation_joint_pos.params["asset_cfg"] = SceneEntityCfg(
+            ARTICULATION_KEY, joint_names=joint_names
+        )
+        self.observations.privileged.articulation_joint_vel.params["asset_cfg"] = SceneEntityCfg(
+            ARTICULATION_KEY, joint_names=joint_names
+        )
+        self.observations.state.articulation_open_amount.params["asset_cfg"] = SceneEntityCfg(
+            ARTICULATION_KEY, joint_names=joint_names
+        )
+        # Only patch the reward / termination if they are the defaults supplied
+        # by articulation_base. Leaves are free to replace them with
+        # task-specific terms (e.g. ``joint_open_fraction_reward``,
+        # ``joint_relative_move`` with ``mode="ratio"``); those are left alone
+        # and the leaf is responsible for wiring joint_names + thresholds.
+        default_open_amount = getattr(self.rewards, "open_amount", None)
+        if default_open_amount is not None and default_open_amount.func is mdp.joint_open_reward:
+            default_open_amount.params["asset_cfg"] = SceneEntityCfg(ARTICULATION_KEY, joint_names=joint_names)
+            if self.success_threshold is not None:
+                default_open_amount.params["threshold_rad"] = self.success_threshold
+        default_success = getattr(self.terminations, "success", None)
+        if default_success is not None and default_success.func is mdp.joint_reach_threshold:
+            default_success.params["asset_cfg"] = SceneEntityCfg(ARTICULATION_KEY, joint_names=joint_names)
+            if self.success_threshold is not None:
+                default_success.params["threshold"] = self.success_threshold
+
+        # 3. Run the parent setup (configures robot, sim params, episode length).
+        super().__post_init__()
+
+        # 3b. Dense reward wiring (terms present only on the Dense presets in
+        # ``config/articulation/rewards.py``). Runs after the parent setup so
+        # ``robot_config.fingertip_body_names`` reflects the active robot.
+        # ``open_amount`` is re-scoped here when its func is the init-relative
+        # progress reward, which the threshold auto-wiring in step 2 skips.
+        open_amount = getattr(self.rewards, "open_amount", None)
+        if open_amount is not None and open_amount.func is mdp.joint_range_progress_from_init:
+            open_amount.params["asset_cfg"] = SceneEntityCfg(ARTICULATION_KEY, joint_names=joint_names)
+        fingers_to_part = getattr(self.rewards, "fingers_to_part", None)
+        if fingers_to_part is not None:
+            fingers_to_part.params["asset_cfg"].body_names = self.robot_config.fingertip_body_names
+            if self.dense_reach_body_names is not None:
+                fingers_to_part.params["target_cfg"].body_names = self.dense_reach_body_names
+
+        # 4. Disable object-related terms inherited from the tabletop base.
+        # Observation groups (rgb / depth / pointcloud / proprio / privileged /
+        # contact) are intentionally kept — every sub-env inherits the base
+        # observation surface; only commands / events / terminations that are
+        # specific to a rigid object are nulled here.
+        if hasattr(self.commands, "object_pose"):
+            self.commands.object_pose = None
+        self.events.object_physics_material = None
+        self.events.object_scale_mass = None
+        self.events.reset_object = None
+        self.terminations.object_out_of_bound = None
+
+        # 5. Seat the articulation on top of the tabletop.
+        table_top_z = dexverse_base_env.DEFAULT_TABLE_TOP_HEIGHT
+        articulation_z = table_top_z + self.articulation_half_height_est
+        ax, ay, _ = self.articulation_init_pos
+        self.scene.articulation.init_state.pos = (ax, ay, articulation_z)
+
+        # 6. Apply the user's reset pose range (or keep the default).
+        if self.articulation_reset_pose_range is not None and self.events.reset_articulation is not None:
+            self.events.reset_articulation.params["pose_range"] = self.articulation_reset_pose_range
+
+        # 7. Set up fingertip contact sensors against the articulation, if enabled.
+        if self.robot_config.setup_contact_sensors:
+            tip_prim_prefix = "{ENV_REGEX_NS}/Robot/"
+            finger_tip_body_list = self.robot_config.fingertip_body_names
+
+            for link_name in finger_tip_body_list:
+                sensor_path = f"{tip_prim_prefix}{link_name}"
+                setattr(
+                    self.scene,
+                    f"{link_name}_articulation_s",
+                    ContactSensorCfg(
+                        prim_path=sensor_path,
+                        filter_prim_paths_expr=[ARTICULATION_PRIM_PATH],
+                    ),
+                )
+
+            self.observations.contact.contact = ObsTerm(
+                func=mdp.fingers_contact_force_b,
+                params={"contact_sensor_names": [f"{link}_articulation_s" for link in finger_tip_body_list]},
+                clip=(-20.0, 20.0),
+            )
+        else:
+            self.observations.contact = None
+
+        # 8. Override observation body names with robot-specific names.
+        self.observations.privileged.hand_tips_state_b.params["body_asset_cfg"].body_names = (
+            self.robot_config.hand_tips_body_names
+        )
+
+
+@configclass
+class ArticulationBaseEnvFloatingDexHandRightCfg(ArticulationBaseEnvCfg):
+    """Floating DexHand variant (Shadow / Leap, right-handed) of the base env.
+
+    Children typically subclass *this* class and override only the
+    ``articulation_*`` / ``success_*`` attributes.
+    """
+
+    robot_type: str = "floating_shadow_right"
+    xr: XrCfg = DEFAULT_FLOATING_SHADOW_XR_CFG
+
+    def __post_init__(self):
+        super().__post_init__()
+        setup_floating_teleop(self)

--- a/source/dexverse/dexverse/baseline_v1/config/articulation/articulation_base/usd_helpers.py
+++ b/source/dexverse/dexverse/baseline_v1/config/articulation/articulation_base/usd_helpers.py
@@ -1,0 +1,493 @@
+# Copyright (c) 2025-2026, The DexVerse Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Asset-time USD utilities for articulation tasks.
+
+Provides:
+
+* :func:`ensure_single_articulation_root` -- repair USDs that author
+  :class:`UsdPhysics.ArticulationRootAPI` on more than one prim (some
+  synthesis / PartNet-style assets do this and IsaacLab aborts with
+  ``Failed to find a single articulation when resolving '<...>'``).
+* :func:`collect_articulation_usds_from_dir` -- discover the
+  ``<id>/mobility.usd`` tree produced by ``partnet_mobility_to_usd.py``,
+  optionally filtering by asset id substring or by ``meta.json`` target_slot.
+
+Cleaned USDs are cached next to the original as ``<name>__cleaned.usd`` and
+regenerated only when the source's mtime changes.
+"""
+
+from __future__ import annotations
+
+import glob
+import json
+import logging
+import os
+import re
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+_USD_EXTENSIONS = (".usd", ".usda", ".usdc", ".usdz")
+
+
+def replace_joint_with_fixed_parent(
+    usd_path: str | Path,
+    *,
+    joint_name: str,
+    parent_body_path: str,
+) -> str:
+    """Return a cached USD with ``joint_name`` fixed directly to a new parent.
+
+    The child body is taken from the existing joint's ``body1`` relationship.
+    Its authored rest-pose transform relative to ``parent_body_path`` is used
+    as the fixed-joint frame, so changing the topology does not move the child.
+    This is useful when a nested movable link should become a rigid part of a
+    different ancestor (for example, attaching a stapler magazine to its base
+    instead of its top shell).
+
+    The source is left untouched. On failure, the original path is returned so
+    asset preparation cannot prevent an environment from loading.
+    """
+    src = Path(usd_path)
+    if not src.is_file():
+        return str(src)
+
+    try:
+        from pxr import Gf, Usd, UsdGeom, UsdPhysics  # type: ignore
+    except ImportError:
+        return str(src)
+
+    tag_source = f"{joint_name}_to_{parent_body_path}"
+    tag = re.sub(r"[^A-Za-z0-9_]+", "_", tag_source).strip("_")
+    prepared = src.with_name(f"{src.stem}__{tag}_fixed.usd")
+    if prepared.exists() and prepared.stat().st_mtime >= src.stat().st_mtime:
+        return str(prepared)
+
+    try:
+        stage = Usd.Stage.Open(str(src))
+        if stage is None:
+            return str(src)
+        matches = [prim for prim in stage.Traverse() if prim.GetName() == joint_name]
+        if len(matches) != 1:
+            raise ValueError(f"expected exactly one joint named {joint_name!r}, found {len(matches)}")
+
+        joint_prim = matches[0]
+        old_joint = UsdPhysics.Joint(joint_prim)
+        child_targets = old_joint.GetBody1Rel().GetTargets()
+        if len(child_targets) != 1:
+            raise ValueError(f"joint {joint_name!r} must have exactly one body1 target")
+        child_path = child_targets[0]
+        parent_path = stage.GetPrimAtPath(parent_body_path).GetPath()
+        parent_prim = stage.GetPrimAtPath(parent_path)
+        child_prim = stage.GetPrimAtPath(child_path)
+        if not parent_prim or not child_prim:
+            raise ValueError(f"invalid fixed-joint bodies: parent={parent_path}, child={child_path}")
+
+        xforms = UsdGeom.XformCache(Usd.TimeCode.Default())
+        parent_world = xforms.GetLocalToWorldTransform(parent_prim)
+        child_world = xforms.GetLocalToWorldTransform(child_prim)
+        child_in_parent = child_world * parent_world.GetInverse()
+        local_pos0 = child_in_parent.ExtractTranslation()
+        local_rot0 = child_in_parent.ExtractRotationQuat()
+
+        joint_path = joint_prim.GetPath()
+        stage.RemovePrim(joint_path)
+        fixed = UsdPhysics.FixedJoint.Define(stage, joint_path)
+        fixed.CreateBody0Rel().SetTargets([parent_path])
+        fixed.CreateBody1Rel().SetTargets([child_path])
+        fixed.CreateLocalPos0Attr().Set(Gf.Vec3f(*local_pos0))
+        fixed.CreateLocalRot0Attr().Set(
+            Gf.Quatf(float(local_rot0.GetReal()), Gf.Vec3f(*local_rot0.GetImaginary()))
+        )
+        fixed.CreateLocalPos1Attr().Set(Gf.Vec3f(0.0))
+        fixed.CreateLocalRot1Attr().Set(Gf.Quatf(1.0))
+
+        stage.GetRootLayer().Export(str(prepared))
+        logger.info(
+            "Replaced joint %s in %s with fixed %s -> %s (%s)",
+            joint_name,
+            src.name,
+            parent_path,
+            child_path,
+            prepared.name,
+        )
+        return str(prepared)
+    except Exception as exc:  # noqa: BLE001 - never break asset loading over this
+        logger.warning("Fixed-joint preparation failed for %s: %s", src, exc)
+        return str(src)
+
+
+def ensure_single_articulation_root(usd_path: str | Path) -> str:
+    """Return a USD path that has at most one ``ArticulationRootAPI`` prim.
+
+    If the source is already valid (or pxr is unavailable), the original path is
+    returned unchanged.
+    """
+    src = Path(usd_path)
+    if not src.is_file():
+        return str(src)
+
+    try:
+        from pxr import Usd, UsdPhysics  # type: ignore
+    except ImportError:
+        return str(src)
+
+    cleaned = src.with_name(f"{src.stem}__cleaned.usd")
+    if cleaned.exists() and cleaned.stat().st_mtime >= src.stat().st_mtime:
+        return str(cleaned)
+
+    stage = Usd.Stage.Open(str(src))
+    if stage is None:
+        return str(src)
+
+    root_prims = [p for p in stage.Traverse() if p.HasAPI(UsdPhysics.ArticulationRootAPI)]
+    if len(root_prims) <= 1:
+        return str(src)
+
+    # Prefer roots that are also rigid bodies (the proper articulation root).
+    body_roots = [p for p in root_prims if p.HasAPI(UsdPhysics.RigidBodyAPI)]
+    keepers = body_roots if body_roots else root_prims[:1]
+    keep_paths = {p.GetPath() for p in keepers}
+
+    removed = []
+    for prim in root_prims:
+        if prim.GetPath() in keep_paths:
+            continue
+        prim.RemoveAPI(UsdPhysics.ArticulationRootAPI)
+        removed.append(str(prim.GetPath()))
+
+    if not removed:
+        return str(src)
+
+    stage.GetRootLayer().Export(str(cleaned))
+    logger.info(
+        "Cleaned articulation roots in %s -> %s (removed %d spurious roots: %s)",
+        src.name,
+        cleaned.name,
+        len(removed),
+        removed,
+    )
+    return str(cleaned)
+
+
+def simplify_collision_approximation(
+    usd_path: str | Path,
+    *,
+    replace_with: str | None = "convexDecomposition",
+    expensive: tuple[str, ...] = ("sdf",),
+) -> str:
+    """Return a USD path whose mesh colliders avoid expensive approximations.
+
+    Synthesis / PartNet assets frequently author *every* collider as ``sdf``
+    (signed distance field). With no ``sdfResolution`` authored, PhysX cooks
+    these at its default 256^3 resolution, which is extremely slow and -- on a
+    cold cooking cache, before the first physics step -- routinely manifests as
+    a multi-minute stall or a hard hang at scene load. IsaacLab's
+    ``UsdFileCfg`` exposes no way to override the approximation at spawn time,
+    so we rewrite the USD up-front (mirroring
+    :func:`ensure_single_articulation_root`).
+
+    Any prim whose ``UsdPhysics.MeshCollisionAPI`` approximation is in
+    ``expensive`` (default: just ``sdf``) is switched to ``replace_with``
+    (default ``convexDecomposition`` -- fast to cook and preserves concavity
+    well enough for these tabletop objects). The result is cached next to the
+    source as ``<stem>__collsimple.usd`` and regenerated only when the source
+    changes.
+
+    Pass ``replace_with=None`` to disable (returns the input unchanged). On any
+    error (or if pxr is unavailable) the original path is returned, so this
+    never makes a task fail to load.
+    """
+    if replace_with is None:
+        return str(usd_path)
+
+    src = Path(usd_path)
+    if not src.is_file():
+        return str(src)
+
+    try:
+        from pxr import Usd, UsdPhysics  # type: ignore
+    except ImportError:
+        return str(src)
+
+    cleaned = src.with_name(f"{src.stem}__collsimple.usd")
+    if cleaned.exists() and cleaned.stat().st_mtime >= src.stat().st_mtime:
+        return str(cleaned)
+
+    try:
+        stage = Usd.Stage.Open(str(src))
+        if stage is None:
+            return str(src)
+
+        changed = []
+        for prim in stage.Traverse():
+            if not prim.HasAPI(UsdPhysics.MeshCollisionAPI):
+                continue
+            mca = UsdPhysics.MeshCollisionAPI(prim)
+            attr = mca.GetApproximationAttr()
+            current = attr.Get() if attr else None
+            if current in expensive:
+                if not attr:
+                    attr = mca.CreateApproximationAttr()
+                attr.Set(replace_with)
+                changed.append(str(prim.GetPath()))
+
+        if not changed:
+            return str(src)
+
+        stage.GetRootLayer().Export(str(cleaned))
+        logger.info(
+            "Simplified %d collider(s) in %s -> %s (%s -> %s)",
+            len(changed),
+            src.name,
+            cleaned.name,
+            "/".join(expensive),
+            replace_with,
+        )
+        return str(cleaned)
+    except Exception as exc:  # noqa: BLE001 - never break asset loading over this
+        logger.warning("Collision-approximation simplification failed for %s: %s", src, exc)
+        return str(src)
+
+
+def normalize_joint_limits(usd_path: str | Path) -> str:
+    """Return a USD path whose revolute/prismatic joints have lower <= upper.
+
+    Some synthesis assets author a joint's ``physics:lowerLimit`` /
+    ``physics:upperLimit`` in the wrong order (e.g. ``scissors004``'s right hinge
+    is ``[50, 0]`` instead of ``[0, 50]``). PhysX / Isaac Lab keep them as
+    authored, which breaks anything that assumes an ascending range -- notably
+    the ``progress`` success metric, which divides by
+    ``reachable = max(q_init - lower, upper - q_init)``. For an inverted range
+    that collapses to ~0, so the task "succeeds" on the tiniest joint motion.
+
+    Any joint whose lower limit exceeds its upper limit is rewritten with the
+    two swapped. The result is cached next to the source as ``<stem>__limfix.usd``
+    and regenerated only when the source changes. On any error (or if pxr is
+    unavailable) the original path is returned, so this never blocks loading.
+    """
+    src = Path(usd_path)
+    if not src.is_file():
+        return str(src)
+
+    try:
+        from pxr import Usd  # type: ignore
+    except ImportError:
+        return str(src)
+
+    cleaned = src.with_name(f"{src.stem}__limfix.usd")
+    if cleaned.exists() and cleaned.stat().st_mtime >= src.stat().st_mtime:
+        return str(cleaned)
+
+    try:
+        stage = Usd.Stage.Open(str(src))
+        if stage is None:
+            return str(src)
+
+        fixed = []
+        for prim in stage.Traverse():
+            lo_attr = prim.GetAttribute("physics:lowerLimit")
+            hi_attr = prim.GetAttribute("physics:upperLimit")
+            if not (lo_attr and hi_attr):
+                continue
+            lo, hi = lo_attr.Get(), hi_attr.Get()
+            if lo is None or hi is None:
+                continue
+            if lo > hi:
+                lo_attr.Set(hi)
+                hi_attr.Set(lo)
+                fixed.append(f"{prim.GetName()}: [{lo}, {hi}] -> [{hi}, {lo}]")
+
+        if not fixed:
+            return str(src)
+
+        stage.GetRootLayer().Export(str(cleaned))
+        logger.info(
+            "Normalized %d inverted joint limit(s) in %s -> %s: %s",
+            len(fixed),
+            src.name,
+            cleaned.name,
+            "; ".join(fixed),
+        )
+        return str(cleaned)
+    except Exception as exc:  # noqa: BLE001 - never break asset loading over this
+        logger.warning("Joint-limit normalization failed for %s: %s", src, exc)
+        return str(src)
+
+
+def make_floating_articulation_root(usd_path: str | Path) -> str:
+    """Return a USD path whose articulation root is on the root *rigid body*.
+
+    Many PartNet-Mobility assets are authored ``fix_base=true``: the converter
+    pins the root link to the world with a global ``root_joint``
+    (:class:`UsdPhysics.FixedJoint` with one empty body target) and applies the
+    :class:`UsdPhysics.ArticulationRootAPI` *to that joint prim*. PhysX accepts
+    this only for a **fixed-base** articulation. For a **floating** articulation
+    (``fix_root_link=False``, e.g. a liftable object) PhysX requires the
+    articulation root to live on the root rigid body. With the root API stranded
+    on the world-fixed joint, the articulation fails to parse entirely::
+
+        Pattern '/World/envs/env_*/Articulation/root_joint'
+            did not match any articulations
+        AttributeError: 'NoneType' object has no attribute 'shared_metatype'
+
+    This helper rewrites the USD into floating-base form:
+
+    * the global fixed joint(s) (one empty body target — they attach a link to
+      the world) are deactivated, freeing the root link, and
+    * the ``ArticulationRootAPI`` is moved off of every other prim and applied to
+      the root rigid body (the body the global fixed joint attached to the
+      world).
+
+    The result is cached next to the source as ``<stem>__floatroot.usd`` and
+    regenerated only when the source changes. If the asset has no global fixed
+    joint (already floating-friendly), or on any error / if pxr is unavailable,
+    the input path is returned unchanged so this never blocks loading.
+
+    Only call this when the task wants a free root (``fix_root_link=False``);
+    fixed-base tasks must keep the authored ``root_joint`` + root API in place.
+    """
+    src = Path(usd_path)
+    if not src.is_file():
+        return str(src)
+
+    try:
+        from pxr import Usd, UsdPhysics  # type: ignore
+    except ImportError:
+        return str(src)
+
+    cleaned = src.with_name(f"{src.stem}__floatroot.usd")
+    if cleaned.exists() and cleaned.stat().st_mtime >= src.stat().st_mtime:
+        return str(cleaned)
+
+    try:
+        stage = Usd.Stage.Open(str(src))
+        if stage is None:
+            return str(src)
+
+        # A "global" fixed joint attaches a single link to the simulation world:
+        # exactly one of body0/body1 has a target (mirrors IsaacLab's
+        # find_global_fixed_joint_prim). Internal joints (both bodies set) stay.
+        global_fixed = []  # (joint_prim, root_body_path)
+        for prim in stage.Traverse():
+            joint = UsdPhysics.Joint(prim)
+            if not joint:
+                continue
+            body_0 = list(joint.GetBody0Rel().GetTargets())
+            body_1 = list(joint.GetBody1Rel().GetTargets())
+            if bool(body_0) == bool(body_1):
+                continue  # both set (internal) or both empty (degenerate)
+            global_fixed.append((prim, (body_0 or body_1)[0]))
+
+        if not global_fixed:
+            return str(src)  # already floating-friendly; nothing to relocate.
+
+        root_body_path = global_fixed[0][1]
+        root_body_prim = stage.GetPrimAtPath(root_body_path)
+        if not root_body_prim or not root_body_prim.IsValid():
+            return str(src)
+
+        # Move the articulation root onto the root rigid body, stripping it from
+        # everywhere else (notably the world-fixed joint prim).
+        for prim in stage.Traverse():
+            if prim.HasAPI(UsdPhysics.ArticulationRootAPI) and prim.GetPath() != root_body_path:
+                prim.RemoveAPI(UsdPhysics.ArticulationRootAPI)
+        if not root_body_prim.HasAPI(UsdPhysics.ArticulationRootAPI):
+            UsdPhysics.ArticulationRootAPI.Apply(root_body_prim)
+
+        # Free the root link: drop the world-fixed joint(s) from composition.
+        for joint_prim, _ in global_fixed:
+            joint_prim.SetActive(False)
+
+        stage.GetRootLayer().Export(str(cleaned))
+        logger.info(
+            "Converted %s -> %s to floating-base (root API -> %s; deactivated %s)",
+            src.name,
+            cleaned.name,
+            root_body_path,
+            ", ".join(str(j.GetPath()) for j, _ in global_fixed),
+        )
+        return str(cleaned)
+    except Exception as exc:  # noqa: BLE001 - never break asset loading over this
+        logger.warning("Floating-root conversion failed for %s: %s", src, exc)
+        return str(src)
+
+
+def is_usd_file_path(path: str | Path) -> bool:
+    """Return True if ``path`` looks like a single USD asset file (by extension)."""
+    return str(path).lower().endswith(_USD_EXTENSIONS)
+
+
+def collect_articulation_usds_from_dir(
+    parent_dir: str | Path,
+    *,
+    articulation_ids: list[str] | None = None,
+    target_slot: str | None = None,
+) -> list[str]:
+    """Discover ``<asset_id>/mobility.usd`` files under ``parent_dir``.
+
+    Mirrors the pattern of :func:`pickup_object.base_cfg.collect_usd_files_from_dir`,
+    adapted for the canonical PartNet-Mobility tree produced by
+    ``partnet_mobility_to_usd.py``.
+
+    Args:
+        parent_dir: Directory containing one ``<asset_id>/`` subdir per asset,
+            each holding ``mobility.usd`` (and a sibling ``meta.json`` produced
+            by the processing script).
+        articulation_ids: Optional explicit list of asset ids to keep
+            (substring match against the path, same convention as pickup_object).
+        target_slot: Optional ``"target_joint_prismatic"`` /
+            ``"target_joint_revolute"`` filter. Reads each asset's
+            ``meta.json`` and keeps only those whose ``target_slot`` matches.
+            Assets without a parseable ``meta.json`` are dropped if the filter
+            is set.
+
+    Returns:
+        A sorted list of absolute USD paths.
+    """
+    parent = Path(parent_dir)
+    if not parent.is_dir():
+        raise FileNotFoundError(f"USD parent directory does not exist: {parent}")
+
+    candidates: list[str] = []
+    for ext in _USD_EXTENSIONS:
+        candidates.extend(glob.glob(os.path.join(str(parent), f"**/*{ext}"), recursive=True))
+    candidates = sorted(set(candidates))
+    candidates = [
+        f
+        for f in candidates
+        if "instanceable_meshes" not in f
+        and "configuration" not in os.path.relpath(f, parent).split(os.sep)
+        and not os.path.basename(f).startswith(".")
+    ]
+
+    if articulation_ids is not None:
+        wanted = list(articulation_ids)
+        candidates = [f for f in candidates if any(aid in f for aid in wanted)]
+
+    if target_slot is not None:
+        kept: list[str] = []
+        for usd in candidates:
+            meta_path = Path(usd).with_name("meta.json")
+            if not meta_path.exists():
+                continue
+            try:
+                meta = json.loads(meta_path.read_text(encoding="utf-8"))
+            except (json.JSONDecodeError, OSError):
+                continue
+            if meta.get("target_slot") == target_slot:
+                kept.append(usd)
+        candidates = kept
+
+    if not candidates:
+        msg = f"No USD assets found under {parent}"
+        if articulation_ids:
+            msg += f" matching ids={articulation_ids}"
+        if target_slot:
+            msg += f" with target_slot={target_slot!r}"
+        raise FileNotFoundError(msg)
+
+    return candidates

--- a/source/dexverse/dexverse/baseline_v1/config/articulation/base_cfg.py
+++ b/source/dexverse/dexverse/baseline_v1/config/articulation/base_cfg.py
@@ -1,0 +1,260 @@
+# Copyright (c) 2025-2026, The DexVerse Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Shared base for *fixate-then-manipulate* tabletop tasks.
+
+Unlike :mod:`dexverse.tasks.config.articulation.articulation_base`, the
+articulation here is *not* bolted to the world — its root link is a free
+rigid body sitting on the tabletop. Actuating the target joint therefore
+tends to tip or slide the whole object, so the robot has to pin the body
+in place with one hand (or parts of one hand) while the other hand / free
+fingers drive the joint past a threshold.
+
+Concrete per-object configs (``open_laptop_cfg.py``, ``squeeze_scissors_cfg.py``,
+etc.) subclass :class:`FixateArticulationEnvFloatingDexHandRightCfg` and set:
+
+* ``articulation_usd_path`` — synthesis asset USD to load.
+* ``articulation_scale`` / ``articulation_init_pos`` / ``articulation_init_rot``
+  — placement on the table.
+* ``articulation_half_height_est`` — height of the asset root above its
+  bottom, used to seat the mesh flush on the tabletop.
+* ``success_joint_names`` — regex or list of joint names used for reward /
+  termination (defaults to ``".*"`` which matches every joint; override
+  this when an asset has multiple joints of different semantics).
+* ``success_threshold`` — scalar threshold in radians (revolute) or meters
+  (prismatic); success fires when ``max(|joint_pos|)`` for
+  ``success_joint_names`` crosses it.
+
+The base adds a table-bounds ``out_of_bound`` termination so the episode
+ends if the object falls / slides off the tabletop (the parent class
+disables this term for fixed articulations).
+"""
+
+from __future__ import annotations
+
+import isaaclab.sim as sim_utils
+from isaaclab.assets import RigidObjectCfg
+from isaaclab.managers import SceneEntityCfg
+from isaaclab.managers import TerminationTermCfg as DoneTerm
+from isaaclab.utils import configclass
+
+from ... import mdp
+from ...dexverse_base_env_cfg import DEFAULT_TABLE_TOP_HEIGHT
+from .articulation_base import ArticulationBaseEnvFloatingDexHandRightCfg
+from .articulation_base.articulation_base_cfg import ARTICULATION_KEY
+from .rewards import DenseFixateArticulationRewardsCfg
+
+# All-zero reset pose range used by per-object configs that want the
+# articulation to spawn at exactly the same pose every episode. Useful
+# while we're focused on the manipulation itself rather than spatial
+# robustness (e.g. objects resting on padding blocks would fall off if
+# their xy is perturbed).
+DETERMINISTIC_RESET_POSE_RANGE: dict[str, list[float]] = {
+    "x": [0.0, 0.0],
+    "y": [0.0, 0.0],
+    "z": [0.0, 0.0],
+    "roll": [0.0, 0.0],
+    "pitch": [0.0, 0.0],
+    "yaw": [0.0, 0.0],
+}
+
+
+@configclass
+class FixateArticulationEnvFloatingDexHandRightCfg(ArticulationBaseEnvFloatingDexHandRightCfg):
+    """Base config for a free-root articulation that the robot must stabilise.
+
+    Override ``articulation_*`` and ``success_*`` class attributes on a
+    subclass (see the per-object configs in this package).
+
+    The default ``robot_type`` (inherited from the parent) is
+    ``floating_shadow_right``. Pass ``env.robot_type=floating_shadow_bimanual``
+    (or ``bimanual_leap`` / ``xarm7_leap_bimanual``) on the CLI to switch to
+    two hands — the scene, obs and rewards are all robot-agnostic and follow
+    ``robot_config.fingertip_body_names`` automatically.
+    """
+
+    # Let the root link float freely. ``False`` explicitly disables any
+    # authored fixed joint in the USD. If a particular synthesis asset fails
+    # to spawn ("Failed to find a single articulation"), try ``None`` — that
+    # keeps the USD's authored articulation root untouched, which some
+    # synthesis USDs require because their ArticulationRootAPI is on a
+    # non-rigid prim.
+    articulation_fix_root_link: bool | None = False
+
+    # Modest reset pose randomisation so the policy practises stabilising
+    # the object from varying starts. Per-object configs may override.
+    articulation_reset_pose_range: dict[str, list[float]] = {
+        "x": [-0.02, 0.02],
+        "y": [-0.08, 0.08],
+        "z": [0.0, 0.0],
+        "roll": [0.0, 0.0],
+        "pitch": [0.0, 0.0],
+        "yaw": [-0.2, 0.2],
+    }
+
+    # Recovery-from-topple + opening is slower than driving a fixed handle.
+    episode_length_s_override: float = 8.0
+
+    # PPO-ready dense preset: init-relative joint progress + fingertip reach
+    # + free-root stabilization penalties. Param wiring happens in
+    # ``ArticulationBaseEnvCfg.__post_init__`` (step 3b).
+    rewards: DenseFixateArticulationRewardsCfg = DenseFixateArticulationRewardsCfg()
+
+    # ------------------------------------------------------------------
+    # Damping / friction knobs
+    # ------------------------------------------------------------------
+    # ``articulation_base.make_articulation_cfg`` builds the asset with
+    # ``linear_damping = angular_damping = None`` and ``joint_drive.damping = 0``,
+    # and never attaches a physics material. That's fine while the root is
+    # bolted to the world, but once we unfix it the body glides forever on
+    # the table and the hinges/sliders whip around like they're greased.
+    # The values below add just enough dissipation and contact friction to
+    # feel physical without making the object feel sticky. Per-object
+    # configs can override any of these (e.g. a waxy laptop lid may want
+    # less table friction than a rubber-footed stapler).
+
+    # Rigid body damping on the articulation root/links. Applied to
+    # ``spawn.rigid_props`` so the physics engine dissipates translation
+    # and rotation continuously. These are unitless PhysX damping
+    # coefficients; 0.1 is "barely anything", 1.0 is "distinctly damped".
+    articulation_linear_damping: float = 0.5
+    articulation_angular_damping: float = 0.5
+
+    # Viscous joint damping via the physics joint drive. With stiffness
+    # still 0 this acts as pure velocity resistance (F = -D * joint_vel),
+    # which keeps lids / blades from flopping open freely under gravity
+    # while still leaving them fully passive — the robot is what actuates
+    # the joint, not a servo.
+    articulation_joint_damping: float = 2.0
+
+    # Contact friction between the articulation's collision shapes and
+    # anything else (table, robot hands). Ranges are sampled per env at
+    # startup so trained policies see some variation.
+    articulation_static_friction_range: tuple[float, float] = (0.8, 1.2)
+    articulation_dynamic_friction_range: tuple[float, float] = (0.6, 1.0)
+
+    # Coulomb-style joint friction (torque threshold that must be
+    # overcome before the joint moves). Small, mostly to prevent the
+    # joint from drifting when the robot just barely touches it.
+    articulation_joint_friction_range: tuple[float, float] = (0.05, 0.15)
+
+    # ------------------------------------------------------------------
+    # Padding blocks
+    # ------------------------------------------------------------------
+    # For thin / small articulations (scissors, knife, phone) it helps to
+    # prop the object up on two little support blocks so the robot's
+    # fingers can slide underneath to pin or pry. When enabled, a pair of
+    # static kinematic cuboids are added to the scene directly below the
+    # articulation spawn; the articulation is seated on top of them
+    # instead of flat on the table.
+    articulation_use_padding_blocks: bool = False
+
+    # (width, depth, height) of each block in metres. Height matters most
+    # — it's how much finger clearance you get under the object.
+    articulation_padding_block_size: tuple[float, float, float] = (0.04, 0.04, 0.015)
+
+    # 2D (dx, dy) offsets of each block centre from the articulation's
+    # ``articulation_init_pos`` xy in world frame. The default spacing
+    # works for objects laid long along world-y (e.g. +90 yawed scissors,
+    # knife); override per object when the long axis is different.
+    articulation_padding_block_offsets: tuple[tuple[float, float], ...] = (
+        (0.0, -0.03),
+        (0.0, 0.03),
+    )
+
+    def __post_init__(self):
+        super().__post_init__()
+
+        # The parent strips ``object_out_of_bound`` because it assumes a
+        # fixed articulation that cannot leave the table. Add it back,
+        # clamped to the table footprint, so a toppled object ends the
+        # episode instead of dragging the sim.
+        table_size = self.scene.table.spawn.size
+        self.terminations.articulation_out_of_bound = DoneTerm(
+            func=mdp.out_of_bound,
+            params={
+                "in_bound_range": {
+                    "x": (-table_size[0] * 0.5, table_size[0] * 0.5),
+                    "y": (-table_size[1] * 0.5, table_size[1] * 0.5),
+                    "z": (-0.05, 1.5),
+                },
+                "asset_cfg": SceneEntityCfg(ARTICULATION_KEY),
+            },
+        )
+
+        self.episode_length_s = self.episode_length_s_override
+
+        # --------------------------------------------------------------
+        # Damping and friction.
+        # --------------------------------------------------------------
+        # These all piggy-back on the ``ArticulationCfg`` the parent
+        # built in step (1) of ``ArticulationBaseEnvCfg.__post_init__``.
+        spawn = self.scene.articulation.spawn
+
+        # Rigid-body damping: dissipates translation / rotation so a
+        # toppled or shoved object settles instead of gliding forever.
+        spawn.rigid_props.linear_damping = self.articulation_linear_damping
+        spawn.rigid_props.angular_damping = self.articulation_angular_damping
+
+        # Viscous joint damping. Stiffness stays at 0 — we don't want
+        # the joint to spring back to a target, we only want it to
+        # resist velocity so free-swinging lids / blades don't whip.
+        spawn.joint_drive_props.damping = self.articulation_joint_damping
+
+        # Disable startup-time articulation friction/material randomization.
+        self.events.articulation_physics_material = None
+        self.events.articulation_joint_friction = None
+
+        # --------------------------------------------------------------
+        # Padding blocks
+        # --------------------------------------------------------------
+        # Spawned last because they need the final articulation xyz
+        # (parent already seated it on the table in step 5), and because
+        # we also need to bump the articulation up by the block height
+        # so it rests *on* the blocks rather than clipping through.
+        if self.articulation_use_padding_blocks:
+            self._attach_padding_blocks()
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+    def _attach_padding_blocks(self) -> None:
+        """Add static support cuboids under the articulation and re-seat it.
+
+        Each entry in ``articulation_padding_block_offsets`` becomes one
+        kinematic ``RigidObjectCfg`` whose top surface is flush with
+        ``table_top + block_height``. The articulation is then shifted
+        up by ``block_height`` so it lands on the blocks instead of the
+        table.
+        """
+        block_w, block_d, block_h = self.articulation_padding_block_size
+        block_z_center = DEFAULT_TABLE_TOP_HEIGHT + block_h * 0.5
+
+        # Use the articulation's xy from what the parent already resolved
+        # (which is the class-level ``articulation_init_pos`` xy).
+        ax, ay, az = self.scene.articulation.init_state.pos
+
+        for i, (dx, dy) in enumerate(self.articulation_padding_block_offsets):
+            block_cfg = RigidObjectCfg(
+                prim_path=f"{{ENV_REGEX_NS}}/PaddingBlock_{i}",
+                spawn=sim_utils.CuboidCfg(
+                    size=(block_w, block_d, block_h),
+                    rigid_props=sim_utils.RigidBodyPropertiesCfg(kinematic_enabled=True),
+                    collision_props=sim_utils.CollisionPropertiesCfg(),
+                    visual_material=sim_utils.PreviewSurfaceCfg(
+                        diffuse_color=(0.35, 0.35, 0.38),
+                        roughness=0.8,
+                    ),
+                    visible=True,
+                ),
+                init_state=RigidObjectCfg.InitialStateCfg(
+                    pos=(ax + dx, ay + dy, block_z_center),
+                    rot=(1.0, 0.0, 0.0, 0.0),
+                ),
+            )
+            setattr(self.scene, f"padding_block_{i}", block_cfg)
+
+        # Seat the articulation on top of the blocks.
+        self.scene.articulation.init_state.pos = (ax, ay, az + block_h)

--- a/source/dexverse/dexverse/baseline_v1/config/articulation/close_folder_insert_shelf_cfg.py
+++ b/source/dexverse/dexverse/baseline_v1/config/articulation/close_folder_insert_shelf_cfg.py
@@ -1,0 +1,251 @@
+# Copyright (c) 2025-2026, The DexVerse Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Bimanual: close an open folder, rotate it upright, and insert it in a slot.
+
+Three-stage extension of :mod:`open_flat_folder_cfg` (same folder asset and
+Shadow bimanual robot): the folder spawns lying *open* on the table; the robot
+must swing the cover shut, lift the closed folder with two hands, rotate it so
+it stands vertically like a file, and insert it into the shelf's single narrow
+vertical slot (:mod:`dexverse.assets.shelf_builder`: base + back + sides + two
+groups of smaller stored-folder props). The slot is open at the front and top.
+Its 8 cm opening closely fits the closed folder's roughly 6.2 cm thickness, while its
+32 cm height accommodates the folder's approximately 28 cm height. The folder
+stands like a file: its thickness spans the narrow slot and its 23 cm broad
+dimension extends into the shelf. The shelf stands at the far side of the
+table, randomly placed, with its opening turned toward the hands' start.
+
+Success :func:`mdp.articulation_closed_and_inserted`: hinge closed (< 20 deg),
+folder root inserted past the slot front, folder thickness axis aligned with
+the narrow slot-width axis, and the folder's height axis aligned with shelf up. It
+must be standing vertically and at rest. Failure: folder out of
+bounds. Rewards are inherited from the fixate-articulation preset (joint
+progress from init counts closing as progress); a task-specific dense preset is
+TODO before RL.
+"""
+
+from __future__ import annotations
+
+import math
+
+import isaaclab.sim as sim_utils
+from isaaclab.assets import RigidObjectCfg
+from isaaclab.managers import EventTermCfg as EventTerm
+from isaaclab.managers import ObservationGroupCfg as ObsGroup
+from isaaclab.managers import ObservationTermCfg as ObsTerm
+from isaaclab.managers import SceneEntityCfg
+from isaaclab.utils import configclass
+from isaaclab.utils.noise import UniformNoiseCfg as Unoise
+
+from dexverse.assets.shelf_builder import ensure_slot_shelf_asset
+
+from ... import dexverse_base_env_cfg as dexverse_base_env
+from ... import mdp
+from .articulation_base.articulation_base_cfg import ARTICULATION_KEY
+from .open_flat_folder_cfg import OpenFlatFolderEnvFloatingDexHandRightCfg
+
+# Folder closed is ~0.23 x 0.28 x 0.062 m at scale 1.2. The narrow vertical
+# opening follows its 6.2 cm thickness with ~1.8 cm total side clearance.
+FOLDER_CLOSED_THICKNESS = 0.062
+SLOT_THICKNESS_CLEARANCE = 0.018
+SHELF_NAME = "slot_shelf_vertical_folder_thickness"
+SHELF_PARAMS = dict(
+    inner_depth=0.30,
+    slot_width=FOLDER_CLOSED_THICKNESS + SLOT_THICKNESS_CLEARANCE,
+    filler_width=0.12,
+    height=0.32,
+    panel_thickness=0.02,
+    top_closed=False,
+    slot_orientation="vertical",
+    vertical_filler_style="folder_props",
+)
+SHELF_USD_PATH, SHELF_MANIFEST = ensure_slot_shelf_asset(SHELF_NAME, **SHELF_PARAMS)
+SLOT_CENTER_LOCAL: tuple[float, float, float] = tuple(SHELF_MANIFEST["slot"]["center"])
+SLOT_HALF_EXTENTS: tuple[float, float, float] = tuple(SHELF_MANIFEST["slot"]["half_extents"])
+SHELF_FOOTPRINT_HALF_EXTENTS: tuple[float, float] = (
+    float(SHELF_MANIFEST["footprint"]["x_half"]),
+    float(SHELF_MANIFEST["footprint"]["y_half"]),
+)
+# At the 3.2 rad reset angle, the cover unfolds along local +x. These values
+# conservatively enclose both scaled folder panels in the tabletop plane.
+FOLDER_OPEN_FOOTPRINT_CENTER_LOCAL = (0.11, 0.0)
+FOLDER_OPEN_FOOTPRINT_HALF_EXTENTS = (0.22, 0.14)
+FOLDER_OPEN_JOINT_POS = 3.2  # rad, hinge range is [0, 3.32]; cover lying flat open
+
+
+def make_shelf_cfg(usd_path: str, init_pos: tuple[float, float, float]) -> RigidObjectCfg:
+    return RigidObjectCfg(
+        prim_path="{ENV_REGEX_NS}/Shelf",
+        spawn=sim_utils.UsdFileCfg(
+            func=dexverse_base_env.spawn_usd_with_rigid_properties,
+            usd_path=usd_path,
+            rigid_props=sim_utils.RigidBodyPropertiesCfg(rigid_body_enabled=True, kinematic_enabled=True, disable_gravity=True),
+            collision_props=None,  # authored per box prim
+            mass_props=None,
+        ),
+        init_state=RigidObjectCfg.InitialStateCfg(pos=init_pos, rot=(1.0, 0.0, 0.0, 0.0)),
+    )
+
+
+@configclass
+class CloseFolderInsertShelfEnvFloatingDexHandRightCfg(OpenFlatFolderEnvFloatingDexHandRightCfg):
+    """Close the folder, rotate it vertically, and insert it like a file."""
+
+    # Folder starts open flat.
+    articulation_init_joint_pos: dict[str, float] = {"RevoluteJoint_file_9_up": FOLDER_OPEN_JOINT_POS}
+    # Same per-collider collision offsets as the tray (retrieve_tray_from_rack):
+    # the folder flaps are thin, so engaging finger contacts earlier
+    # (contact_offset) and settling them slightly above the mesh (rest_offset)
+    # stabilises the bimanual grasp.
+    articulation_contact_offset: float | None = 0.02
+    articulation_rest_offset: float | None = 0.002
+    # Open, the folder rests with its root ~3.3 cm above the table (reset audit, Aug
+    # 2026: seated at the closed-folder height it pushed itself up 2.8 cm); seat it
+    # ~3 mm above that rest height instead.
+    articulation_half_height_est: float = 0.036
+    # Folder spawn box (offsets from its seated init pose at the table centre) --
+    # kept clear of the shelf band and in front of the bimanual palms (x=-0.25).
+    articulation_reset_pose_range: dict[str, list[float]] = {
+        "x": [-0.25, -0.05],
+        "y": [-0.25, 0.25],
+        "z": [0.0, 0.0],
+        "roll": [0.0, 0.0],
+        "pitch": [0.0, 0.0],
+        "yaw": [math.radians(-45.0-90), math.radians(45.0-90)],
+    }
+    # Shelf band (offsets from shelf_init_x/y); the open front is aimed at the
+    # hands' start ``shelf_face_point`` by reset_root_pose_uniform_facing.
+    # x in [0.26, 0.32], y +-0.25: 16 cm closer to the hands than the previous
+    # band. Even at the angled approach extrema, its footprint remains on the
+    # 0.75 m-half-width tabletop.
+    shelf_init_x: float = 0.29
+    shelf_init_y: float = 0.0
+    shelf_pose_range: dict[str, list[float]] = {"x": [-0.03, 0.03], "y": [-0.25, 0.25], "z": [0.0, 0.0]}
+    shelf_face_point: tuple[float, float] = (-0.25, 0.0)
+    # Keep the opening up front: rotate at most 45 degrees either way relative
+    # to the heading that points the opening toward the hands.
+    shelf_yaw_jitter: tuple[float, float] = (math.radians(-45.0), math.radians(45.0))
+    # Reject actual oriented-footprint overlap at reset. This allows the shelf
+    # to move closer without the old 0.58 m circumscribed-radius rule discarding
+    # safe poses. A 1 cm gap absorbs footprint/model approximation error.
+    folder_shelf_reset_clearance: float = 0.01
+
+    closed_threshold_rad: float = 0.35
+    max_axis_angle_rad: float = 0.3491  # 20 deg from vertical
+    max_lin_speed: float = 0.05
+    # The scaled folder reaches about 12 cm from its root along the insertion
+    # axis. Requiring the root 15 cm past the opening puts the whole folder
+    # inside, with its front edge roughly 3 cm behind the shelf front.
+    min_insertion_depth: float = 0.15
+    episode_length_s_override: float = 25.0
+
+    def configure_debug_vis(self) -> None:
+        super().configure_debug_vis()
+        if not self.enable_debug_vis:
+            return
+        c, h = SLOT_CENTER_LOCAL, SLOT_HALF_EXTENTS
+        self.add_scene_vis_term(
+            "slot_target",
+            ObsTerm(
+                func=mdp.forbidden_zones_vis,
+                params={
+                    "box_zones": [(c[0], c[1], c[2], h[0], h[1], h[2])],
+                    "object_cfg": SceneEntityCfg("shelf"),
+                    "color": (0.15, 0.75, 0.25),
+                    "opacity": 0.25,
+                    "prim_path_prefix": "/Visuals/SlotTarget",
+                },
+            ),
+        )
+
+    def __post_init__(self):
+        table_top_z = dexverse_base_env.DEFAULT_TABLE_TOP_HEIGHT
+        self.scene.shelf = make_shelf_cfg(str(SHELF_USD_PATH), (self.shelf_init_x, self.shelf_init_y, table_top_z))
+
+        super().__post_init__()
+
+        # --- reset order: shelf first, then the folder kept clear of it ------------
+        # The base's ``reset_articulation`` (uniform pose) fires before any event we
+        # add here, so replace it: null it and re-add the folder reset *after* the
+        # shelf placement, using the shelf as an exclusion reference.
+        folder_pose_range = dict(self.events.reset_articulation.params["pose_range"]) if self.events.reset_articulation is not None else self.articulation_reset_pose_range
+        self.events.reset_articulation = None
+        self.events.reset_shelf = EventTerm(
+            func=mdp.reset_root_pose_uniform_facing,
+            mode="reset",
+            params={
+                "asset_cfg": SceneEntityCfg("shelf"),
+                "pose_range": self.shelf_pose_range,
+                "face_asset_cfg": None,
+                "face_point": tuple(self.shelf_face_point),
+                "open_dir_local": (-1.0, 0.0),
+                "yaw_jitter": tuple(self.shelf_yaw_jitter),
+            },
+        )
+        self.events.reset_folder = EventTerm(
+            func=mdp.reset_root_pose_uniform_excluding,
+            mode="reset",
+            params={
+                "asset_cfg": SceneEntityCfg(ARTICULATION_KEY),
+                "pose_range": folder_pose_range,
+                "reference_asset_cfg": SceneEntityCfg("shelf"),
+                "footprint_half_extents": FOLDER_OPEN_FOOTPRINT_HALF_EXTENTS,
+                "footprint_center_local": FOLDER_OPEN_FOOTPRINT_CENTER_LOCAL,
+                "reference_footprint_half_extents": SHELF_FOOTPRINT_HALF_EXTENTS,
+                "footprint_clearance": self.folder_shelf_reset_clearance,
+                "max_attempts": 100,
+            },
+        )
+        # joints (open) are re-seated by the base's reset_articulation_joints, which
+        # runs before reset_folder -- fine, joint state is independent of the root pose.
+
+        # --- success --------------------------------------------------------------
+        self.terminations.success.func = mdp.articulation_closed_and_inserted
+        self.terminations.success.params = {
+            "asset_cfg": SceneEntityCfg(ARTICULATION_KEY, joint_names=self.success_joint_names),
+            "shelf_cfg": SceneEntityCfg("shelf"),
+            "slot_center_local": SLOT_CENTER_LOCAL,
+            "slot_half_extents": SLOT_HALF_EXTENTS,
+            "xy_margin": 0.02,
+            "z_margin": 0.02,
+            "closed_threshold": self.closed_threshold_rad,
+            # Closed folder axes: local x = broad width, local y = height,
+            # local z = thickness. Insert it like a file: thickness spans the
+            # narrow shelf width (+y), broad width extends through the depth
+            # (+/-x), and height points up (+z).
+            "thickness_axis_local": (0.0, 0.0, 1.0),
+            "slot_width_axis_local": tuple(SHELF_MANIFEST["slot"]["width_axis_local"]),
+            "upright_axis_local": (0.0, 1.0, 0.0),
+            "slot_up_axis_local": (0.0, 0.0, 1.0),
+            "slot_front_x_local": float(SHELF_MANIFEST["slot"]["front_x"]),
+            "min_insertion_depth": self.min_insertion_depth,
+            "max_axis_angle_rad": self.max_axis_angle_rad,
+            "max_lin_speed": self.max_lin_speed,
+        }
+
+        # --- operator cue: translucent slot box on the shelf (teleop only) ------------
+        self.configure_debug_vis()
+
+        # --- observations: shelf pose + slot centre ---------------------------------
+        state = self.observations.state
+        if state is not None:
+            state.shelf_pos_b = ObsTerm(func=mdp.asset_pos_b, params={"asset_cfg": SceneEntityCfg("shelf")}, noise=Unoise(n_min=-0.0, n_max=0.0))
+            state.shelf_quat_b = ObsTerm(func=mdp.object_quat_b, params={"object_cfg": SceneEntityCfg("shelf")}, noise=Unoise(n_min=-0.0, n_max=0.0))
+        if getattr(self.observations, "goal", None) is None:
+
+            @configclass
+            class GoalObsCfg(ObsGroup):
+                slot_pos_b = ObsTerm(
+                    func=mdp.object_local_point_pos_b,
+                    params={"object_cfg": SceneEntityCfg("shelf"), "local_offset": SLOT_CENTER_LOCAL},
+                    noise=Unoise(n_min=-0.0, n_max=0.0),
+                )
+
+                def __post_init__(self):
+                    self.enable_corruption = True
+                    self.concatenate_terms = True
+                    self.history_length = 0
+
+            self.observations.goal = GoalObsCfg()

--- a/source/dexverse/dexverse/baseline_v1/config/articulation/cut_seam_utility_knife_cfg.py
+++ b/source/dexverse/dexverse/baseline_v1/config/articulation/cut_seam_utility_knife_cfg.py
@@ -1,0 +1,331 @@
+# Copyright (c) 2025-2026, The DexVerse Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Two-phase utility knife: slide the blade out, then cut a taped seam.
+
+Extends :mod:`slide_utility_knife_cfg` with a functional phase. A kinematic
+"mimicked box" workpiece (:func:`dexverse.assets.cut_props_builder.
+build_taped_seam_workpiece`: two cuboid blocks separated by a thin open slot,
+covered by a colored tape strip) stands on the table. The robot must extend
+the blade and drag the blade tip through the tape along the whole seam.
+
+Cutting is measured, never force-simulated (see :mod:`...mdp.cut_sweep`):
+
+- A prestartup :func:`mdp.filter_collision_pairs` event makes the ``tape``
+  prim collide with everything *except* the blade link, so the extended blade
+  phantoms through the tape into the slot while the knife body cannot; the
+  unfiltered slot walls physically guide the blade along the seam.
+- A per-env **cut frontier** advances only while the blade is extended, the
+  tip is pressed through the tape into the slot near the seam line, the knife
+  heading tracks the seam, and the tip is *at* the frontier -- advancing at a
+  capped rate. Teleporting or tapping the far end accrues nothing.
+
+Success = the frontier passes ``cut_complete_frac`` of the seam. The parent's
+0.2 m lift gate is retired: reaching the seam already forces holding the
+knife. Stage graph (blade_extended -> seam_cut) provides latched stage
+signals / progress via the standard stage-machine interface.
+"""
+
+from __future__ import annotations
+
+import isaaclab.sim as sim_utils
+from dexverse.assets.cut_props_builder import ensure_taped_seam_workpiece_asset
+from isaaclab.assets import RigidObjectCfg
+from isaaclab.managers import EventTermCfg as EventTerm
+from isaaclab.managers import ObservationGroupCfg as ObsGroup
+from isaaclab.managers import ObservationTermCfg as ObsTerm
+from isaaclab.managers import RewardTermCfg as RewTerm
+from isaaclab.managers import SceneEntityCfg
+from isaaclab.utils import configclass
+from isaaclab.utils.noise import UniformNoiseCfg as Unoise
+
+from ... import dexverse_base_env_cfg as dexverse_base_env
+from ... import mdp
+from .articulation_base.articulation_base_cfg import ARTICULATION_KEY
+from .slide_utility_knife_cfg import SlideUtilityKnifeEnvFloatingDexHandRightCfg
+
+STAGE_KEY = "cut_seam_utility_knife"
+WORKPIECE_NAME = "taped_seam_workpiece"
+WORKPIECE_PARAMS = dict(
+    seam_length=0.10,
+    slot_width=0.012,
+    block_width=0.07,
+    block_height=0.045,
+    tape_thickness=0.0025,
+    tape_width=0.05,
+    # Darker kraft-cardboard body so it reads as a shipping box (Aug 2026).
+    block_color=(0.42, 0.27, 0.14),
+)
+WORKPIECE_USD_PATH, WORKPIECE_MANIFEST = ensure_taped_seam_workpiece_asset(WORKPIECE_NAME, **WORKPIECE_PARAMS)
+SEAM_START_LOCAL: tuple[float, float, float] = tuple(WORKPIECE_MANIFEST["seam"]["start"])
+SEAM_END_LOCAL: tuple[float, float, float] = tuple(WORKPIECE_MANIFEST["seam"]["end"])
+SLOT_CENTER_LOCAL: tuple[float, float, float] = tuple(WORKPIECE_MANIFEST["slot"]["center"])
+SLOT_HALF_EXTENTS: tuple[float, float, float] = tuple(WORKPIECE_MANIFEST["slot"]["half_extents"])
+Z_BLOCK_TOP: float = float(WORKPIECE_MANIFEST["z_block_top"])
+
+# Knife link names (synthesis/utility knife002). The sweep's reference point is
+# the blade's *cutting-edge tip corner* in the *scaled* (1.3x) blade-link
+# frame: the blade is a trapezoid whose cutting edge is the -x side of the
+# plate (it reaches the tip at y=0.109 unscaled; the +x spine side stops at
+# y=0.100), so the corner sits at (-0.009, 0.109, -0.0065) unscaled. Using the
+# edge (not the plate mid-width, 11.7 mm up the plate) makes the dip gate mean
+# "the edge is through the tape" rather than demanding a ~15 mm deep stroke.
+KNIFE_BLADE_BODY = "E_link_blade_2"
+KNIFE_TIP_LOCAL_OFFSET: tuple[float, float, float] = (-0.0117, 0.142, -0.0045)
+
+
+def make_workpiece_cfg(usd_path: str, init_pos: tuple[float, float, float]) -> RigidObjectCfg:
+    return RigidObjectCfg(
+        prim_path="{ENV_REGEX_NS}/Workpiece",
+        spawn=sim_utils.UsdFileCfg(
+            func=dexverse_base_env.spawn_usd_with_rigid_properties,
+            usd_path=usd_path,
+            rigid_props=sim_utils.RigidBodyPropertiesCfg(
+                rigid_body_enabled=True, kinematic_enabled=True, disable_gravity=True
+            ),
+            collision_props=None,  # authored per box prim
+            mass_props=None,
+        ),
+        init_state=RigidObjectCfg.InitialStateCfg(pos=init_pos, rot=(1.0, 0.0, 0.0, 0.0)),
+    )
+
+
+@configclass
+class CutSeamUtilityKnifeEnvFloatingDexHandRightCfg(SlideUtilityKnifeEnvFloatingDexHandRightCfg):
+    """Slide the blade out, then drag the tip through the taped seam."""
+
+    # Two-phase episode: grasp + extend + carry + gated 10 cm drag.
+    episode_length_s_override: float = 20.0
+
+    # Goal-at-centre layout: the workpiece sits at the exact table centre
+    # (no translation jitter -- easy, consistent reach from the hands' start
+    # at x=-0.2) with only a slight heading jitter about "seam along world y"
+    # so a right-hand drag stays natural; the knife rig is then
+    # rejection-sampled *around* it (see ``articulation_reset_pose_range``
+    # below + the rig reset in __post_init__).
+    workpiece_init_x: float = 0.0
+    workpiece_init_y: float = 0.0
+    workpiece_pose_range: dict[str, list[float]] = {
+        "x": [0.0, 0.0],
+        "y": [0.0, 0.0],
+        "z": [0.0, 0.0],
+        "roll": [0.0, 0.0],
+        "pitch": [0.0, 0.0],
+        "yaw": [-0.26, 0.26],
+    }
+    # Cut direction as seen by the operator (hands face +x, so their left is
+    # +y): True drags the blade from +y to -y, i.e. left -> right.
+    cut_left_to_right: bool = True
+    # Knife-rig spawn band: a compact segment on the hand side of the centred
+    # workpiece; the point-based exclusion below carves out the overlap region.
+    articulation_reset_pose_range: dict[str, list[float]] = {
+        "x": [-0.32, -0.05],
+        "y": [-0.22, 0.22],
+        "z": [0.0, 0.0],
+        "roll": [0.0, 0.0],
+        "pitch": [0.0, 0.0],
+        # Blade / jaws (tool local +y) toward the operator's LEFT (world +y,
+        # the hands face +x): yaw about 0 only, so the left hand takes the
+        # body and the right hand the functional end (teleop feedback, Aug 2026).
+        "yaw": [-0.4, 0.4],
+    }
+    # Rig-vs-workpiece exclusion: the knife + its two stands form a ~0.26 m
+    # bar along the knife's local +y (stands at y=0 and y=0.2); three check
+    # points along it, each kept ``min_knife_workpiece_xy_distance`` from the
+    # workpiece centre (stand half-diagonal ~0.04 + knife half-width ~0.03 +
+    # workpiece half-diagonal ~0.08 at the 0.10 m seam). The rig may sit much
+    # closer than a single root radius whenever it points away from the box.
+    knife_rig_exclusion_points: tuple[tuple[float, float, float], ...] = ((0.0, 0.0, 0.0), (0.0, 0.1, 0.0), (0.0, 0.2, 0.0))
+    min_knife_workpiece_xy_distance: float = 0.16
+
+    # --- sweep gates (see mdp.CutSweepSpec) --------------------------------
+    cut_complete_frac: float = 0.95
+    cut_lateral_tol: float = 0.012
+    cut_min_dip: float = 0.003
+    cut_backlash: float = 0.02
+    cut_max_step_advance: float = 0.01
+    cut_align_threshold_cos: float = 0.90
+    # Blade-extension gate reuses the parent success threshold (progress units).
+
+    def configure_debug_vis(self) -> None:
+        super().configure_debug_vis()
+        if not self.enable_debug_vis:
+            return
+        # Red -> green sphere riding the cut frontier. (A translucent green
+        # slab over the slot was tried and removed -- it blocked the
+        # operator's view of the seam; the yellow tape strip itself is the
+        # "cut here" cue.)
+        self.add_scene_vis_term(
+            "cut_frontier",
+            ObsTerm(func=mdp.cut_frontier_vis, params={"task_key": STAGE_KEY, "radius": 0.015}),
+        )
+
+    def __post_init__(self):
+        table_top_z = dexverse_base_env.DEFAULT_TABLE_TOP_HEIGHT
+        self.scene.workpiece = make_workpiece_cfg(
+            str(WORKPIECE_USD_PATH), (self.workpiece_init_x, self.workpiece_init_y, table_top_z)
+        )
+
+        super().__post_init__()
+
+        # --- reset order: workpiece at the centre FIRST, then the knife rig
+        # (knife + support stands as one rigid transform) rejection-sampled
+        # around it. The inherited ``reset_articulation`` fires before any
+        # appended event, so null it and re-add the rig reset after the
+        # workpiece with the exclusion reference (close_folder_insert_shelf
+        # pattern).
+        rig_params = dict(self.events.reset_articulation.params)
+        self.events.reset_articulation = None
+        self.events.reset_workpiece = EventTerm(
+            func=mdp.reset_root_pose_uniform,
+            mode="reset",
+            params={
+                "asset_cfg": SceneEntityCfg("workpiece"),
+                "pose_range": self.workpiece_pose_range,
+            },
+        )
+        self.events.reset_knife_rig = EventTerm(
+            func=mdp.reset_articulation_with_supports_uniform,
+            mode="reset",
+            params={
+                **rig_params,
+                "reference_asset_cfg": SceneEntityCfg("workpiece"),
+                "min_xy_distance": self.min_knife_workpiece_xy_distance,
+                "exclusion_points_local": list(self.knife_rig_exclusion_points),
+                "max_attempts": 60,
+            },
+        )
+
+        # --- phantom tape: blade passes through, everything else collides ----
+        self.events.filter_tape_blade = EventTerm(
+            func=mdp.filter_collision_pairs,
+            mode="prestartup",
+            params={
+                "source_prim_path": "{ENV_REGEX_NS}/Workpiece/" + WORKPIECE_MANIFEST["tape_prim"],
+                "target_prim_paths": ["{ENV_REGEX_NS}/Articulation/" + KNIFE_BLADE_BODY],
+            },
+        )
+
+        # --- cut sweep registration ------------------------------------------
+        mdp.register_cut_sweep(
+            STAGE_KEY,
+            mdp.CutSweepSpec(
+                workpiece_asset_name="workpiece",
+                seam_start_local=SEAM_END_LOCAL if self.cut_left_to_right else SEAM_START_LOCAL,
+                seam_end_local=SEAM_START_LOCAL if self.cut_left_to_right else SEAM_END_LOCAL,
+                tool_asset_name=ARTICULATION_KEY,
+                tip_body_name=KNIFE_BLADE_BODY,
+                tip_local_offset=KNIFE_TIP_LOCAL_OFFSET,
+                ext_joint_name=self.success_joint_names[0],
+                ext_threshold=self.success_threshold,
+                lateral_tol=self.cut_lateral_tol,
+                z_surface_local=Z_BLOCK_TOP,
+                min_dip=self.cut_min_dip,
+                align_axis_tool_local=(0.0, 1.0, 0.0),
+                align_threshold_cos=self.cut_align_threshold_cos,
+                backlash=self.cut_backlash,
+                max_step_advance=self.cut_max_step_advance,
+                complete_frac=self.cut_complete_frac,
+            ),
+            override=True,
+        )
+
+        # --- stage graph: blade_extended -> seam_cut --------------------------
+        mdp.register_stage_graph(
+            STAGE_KEY,
+            mdp.StageGraphSpec(
+                stages=(
+                    mdp.StageSpec(
+                        name="blade_extended",
+                        func=mdp.joint_relative_move,
+                        params={
+                            "threshold": self.success_threshold,
+                            "asset_cfg": SceneEntityCfg(ARTICULATION_KEY, joint_names=self.success_joint_names),
+                            "mode": "progress",
+                            "op": ">=",
+                            "reduce": "any",
+                        },
+                    ),
+                    mdp.StageSpec(
+                        name="seam_cut",
+                        func=mdp.cut_sweep_complete,
+                        params={"task_key": STAGE_KEY},
+                        deps=("blade_extended",),
+                    ),
+                ),
+                terminal_stage="seam_cut",
+                ordering_mode="strict",
+                success_mode="substage",
+            ),
+            override=True,
+        )
+
+        # --- success: the seam is cut (lift gate retired -- reaching the seam
+        # already forces holding the knife) ------------------------------------
+        self.terminations.success.func = mdp.stage_success
+        self.terminations.success.params = {"task_key": STAGE_KEY, "persistent": True}
+
+        # --- rewards: keep the fixate preset (parent wired knife_lift before we
+        # null it), add sweep shaping ------------------------------------------
+        self.rewards.knife_lift = None
+        self.rewards.tip_to_frontier = RewTerm(
+            func=mdp.cut_sweep_tip_tracking_reward,
+            weight=1.5,
+            params={"task_key": STAGE_KEY, "distance_gain": 10.0, "require_ext": True},
+        )
+        self.rewards.cut_progress = RewTerm(
+            func=mdp.cut_sweep_progress_reward,
+            weight=5.0,
+            params={"task_key": STAGE_KEY},
+        )
+        self.rewards.stage_bonus = RewTerm(
+            func=mdp.stage_success_reward,
+            weight=5.0,
+            params={"task_key": STAGE_KEY, "persistent": True},
+        )
+
+        # --- observations ------------------------------------------------------
+        state = self.observations.state
+        if state is not None:
+            state.workpiece_pos_b = ObsTerm(
+                func=mdp.asset_pos_b,
+                params={"asset_cfg": SceneEntityCfg("workpiece")},
+                noise=Unoise(n_min=-0.0, n_max=0.0),
+            )
+            state.workpiece_quat_b = ObsTerm(
+                func=mdp.object_quat_b,
+                params={"object_cfg": SceneEntityCfg("workpiece")},
+                noise=Unoise(n_min=-0.0, n_max=0.0),
+            )
+            state.stage_signals = ObsTerm(
+                func=mdp.stage_signals, params={"task_key": STAGE_KEY, "persistent": True}
+            )
+            state.cut_frontier = ObsTerm(func=mdp.cut_sweep_frontier, params={"task_key": STAGE_KEY})
+        if getattr(self.observations, "goal", None) is None:
+            seam_start = SEAM_END_LOCAL if self.cut_left_to_right else SEAM_START_LOCAL
+            seam_end = SEAM_START_LOCAL if self.cut_left_to_right else SEAM_END_LOCAL
+
+            @configclass
+            class GoalObsCfg(ObsGroup):
+                seam_start_b = ObsTerm(
+                    func=mdp.object_local_point_pos_b,
+                    params={"object_cfg": SceneEntityCfg("workpiece"), "local_offset": seam_start},
+                    noise=Unoise(n_min=-0.0, n_max=0.0),
+                )
+                seam_end_b = ObsTerm(
+                    func=mdp.object_local_point_pos_b,
+                    params={"object_cfg": SceneEntityCfg("workpiece"), "local_offset": seam_end},
+                    noise=Unoise(n_min=-0.0, n_max=0.0),
+                )
+
+                def __post_init__(self):
+                    self.enable_corruption = True
+                    self.concatenate_terms = True
+                    self.history_length = 0
+
+            self.observations.goal = GoalObsCfg()
+
+        # --- operator cues -----------------------------------------------------
+        self.configure_debug_vis()

--- a/source/dexverse/dexverse/baseline_v1/config/articulation/cut_strip_scissors_cfg.py
+++ b/source/dexverse/dexverse/baseline_v1/config/articulation/cut_strip_scissors_cfg.py
@@ -1,0 +1,348 @@
+# Copyright (c) 2025-2026, The DexVerse Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Two-phase scissors: open the blades, then snip a paper strip.
+
+Extends :mod:`squeeze_scissors_cfg` with a functional phase. A kinematic
+strip-on-a-stand prop (:func:`dexverse.assets.cut_props_builder.
+build_strip_stand`: base + post + clamp holding a cantilevered paper strip)
+stands at the table centre, its free edge aimed at the hands' start; the
+scissors rig spawns around it. The robot must open the scissors, bring them so
+the strip sits between the blades, and close them on it.
+
+The paper has its normal authored collider and exchanges contact forces with
+the complete scissors, including both blade links. Success is the contact
+predicate :func:`mdp.scissors_inner_blades_touch_strip`: a long rectangular
+zone along each blade's inward-facing cutting edge defines its functional
+region, and both regions must touch opposite sides of the paper for a short
+dwell, with their midpoint within its inset top face. No particular hinge
+velocity or final joint angle is required; the paper also has full collision.
+
+Stage graph: ``jaws_open`` (the parent's open-success predicate, latched --
+the scissors must have been opened first) -> ``strip_cut``. A stricter
+finger-keep-away term (``hand_near_body_point`` on the strip) is available if
+demos show operators nudging the stand; the stage-2 predicate itself involves
+only the scissors' joints and the strip/blade frames, so fingers cannot fake
+it.
+"""
+
+from __future__ import annotations
+
+import isaaclab.sim as sim_utils
+from dexverse.assets.cut_props_builder import ensure_strip_stand_asset
+from isaaclab.assets import RigidObjectCfg
+from isaaclab.managers import EventTermCfg as EventTerm
+from isaaclab.managers import ObservationGroupCfg as ObsGroup
+from isaaclab.managers import ObservationTermCfg as ObsTerm
+from isaaclab.managers import RewardTermCfg as RewTerm
+from isaaclab.managers import SceneEntityCfg
+from isaaclab.utils import configclass
+from isaaclab.utils.noise import UniformNoiseCfg as Unoise
+
+from ... import dexverse_base_env_cfg as dexverse_base_env
+from ... import mdp
+from .articulation_base.articulation_base_cfg import ARTICULATION_KEY
+from .squeeze_scissors_cfg import SqueezeScissorsEnvFloatingDexHandRightCfg
+
+STAGE_KEY = "cut_strip_scissors"
+STAND_NAME = "strip_stand"
+STAND_PARAMS = dict(
+    base_size=0.12,
+    base_height=0.02,
+    post_size=0.03,
+    post_height=0.115,
+    clamp_size=(0.04, 0.035, 0.015),
+    strip_length=0.14,
+    strip_width=0.03,
+    strip_thickness=0.0015,
+    cut_point_inset=0.025,
+    # Orange PLA-like stand so it reads as a 3D-printed fixture (Aug 2026).
+    stand_color=(0.92, 0.42, 0.08),
+)
+STAND_USD_PATH, STAND_MANIFEST = ensure_strip_stand_asset(STAND_NAME, **STAND_PARAMS)
+CUT_POINT_LOCAL: tuple[float, float, float] = tuple(STAND_MANIFEST["cut_point"])
+# The whole paper strip as a box in the stand root frame; blade contact may
+# occur anywhere along it.
+_FREE_EDGE = STAND_MANIFEST["free_edge_local"]
+STRIP_BOX_CENTER_LOCAL: tuple[float, float, float] = (
+    float(_FREE_EDGE[0]) + STAND_PARAMS["strip_length"] / 2.0,
+    0.0,
+    float(STAND_MANIFEST["z_strip"]),
+)
+STRIP_BOX_HALF_EXTENTS: tuple[float, float, float] = (
+    STAND_PARAMS["strip_length"] / 2.0,
+    STAND_PARAMS["strip_width"] / 2.0,
+    STAND_PARAMS["strip_thickness"] / 2.0,
+)
+
+# Scissor blade links (scissors010): the two halves hinged on the pivot screw
+# ``body_19`` (= the articulation root). Both blade link frames sit at the
+# pivot with the jaw along local +y and the shear line near local x = 0.
+SCISSOR_BLADE_BODIES = ("Left_scissor_handle_3", "Right_cut_handle_6")
+
+
+def make_strip_stand_cfg(usd_path: str, init_pos: tuple[float, float, float]) -> RigidObjectCfg:
+    return RigidObjectCfg(
+        prim_path="{ENV_REGEX_NS}/StripStand",
+        spawn=sim_utils.UsdFileCfg(
+            func=dexverse_base_env.spawn_usd_with_rigid_properties,
+            usd_path=usd_path,
+            rigid_props=sim_utils.RigidBodyPropertiesCfg(
+                rigid_body_enabled=True, kinematic_enabled=True, disable_gravity=True
+            ),
+            collision_props=None,  # authored per box prim
+            mass_props=None,
+        ),
+        init_state=RigidObjectCfg.InitialStateCfg(pos=init_pos, rot=(1.0, 0.0, 0.0, 0.0)),
+    )
+
+
+@configclass
+class CutStripScissorsEnvFloatingDexHandRightCfg(SqueezeScissorsEnvFloatingDexHandRightCfg):
+    """Open the scissors, then close them on the strip's cut point."""
+
+    # Two-phase episode: grasp + open + carry to the strip + snip.
+    # 20 s = 1200 steps at 60 Hz (was 15 s): the task is long -- teleop demos run
+    # 550-1250 steps -- so the eval budget matches the other functional tasks.
+    episode_length_s_override: float = 20.0
+
+    # Goal-at-centre layout: the strip stand sits at the exact table centre
+    # (no jitter -- easy, consistent reach from the hands' start at x=-0.2),
+    # its strip aimed exactly at the hands; the scissors rig is then
+    # rejection-sampled *around* it (see ``articulation_reset_pose_range``
+    # below + the rig reset in __post_init__).
+    stand_init_x: float = 0.0
+    stand_init_y: float = 0.0
+    stand_pose_range: dict[str, list[float]] = {"x": [0.0, 0.0], "y": [0.0, 0.0], "z": [0.0, 0.0]}
+    # Aim the strip's free edge (local -x) at the hands' start, with the
+    # original slight heading variation so a right-hand snip stays natural.
+    stand_face_point: tuple[float, float] = (-0.25, 0.0)
+    stand_yaw_jitter: tuple[float, float] = (-0.26, 0.26)
+    # Scissors-rig spawn band: a compact segment on the hand side of the
+    # centred stand; the point-based exclusion below carves out the overlap
+    # region.
+    articulation_reset_pose_range: dict[str, list[float]] = {
+        "x": [-0.30, -0.05],
+        "y": [-0.22, 0.22],
+        "z": [0.0, 0.0],
+        "roll": [0.0, 0.0],
+        "pitch": [0.0, 0.0],
+        # Blade / jaws (tool local +y) toward the operator's LEFT (world +y,
+        # the hands face +x): yaw about 0 only, so the left hand takes the
+        # body and the right hand the functional end (teleop feedback, Aug 2026).
+        "yaw": [-0.4, 0.4],
+    }
+    # Rig-vs-stand exclusion: the scissors + their two stands form a ~0.26 m
+    # bar along local y centred on the pivot (stands at y=+-0.09); three check
+    # points along it, each kept ``min_scissors_stand_xy_distance`` from the
+    # stand centre (stand-block half-diagonal ~0.04 + strip-stand base
+    # half-diagonal ~0.09). The strip itself cantilevers 0.14 m above the
+    # scissors' resting height, so only the base footprint matters.
+    scissors_rig_exclusion_points: tuple[tuple[float, float, float], ...] = (
+        (0.0, -0.12, 0.0),
+        (0.0, 0.0, 0.0),
+        (0.0, 0.12, 0.0),
+    )
+    min_scissors_stand_xy_distance: float = 0.14
+
+    # Continuous rectangular inner-blade region in each blade link frame. Only
+    # the distal (tip-side) half of the cutting edge is active, so both blades
+    # can touch the strip only at a relatively small jaw angle. The contact
+    # cross-section remains forgiving; the success predicate separately
+    # requires the blade zones to straddle the paper, rejecting flat placement.
+    blade_zone_y_range: tuple[float, float] = (0.0485, 0.095)
+    blade_zone_half_extents: tuple[float, float, float] = (0.008, 0.02325, 0.004)
+    blade_contact_inflation: tuple[float, float, float] = (0.004, 0.004, 0.006)
+    # The midpoint between the two inner edges must pass through this inset
+    # top-face area, preventing contact against a vertical side from counting.
+    strip_cut_edge_margin_xy: tuple[float, float] = (0.008, 0.004)
+    blade_contact_hold_steps: int = 3
+
+    def configure_debug_vis(self) -> None:
+        super().configure_debug_vis()
+        if not self.enable_debug_vis:
+            return
+        # Sphere on the strip's cut point: the operator's "cut here" cue.
+        self.add_scene_vis_term(
+            "cut_point",
+            ObsTerm(
+                func=mdp.body_point_zone_vis,
+                params={
+                    "target_cfg": SceneEntityCfg("strip_stand"),
+                    "local_offset": CUT_POINT_LOCAL,
+                    "radius": 0.02,
+                    "color": (0.15, 0.75, 0.25),
+                    "opacity": 0.5,
+                    "prim_path": "/Visuals/CutPoint",
+                    "hide_from_cameras": True,
+                },
+            ),
+        )
+        # Blue rectangles exactly matching the functional contact regions.
+        zone_mid_y = 0.5 * (self.blade_zone_y_range[0] + self.blade_zone_y_range[1])
+        zone_size = tuple(2.0 * value for value in self.blade_zone_half_extents)
+        for index, body_name in enumerate(SCISSOR_BLADE_BODIES):
+            self.add_scene_vis_term(
+                f"blade_edge_{index}",
+                ObsTerm(
+                    func=mdp.body_box_zone_vis,
+                    params={
+                        "target_cfg": SceneEntityCfg(ARTICULATION_KEY, body_names=[body_name]),
+                        "local_offset": (0.0, zone_mid_y, 0.0),
+                        "size": zone_size,
+                        "color": (0.15, 0.45, 0.85),
+                        "opacity": 0.5,
+                        "prim_path": f"/Visuals/BladeEdge{index}",
+                        "hide_from_cameras": True,
+                    },
+                ),
+            )
+
+    def __post_init__(self):
+        table_top_z = dexverse_base_env.DEFAULT_TABLE_TOP_HEIGHT
+        self.scene.strip_stand = make_strip_stand_cfg(
+            str(STAND_USD_PATH), (self.stand_init_x, self.stand_init_y, table_top_z)
+        )
+
+        super().__post_init__()
+
+        # --- reset order: stand at the centre FIRST (strip aimed at the
+        # hands), then the scissors rig (scissors + padding stands as one
+        # rigid transform) rejection-sampled around it. The inherited
+        # ``reset_articulation`` fires before any appended event, so null it
+        # and re-add the rig reset after the stand with the exclusion
+        # reference (close_folder_insert_shelf pattern).
+        rig_params = dict(self.events.reset_articulation.params)
+        self.events.reset_articulation = None
+        self.events.reset_strip_stand = EventTerm(
+            func=mdp.reset_root_pose_uniform_facing,
+            mode="reset",
+            params={
+                "asset_cfg": SceneEntityCfg("strip_stand"),
+                "pose_range": self.stand_pose_range,
+                "face_asset_cfg": None,
+                "face_point": tuple(self.stand_face_point),
+                "open_dir_local": (-1.0, 0.0),
+                "yaw_jitter": tuple(self.stand_yaw_jitter),
+            },
+        )
+        self.events.reset_scissors_rig = EventTerm(
+            func=mdp.reset_articulation_with_supports_uniform,
+            mode="reset",
+            params={
+                **rig_params,
+                "reference_asset_cfg": SceneEntityCfg("strip_stand"),
+                "min_xy_distance": self.min_scissors_stand_xy_distance,
+                "exclusion_points_local": list(self.scissors_rig_exclusion_points),
+                "max_attempts": 60,
+            },
+        )
+
+        # --- stage graph: jaws_open (latched) -> strip_cut ----------------------
+        mdp.register_stage_graph(
+            STAGE_KEY,
+            mdp.StageGraphSpec(
+                stages=(
+                    mdp.StageSpec(
+                        name="jaws_open",
+                        func=mdp.joint_relative_move,
+                        params={
+                            "threshold": self.success_threshold,
+                            "asset_cfg": SceneEntityCfg(ARTICULATION_KEY, joint_names=self.success_joint_names),
+                            "mode": "progress",
+                            "op": ">=",
+                            "reduce": "any",
+                        },
+                    ),
+                    mdp.StageSpec(
+                        name="strip_cut",
+                        func=mdp.scissors_inner_blades_touch_strip,
+                        params={
+                            "scissors_cfg": SceneEntityCfg(ARTICULATION_KEY, joint_names=self.success_joint_names),
+                            "blade_body_names": SCISSOR_BLADE_BODIES,
+                            "blade_zone_center_local": (
+                                0.0,
+                                0.5 * (self.blade_zone_y_range[0] + self.blade_zone_y_range[1]),
+                                0.0,
+                            ),
+                            "blade_zone_half_extents": self.blade_zone_half_extents,
+                            "strip_cfg": SceneEntityCfg("strip_stand"),
+                            "strip_box_center_local": STRIP_BOX_CENTER_LOCAL,
+                            "strip_box_half_extents": STRIP_BOX_HALF_EXTENTS,
+                            "contact_inflation": self.blade_contact_inflation,
+                            "strip_edge_margin_xy": self.strip_cut_edge_margin_xy,
+                            "hold_steps": self.blade_contact_hold_steps,
+                        },
+                        deps=("jaws_open",),
+                    ),
+                ),
+                terminal_stage="strip_cut",
+                ordering_mode="strict",
+                success_mode="substage",
+            ),
+            override=True,
+        )
+        self.terminations.success.func = mdp.stage_success
+        self.terminations.success.params = {"task_key": STAGE_KEY, "persistent": True}
+
+        # --- rewards: fixate preset plus carry-to-strip and stage shaping -------
+        # ``point_to_point_distance_exp`` is valid here because the scissors'
+        # pivot screw IS the articulation root.
+        self.rewards.pivot_to_cutpoint = RewTerm(
+            func=mdp.point_to_point_distance_exp,
+            weight=1.5,
+            params={
+                "source_cfg": SceneEntityCfg(ARTICULATION_KEY),
+                "source_local_offset": (
+                    0.0,
+                    0.5 * (self.blade_zone_y_range[0] + self.blade_zone_y_range[1]),
+                    0.0,
+                ),
+                "target_cfg": SceneEntityCfg("strip_stand"),
+                "target_local_offset": CUT_POINT_LOCAL,
+                "distance_gain": 10.0,
+            },
+        )
+        self.rewards.stage_bonus = RewTerm(
+            func=mdp.stage_success_reward,
+            weight=5.0,
+            params={"task_key": STAGE_KEY, "persistent": True},
+        )
+
+        # --- observations --------------------------------------------------------
+        state = self.observations.state
+        if state is not None:
+            state.stand_pos_b = ObsTerm(
+                func=mdp.asset_pos_b,
+                params={"asset_cfg": SceneEntityCfg("strip_stand")},
+                noise=Unoise(n_min=-0.0, n_max=0.0),
+            )
+            state.stand_quat_b = ObsTerm(
+                func=mdp.object_quat_b,
+                params={"object_cfg": SceneEntityCfg("strip_stand")},
+                noise=Unoise(n_min=-0.0, n_max=0.0),
+            )
+            state.stage_signals = ObsTerm(
+                func=mdp.stage_signals, params={"task_key": STAGE_KEY, "persistent": True}
+            )
+        if getattr(self.observations, "goal", None) is None:
+
+            @configclass
+            class GoalObsCfg(ObsGroup):
+                cut_point_b = ObsTerm(
+                    func=mdp.object_local_point_pos_b,
+                    params={"object_cfg": SceneEntityCfg("strip_stand"), "local_offset": CUT_POINT_LOCAL},
+                    noise=Unoise(n_min=-0.0, n_max=0.0),
+                )
+
+                def __post_init__(self):
+                    self.enable_corruption = True
+                    self.concatenate_terms = True
+                    self.history_length = 0
+
+            self.observations.goal = GoalObsCfg()
+
+        # --- operator cues -------------------------------------------------------
+        self.configure_debug_vis()

--- a/source/dexverse/dexverse/baseline_v1/config/articulation/open_cutaway_door_cfg.py
+++ b/source/dexverse/dexverse/baseline_v1/config/articulation/open_cutaway_door_cfg.py
@@ -1,0 +1,151 @@
+"""Pull the narrow cutout, clear it for the automatic latch, then release."""
+
+import math
+from pathlib import Path
+
+from isaaclab.actuators import ImplicitActuatorCfg
+from isaaclab.managers import EventTermCfg as EventTerm
+from isaaclab.managers import ObservationTermCfg as ObsTerm
+from isaaclab.managers import RewardTermCfg as RewTerm
+from isaaclab.managers import SceneEntityCfg
+from isaaclab.managers import TerminationTermCfg as DoneTerm
+from isaaclab.sensors import ContactSensorCfg
+from isaaclab.utils import configclass
+
+from dexverse.assets import DEXVERSE_AUTHORED_ARTICULATIONS_DIR
+from ... import dexverse_base_env_cfg as base, mdp
+from ...mdp import door_latch
+from .articulation_base import ArticulationBaseEnvFloatingDexHandRightCfg
+
+DOOR_USD_PATH = DEXVERSE_AUTHORED_ARTICULATIONS_DIR / "cutaway_door/cutaway_door.usd"
+
+
+@configclass
+class OpenCutawayDoorEnvFloatingDexHandRightCfg(ArticulationBaseEnvFloatingDexHandRightCfg):
+    """Single right hand; two passive spring joints and contact-only retention."""
+
+    articulation_usd_path: str = str(DOOR_USD_PATH)
+    articulation_scale: tuple = (1.0, 1.0, 1.0)
+    # Local +X panel maps to world +Y; it opens toward the hand (world -X).
+    articulation_init_pos: tuple = (0.12, -0.17, 0.0)
+    articulation_init_rot: tuple = (math.sqrt(0.5), 0.0, 0.0, math.sqrt(0.5))
+    articulation_init_joint_pos: dict = {"door_hinge": 0.0, "latch_slide": 0.0}
+    articulation_half_height_est: float = 0.003
+    articulation_fix_root_link: bool = True
+    articulation_collision_approximation: str | None = None
+    articulation_contact_offset: float = 0.002
+    articulation_rest_offset: float = 0.0
+    articulation_reset_pose_range: dict = {"x": [-0.015, 0.015], "y": [-0.025, 0.025], "yaw": [-0.10, 0.10]}
+    success_joint_names: list = ["door_hinge"]
+    door_spring_stiffness: float = 0.20
+    door_spring_damping: float = 0.12
+    door_preload_angle: float = -0.20  # ~0.04 Nm toward the closed hard stop even at q=0.
+    latch_spring_stiffness: float = 12.0
+    latch_spring_damping: float = 1.0
+    hold_steps: int = 60
+    episode_length_s_override: float = 30.0
+    rewards = base.RewardsCfg()
+    terminations = base.TerminationsCfg()
+
+    def __post_init__(self):
+        if not Path(self.articulation_usd_path).is_file():
+            raise FileNotFoundError(
+                "New cutaway-door USD is missing. Run from the feature worktree: "
+                "python scripts/run_local.py scripts/asset_tools/convert_cutaway_door.py --headless"
+            )
+        super().__post_init__()
+        self.episode_length_s = self.episode_length_s_override
+        spawn = self.scene.articulation.spawn
+        spawn.articulation_props.enabled_self_collisions = True  # Door/catch contact is essential.
+        spawn.articulation_props.solver_position_iteration_count = 32
+        spawn.articulation_props.solver_velocity_iteration_count = 4
+        # Default stabilization can arrest a weak spring before it reaches its
+        # rest angle. This mechanism must close under small residual torques.
+        spawn.articulation_props.sleep_threshold = 0.0
+        spawn.articulation_props.stabilization_threshold = 0.0
+        spawn.rigid_props.sleep_threshold = 0.0
+        spawn.rigid_props.stabilization_threshold = 0.0
+        spawn.activate_contact_sensors = True
+        spawn.joint_drive_props.drive_type = "force"
+        self.scene.articulation.actuators = {
+            "door_spring": ImplicitActuatorCfg(
+                joint_names_expr=["door_hinge"],
+                stiffness=self.door_spring_stiffness,
+                damping=self.door_spring_damping,
+                effort_limit_sim=3.0,
+                velocity_limit_sim=2.0,
+                friction=0.0,  # Avoid static joint friction defeating the gentle closing spring.
+            ),
+            "catch_spring": ImplicitActuatorCfg(
+                joint_names_expr=["latch_slide"],
+                stiffness=self.latch_spring_stiffness,
+                damping=self.latch_spring_damping,
+                effort_limit_sim=5.0,
+                velocity_limit_sim=0.5,
+                friction=0.0,
+            ),
+        }
+        # GPU contact filters require one explicit rigid-body path per column,
+        # not a wildcard matching the entire hand articulation.
+        from pxr import Usd, UsdPhysics
+
+        robot_stage = Usd.Stage.Open(self.scene.robot.spawn.usd_path)
+        robot_root = robot_stage.GetDefaultPrim().GetPath()
+        robot_filters = [
+            "{ENV_REGEX_NS}/Robot/" + str(prim.GetPath().MakeRelativePath(robot_root))
+            for prim in robot_stage.Traverse()
+            if prim.HasAPI(UsdPhysics.RigidBodyAPI)
+        ]
+        if not robot_filters:
+            raise ValueError("Could not resolve robot rigid bodies for door contact filters")
+        # Replace inherited articulation-root filters with real collider links.
+        for tip in self.robot_config.fingertip_body_names:
+            sensor = getattr(self.scene, f"{tip}_articulation_s", None)
+            if sensor is not None:
+                sensor.filter_prim_paths_expr = ["{ENV_REGEX_NS}/Articulation/door"]
+        for name, body, target in (
+            ("door_hand_contact", "door", "Robot/.*"),
+            ("latch_hand_contact", "latch", "Robot/.*"),
+            ("door_latch_contact", "door", "Articulation/latch"),
+        ):
+            setattr(
+                self.scene,
+                name,
+                ContactSensorCfg(
+                    prim_path=f"{{ENV_REGEX_NS}}/Articulation/{body}",
+                    filter_prim_paths_expr=robot_filters if target == "Robot/.*" else [f"{{ENV_REGEX_NS}}/{target}"],
+                ),
+            )
+        self.events.reset_door_latch = EventTerm(
+            func=door_latch.reset_door_latch,
+            mode="reset",
+            params={"buffer_name": door_latch.BUFFER, "door_preload_angle": self.door_preload_angle},
+        )
+        self.terminations.success = DoneTerm(
+            func=door_latch.door_latched_and_released,
+            params={"hold_steps": self.hold_steps},
+        )
+        self.terminations.door_reclosed = DoneTerm(
+            func=door_latch.door_reclosed,
+            params={"hold_steps": self.hold_steps},
+        )
+        self.rewards.open_angle = RewTerm(
+            func=mdp.joint_open_fraction_reward,
+            weight=1.0,
+            params={
+                "close_angle_rad": 0.0,
+                "open_angle_rad": math.pi / 2,
+                "asset_cfg": SceneEntityCfg("articulation", joint_names=["door_hinge"]),
+            },
+        )
+        if self.observations.state is not None:
+            self.observations.state.articulation_joint_pos.params["asset_cfg"] = SceneEntityCfg(
+                "articulation", joint_names=["door_hinge", "latch_slide"]
+            )
+            self.observations.state.door_latch_signals = ObsTerm(
+                func=door_latch.door_latch_signals, params={"hold_steps": self.hold_steps}
+            )
+        if self.observations.privileged is not None:
+            self.observations.privileged.articulation_joint_vel.params["asset_cfg"] = SceneEntityCfg(
+                "articulation", joint_names=["door_hinge", "latch_slide"]
+            )

--- a/source/dexverse/dexverse/baseline_v1/config/articulation/open_flat_folder_cfg.py
+++ b/source/dexverse/dexverse/baseline_v1/config/articulation/open_flat_folder_cfg.py
@@ -1,0 +1,64 @@
+# Copyright (c) 2025-2026, The DexVerse Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Fixate-then-manipulate: open a flat folder / file (synthesis/flat folder002)."""
+
+
+from dexverse.assets import SYNTHESIS_DIR
+from isaaclab.managers import SceneEntityCfg
+from isaaclab.utils import configclass
+
+from ... import mdp
+from .base_cfg import FixateArticulationEnvFloatingDexHandRightCfg
+
+FLAT_FOLDER_USD_PATH = str(SYNTHESIS_DIR / "flat folder002" / "model_file_9.usd")
+
+
+@configclass
+class OpenFlatFolderEnvFloatingDexHandRightCfg(FixateArticulationEnvFloatingDexHandRightCfg):
+    """Lift the folder envelope off the body along its single hinge.
+
+    Elements: ``E_body_1`` (body / bottom flap), ``E_envelope_2`` (top
+    flap). The envelope is typically very thin and light, so the manipulator
+    hand tends to drag the whole folder across the table unless the other
+    hand pins ``E_body_1`` down — a clear bimanual fixate-then-manipulate
+    win.
+    """
+
+    robot_type: str = "floating_shadow_bimanual"
+    articulation_usd_path: str = FLAT_FOLDER_USD_PATH
+    articulation_scale: tuple = (1.2, 1.2, 1.2)
+    articulation_init_pos: tuple = (0.0, 0.0, 0.0)
+    articulation_init_rot: tuple = (1.0, 0.0, 0.0, 0.0)
+    # Folders lie almost flat on the table.
+    articulation_half_height_est: float = 0.003  # reset audit (Aug 2026): seated ~3 mm above rest instead of dropping (was 0.005)
+    # Reset audit (Aug 2026): x was pinned, giving a 1-D spawn line. Randomize
+    # both table axes; the band stays in front of the bimanual palms (x=-0.25).
+    articulation_reset_pose_range: dict[str, list[float]] = {
+        "x": [-0.15, 0.15],
+        "y": [-0.2, 0.2],
+        "z": [0.0, 0.0],
+        "roll": [0.0, 0.0],
+        "pitch": [0.0, 0.0],
+        # Reset audit (Aug 2026): uniform yaw -- the object can face any way,
+        # like the functional tasks; the two floating hands can approach from
+        # any side.
+        "yaw": [-3.14159, 3.14159],
+    }
+
+    success_joint_names: list[str] = ["RevoluteJoint_file_9_up"]
+    success_threshold: float = 0.6
+
+    def __post_init__(self):
+        super().__post_init__()
+        self.terminations.success.func = mdp.joint_relative_move
+        # ~180 deg of opening over a 190 deg hinge range.
+        self.terminations.success.params = {
+            "threshold": self.success_threshold,
+            "asset_cfg": SceneEntityCfg("articulation", joint_names=self.success_joint_names),
+            "mode": "progress",
+            "op": ">=",
+            "reduce": "any",
+        }

--- a/source/dexverse/dexverse/baseline_v1/config/articulation/open_laptop_cfg.py
+++ b/source/dexverse/dexverse/baseline_v1/config/articulation/open_laptop_cfg.py
@@ -1,0 +1,182 @@
+# Copyright (c) 2025-2026, The DexVerse Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Open a free laptop while keeping its base at its sampled reset pose.
+
+The laptop is a *free* two-link articulation: a base body (``E_body_1``)
+sitting loose on the table and a lid (``E_displayer_5``) joined to it by a
+single revolute hinge (``RevoluteJoint_computer_9_up``). Nothing is bolted to
+the world, so pushing the laptop slides it and lifting the lid while the base
+is unpinned tips the whole laptop. The laptop spawns near the table centre with
+full-circle yaw variation. The task is simply to open the lid while another
+hand stabilizes the base: excessive planar translation or even a small upward
+movement of the base immediately fails the episode.
+
+Hinge convention (from the USD): the joint range is ``[-110 deg, 0 deg]`` where
+``0 deg`` is fully *closed* (lid flat on the base) and negative angles *open*
+the lid (toward ``-110 deg``). The lid starts ajar at a negative angle.
+
+Hinge model -- *friction detent* (the mechanism validated in the debug env).
+The lid is held by an implicit actuator at **zero stiffness** (no position
+servo, so it never springs back to a setpoint) plus PhysX Coulomb **joint
+friction** -- a static, load-proportional holding torque that resists gravity
+at whatever angle the lid sits. The lid therefore stays wherever it is left,
+and the robot must overcome the static friction to pry it open; a little
+``damping`` keeps it from whipping. (An earlier position-drive "hold at the
+current angle" scheme could not statically balance gravity and let the lid
+creep shut.)
+"""
+
+import math
+
+import isaaclab.sim as sim_utils
+from dexverse.assets import SYNTHESIS_DIR
+from isaaclab.actuators import ImplicitActuatorCfg
+from isaaclab.managers import EventTermCfg as EventTerm
+from isaaclab.managers import SceneEntityCfg
+from isaaclab.managers import TerminationTermCfg as DoneTerm
+from isaaclab.utils import configclass
+
+from ... import mdp
+from .base_cfg import FixateArticulationEnvFloatingDexHandRightCfg
+
+LAPTOP_USD_PATH = str(SYNTHESIS_DIR / "laptop001" / "model_computer_9.usd")
+
+# Root-frame yaw that puts the hinge away from the hands (screen facing the
+# operator): clockwise 90 deg around +z.
+OPERATOR_FACING_ROT = (math.sqrt(0.5), 0.0, 0.0, -math.sqrt(0.5))
+
+
+@configclass
+class OpenLaptopEnvFloatingDexHandRightCfg(FixateArticulationEnvFloatingDexHandRightCfg):
+    """Open the laptop while preventing its base from being moved or lifted."""
+
+    robot_type: str = "floating_shadow_bimanual"
+    articulation_usd_path: str = LAPTOP_USD_PATH
+    articulation_scale: tuple = (1.0, 1.0, 1.0)
+    articulation_init_pos: tuple = (0.0, 0.0, 0.0)
+    articulation_init_rot: tuple = OPERATOR_FACING_ROT
+    # The implicit hinge actuator (set in __post_init__) owns the drive; keep
+    # the base implicit joint damping off so it doesn't double up.
+    articulation_joint_damping: float = 0.0
+    # Lid starts moderately ajar. Negative = open (range [-110 deg, 0 deg],
+    # 0 deg == closed). -45 deg is the angle the friction detent was tuned at;
+    # this 25-degree start gives teleoperation a larger initial finger opening.
+    articulation_init_joint_pos: dict[str, float] = {
+        "RevoluteJoint_computer_9_up": math.radians(-25.0),
+    }
+    # The asset's origin is at the *bottom* of the closed laptop, so only a
+    # hair of clearance is needed to seat it flush on the table.
+    articulation_half_height_est: float = 0.005
+    # Spawn band near the table centre (root offsets from articulation_init_pos)
+    # with any heading. Displacement limits are relative to this sampled pose.
+    articulation_reset_pose_range: dict[str, list[float]] = {
+        "x": [-0.12, 0.02],
+        "y": [-0.10, 0.10],
+        "z": [0.0, 0.0],
+        "roll": [0.0, 0.0],
+        "pitch": [0.0, 0.0],
+        "yaw": [-math.pi, math.pi],
+    }
+
+    # Base displacement is measured from each episode's randomized reset pose.
+    # Upward height is one-sided so minor downward settling does not fail.
+    max_base_xy_displacement: float = 0.03
+    max_base_upward_displacement: float = 0.005
+
+    # Original standalone-laptop contact friction.
+    articulation_static_friction_range: tuple[float, float] = (0.4, 0.4)
+    articulation_dynamic_friction_range: tuple[float, float] = (0.3, 0.3)
+
+    # Friction-detent hinge (validated in debug_laptop_cfg).
+    #
+    # stiffness = 0  -> no position servo, so the lid never springs back to a
+    #                   setpoint; it stays wherever it currently is.
+    # friction       -> PhysX Coulomb joint friction: a static, load-
+    #                   proportional holding torque that resists gravity at any
+    #                   angle. Raise it if the lid droops untouched (e.g. when
+    #                   started nearer closed); lower it if the robot can't pry
+    #                   the lid open.
+    # damping        -> a little viscous resistance so the lid doesn't whip.
+    # ``hinge_dynamic_friction`` only takes effect on Isaac Sim >= 5.0.
+    articulation_hinge_stiffness: float = 0.0
+    articulation_hinge_damping: float = 1.0
+    articulation_hinge_static_friction: float = 1.0
+    articulation_hinge_dynamic_friction: float = 1.0
+
+    success_joint_names: list[str] = ["RevoluteJoint_computer_9_up"]
+    success_threshold: float = 0.70
+
+    # Dense reach shaping pulls the fingertips toward the lid link rather
+    # than the whole-laptop mean (which sits inside the base body).
+    dense_reach_body_names: list[str] = ["E_displayer_5"]
+
+    def __post_init__(self):
+        super().__post_init__()
+
+        # Free, movable rigid laptop. ``fix_root_link`` is already False
+        # (inherited) and the hinge connects two real bodies, so the base body
+        # floats: pushing slides it, lifting the lid tips it. Gravity on.
+        self.scene.articulation.spawn.rigid_props.disable_gravity = False
+        self.scene.articulation.spawn.mass_props = sim_utils.MassPropertiesCfg(mass=0.4)
+
+        # Re-enable a (deterministic) contact physics material so the friction
+        # ranges above take effect on table / hand contacts (the base nulls
+        # articulation friction randomization). This is *contact* friction --
+        # separate from the *joint* friction detent below.
+        self.events.articulation_physics_material = EventTerm(
+            func=mdp.randomize_rigid_body_material,
+            mode="startup",
+            params={
+                "asset_cfg": SceneEntityCfg("articulation"),
+                "static_friction_range": self.articulation_static_friction_range,
+                "dynamic_friction_range": self.articulation_dynamic_friction_range,
+                "restitution_range": (0.0, 0.0),
+                "num_buckets": 1,
+            },
+        )
+
+        # Friction-detent hinge: implicit actuator at zero stiffness + Coulomb
+        # joint friction. Implicit (not IdealPDActuator) so the friction goes
+        # straight into the PhysX joint and the holding torque is actually
+        # applied -- an explicit actuator's effort is clipped to the USD joint's
+        # authored maxForce (~0 here), which is why a position drive let the lid
+        # fall. With stiffness 0 there is no setpoint, so the lid holds wherever
+        # it is left and never springs back.
+        self.scene.articulation.actuators = {
+            "laptop_hinge": ImplicitActuatorCfg(
+                joint_names_expr=self.success_joint_names,
+                effort_limit_sim=100.0,
+                velocity_limit_sim=100.0,
+                stiffness=self.articulation_hinge_stiffness,
+                damping=self.articulation_hinge_damping,
+                friction=self.articulation_hinge_static_friction,
+                dynamic_friction=self.articulation_hinge_dynamic_friction,
+            ),
+        }
+        # The lid starts ajar via the base ``reset_articulation_joints``
+        # (``reset_joints_to_init`` seats the hinge at its init angle). With
+        # stiffness 0 the drive target is irrelevant, so no target-writing
+        # reset/startup events are needed -- the joint friction holds the lid
+        # wherever it is left.
+
+        # Opening is the only success condition. Moving or lifting the base
+        # beyond the small allowance fails immediately.
+        self.terminations.success.func = mdp.joint_relative_move
+        self.terminations.success.params = {
+            "threshold": self.success_threshold,
+            "asset_cfg": SceneEntityCfg("articulation", joint_names=self.success_joint_names),
+            "mode": "progress",
+            "op": ">=",
+            "reduce": "any",
+        }
+        self.terminations.base_displaced = DoneTerm(
+            func=mdp.root_pose_displacement_exceeds,
+            params={
+                "asset_cfg": SceneEntityCfg("articulation"),
+                "max_xy_displacement": self.max_base_xy_displacement,
+                "max_upward_z": self.max_base_upward_displacement,
+            },
+        )

--- a/source/dexverse/dexverse/baseline_v1/config/articulation/open_stapler_cfg.py
+++ b/source/dexverse/dexverse/baseline_v1/config/articulation/open_stapler_cfg.py
@@ -1,0 +1,95 @@
+# Copyright (c) 2025-2026, The DexVerse Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Fixate-then-manipulate: press a stapler head (synthesis/green stapler)."""
+
+import math
+
+from isaaclab.actuators import ImplicitActuatorCfg
+
+from dexverse.assets import SYNTHESIS_DIR
+from isaaclab.managers import EventTermCfg as EventTerm
+from isaaclab.managers import SceneEntityCfg
+from isaaclab.utils import configclass
+
+from ... import mdp
+from .base_cfg import FixateArticulationEnvFloatingDexHandRightCfg
+
+STAPLER_USD_PATH = str(SYNTHESIS_DIR / "green stapler" / "model_stapler_1.usd")
+
+
+@configclass
+class OpenStaplerEnvFloatingDexHandRightCfg(FixateArticulationEnvFloatingDexHandRightCfg):
+    """Open the stapler head up onto the body while the base is free.
+
+    Elements: ``E_shell_1`` (top shell), ``E_body_2`` (body / anvil),
+    ``E_stapler_needle_3`` (inner plunger). The main rotary hinge between
+    shell and body is what we ask the policy to actuate. A typical solution
+    pins the body on the table while the palm / fingers press the shell
+    downwards.
+    """
+
+    robot_type: str = "floating_shadow_bimanual"
+    articulation_usd_path: str = STAPLER_USD_PATH
+    articulation_scale: tuple = (1.0, 1.0, 1.0)
+    articulation_init_pos: tuple = (0.0, 0.0, 0.0)
+    # Rotate +90 deg about z (counterclockwise when viewed from +z to -z).
+    articulation_init_rot: tuple = (math.sqrt(0.5), 0.0, 0.0, math.sqrt(0.5))
+    # Staplers sit on a flat base; a small half-height keeps the anvil on
+    # the table.
+    articulation_half_height_est: float = 0.003  # reset audit (Aug 2026): seated ~3 mm above rest instead of dropping (was 0.03)
+    # Reset audit (Aug 2026): x was pinned, giving a 1-D spawn line. Randomize
+    # both table axes; the band stays in front of the bimanual palms (x=-0.25).
+    articulation_reset_pose_range: dict[str, list[float]] = {
+        "x": [-0.15, 0.15],
+        "y": [-0.2, 0.2],
+        "z": [0.0, 0.0],
+        "roll": [0.0, 0.0],
+        "pitch": [0.0, 0.0],
+        # Reset audit (Aug 2026): uniform yaw -- the object can face any way,
+        # like the functional tasks; the two floating hands can approach from
+        # any side.
+        "yaw": [-3.14159, 3.14159],
+    }
+
+    success_joint_names: list[str] = ["RevoluteJoint_stapler_1_up"]
+    success_threshold: float = 0.2
+
+    # Spring-loaded shell hinge (reset audit, Aug 2026: the hinge used to be a free
+    # joint that stayed wherever it was put -- too simple). An implicit position
+    # drive with the setpoint at the rest angle acts like the stapler's spring:
+    # lifting the shell works against ``stiffness`` (N*m/rad) and it snaps back
+    # when released. 1.0 N*m/rad ~= 0.56 N*m at the 32-degree success angle
+    # (~7 N at the shell tip). Set stiffness to 0.0 to recover the free hinge.
+    articulation_hinge_stiffness: float = 1.0
+    articulation_hinge_damping: float = 0.05
+
+    def __post_init__(self):
+        super().__post_init__()
+        if self.articulation_hinge_stiffness > 0.0 or self.articulation_hinge_damping > 0.0:
+            self.scene.articulation.actuators = {
+                "stapler_hinge": ImplicitActuatorCfg(
+                    joint_names_expr=self.success_joint_names,
+                    effort_limit_sim=100.0,
+                    velocity_limit_sim=100.0,
+                    stiffness=self.articulation_hinge_stiffness,
+                    damping=self.articulation_hinge_damping,
+                ),
+            }
+            # keep the drive setpoint at the rest angle every episode
+            self.events.reset_stapler_hinge_target = EventTerm(
+                func=mdp.set_joint_position_target_to_init,
+                mode="reset",
+                params={"asset_cfg": SceneEntityCfg("articulation", joint_names=self.success_joint_names)},
+            )
+        self.terminations.success.func = mdp.joint_relative_move
+        # Deep press: 80% of the shell hinge travel.
+        self.terminations.success.params = {
+            "threshold": self.success_threshold,
+            "asset_cfg": SceneEntityCfg("articulation", joint_names=self.success_joint_names),
+            "mode": "progress",
+            "op": ">=",
+            "reduce": "any",
+        }

--- a/source/dexverse/dexverse/baseline_v1/config/articulation/open_tilted_door_cfg.py
+++ b/source/dexverse/dexverse/baseline_v1/config/articulation/open_tilted_door_cfg.py
@@ -1,0 +1,172 @@
+# Copyright (c) 2025-2026, The DexVerse Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Open-tilted-door task: the door frame lies tilted instead of standing.
+
+Extends :class:`OpenDoorEnvFloatingDexHandRightCfg` (which stays registered):
+each episode draws ONE of two rest modes for the whole frame + leaf assembly —
+**slanted** like a basement bulkhead door (45 deg from vertical) or **flat**
+like a ground/cellar hatch (90 deg, door plane horizontal) — via
+``mdp.reset_root_pose_uniform_orientations`` (the drawn index is recorded in
+``env.door_tilt_choice``). The success criterion is inherited unchanged: hinge
+the leaf past the parent's open ratio; in the tilted modes that means lifting
+the leaf up against gravity.
+
+Padding: the frame is lifted a per-mode clearance above the tabletop so the
+**backside of the latch mechanism never touches the ground** when the leaf
+lies in the frame plane. Four cosmetic corner posts (kinematic, collision
+disabled, always world-vertical) are re-seated under the frame corners every
+reset so the lifted frame reads as a supported structure; their excess length
+sinks invisibly into the table.
+"""
+
+from __future__ import annotations
+
+import math
+
+import isaaclab.sim as sim_utils
+from isaaclab.assets import RigidObjectCfg
+from isaaclab.managers import EventTermCfg as EventTerm
+from isaaclab.managers import SceneEntityCfg
+from isaaclab.utils import configclass
+from scipy.spatial.transform import Rotation as R
+
+from ... import dexverse_base_env_cfg as dexverse_base_env
+from ... import mdp
+from .opendoor_cfg import DOOR_ROT, OpenDoorEnvFloatingDexHandRightCfg
+
+
+def _tilted_door_rot(tilt_deg: float) -> tuple[float, float, float, float]:
+    """Standing door rot composed with a world-frame pitch of ``tilt_deg``.
+
+    Positive pitch about world +y tips the top of the door away from the robot
+    (toward +x), so the handle face ends up facing upward along the slant.
+    scipy quats are xyzw; Isaac's are wxyz.
+    """
+    standing = R.from_quat((*DOOR_ROT[1:], DOOR_ROT[0]))
+    qx, qy, qz, qw = (R.from_euler("y", math.radians(tilt_deg)) * standing).as_quat()
+    return (float(qw), float(qx), float(qy), float(qz))
+
+
+def _build_pad_post_cfg(
+    index: int,
+    *,
+    size: tuple[float, float, float],
+    color: tuple[float, float, float],
+) -> RigidObjectCfg:
+    """Cosmetic vertical post under one frame corner (faucet-pedestal style).
+
+    Kinematic, gravity-free, collision disabled — it never touches the hand or
+    the door; it only fills the visible gap between the tabletop and the
+    lifted/tilted frame. A rigid object (not a bare visual prim) so the
+    per-corner ``sync_object`` reset event can re-seat it each episode.
+    """
+    return RigidObjectCfg(
+        prim_path="{ENV_REGEX_NS}/DoorPadPost" + str(index),
+        spawn=sim_utils.CuboidCfg(
+            size=size,
+            visual_material=sim_utils.PreviewSurfaceCfg(diffuse_color=color),
+            rigid_props=sim_utils.RigidBodyPropertiesCfg(
+                rigid_body_enabled=True,
+                kinematic_enabled=True,
+                disable_gravity=True,
+            ),
+            collision_props=sim_utils.CollisionPropertiesCfg(collision_enabled=False),
+            mass_props=sim_utils.MassPropertiesCfg(mass=1.0),
+        ),
+        init_state=RigidObjectCfg.InitialStateCfg(pos=(0.0, 0.0, -1.0), rot=(1.0, 0.0, 0.0, 0.0)),
+    )
+
+
+@configclass
+class OpenTiltedDoorEnvFloatingDexHandRightCfg(OpenDoorEnvFloatingDexHandRightCfg):
+    """Open-door on a slanted (basement) or flat (ground-hatch) frame."""
+
+    # The tilted door plane extends from the root toward +x, so pull the base
+    # back toward the robot to keep the handle over the hand's workspace
+    # (standing parent uses x = 0.3). TODO: tune after previewing.
+    articulation_init_pos: tuple[float, float, float] = (-0.35, 0.0, 0.0)
+
+    # ---- Tilt modes -------------------------------------------------------
+    # (tilt from vertical in deg, frame lift above the tabletop in m). The
+    # lift is the "padding": clearance so the latch backside on the underside
+    # of the leaf plane never touches the ground. Measured from the USD: the
+    # latch protrudes 0.03 m behind the leaf plane (0.045 m at the 1.5 asset
+    # scale), so the flat mode's 0.08 m lift leaves ~3.5 cm of clearance;
+    # slanted only needs a small seat (the latch is high up the slant).
+    tilt_slanted_deg: float = 45.0
+    tilt_flat_deg: float = 90.0
+    slanted_lift: float = 0.05
+    flat_lift: float = 0.08
+    # Categorical weights (slanted, flat) for the per-episode draw.
+    tilt_weights: tuple[float, float] = (0.5, 0.5)
+
+    # ---- Cosmetic corner posts -------------------------------------------
+    # Frame-corner points in the door asset's LOCAL (USD) frame, PRE-scaled by
+    # the 1.5 asset scale (``sync_object`` rotates offsets but does not apply
+    # the spawn mesh scale). From the USD bbox: frame x in [-0.125, 0.125],
+    # z in [0.114, 0.335] (the frame plane is local x-z; local +y is the
+    # handle-side normal). The posts' tops are synced to these points each
+    # reset; excess post length sinks invisibly into the table.
+    pad_corner_offsets_local: tuple[tuple[float, float, float], ...] = (
+        (-0.1875, 0.0, 0.171),
+        (0.1875, 0.0, 0.171),
+        (-0.1875, 0.0, 0.5025),
+        (0.1875, 0.0, 0.5025),
+    )
+    pad_post_size: tuple[float, float, float] = (0.06, 0.06, 0.5)
+    pad_post_color: tuple[float, float, float] = (0.55, 0.5, 0.45)
+
+    def __post_init__(self):
+        super().__post_init__()
+
+        # Replace the parent's plain pose reset with the categorical
+        # rest-orientation reset: same x/y jitter, per-mode quat + lift, and
+        # the drawn mode index recorded in ``env.door_tilt_choice`` (part of
+        # the recorded scene state for demos).
+        pose_range = self.articulation_reset_pose_range or {}
+        self.events.reset_articulation.func = mdp.reset_root_pose_uniform_orientations
+        self.events.reset_articulation.params = {
+            "asset_cfg": SceneEntityCfg("articulation"),
+            "pose_range": {
+                "x": tuple(pose_range.get("x", (0.0, 0.0))),
+                "y": tuple(pose_range.get("y", (0.0, 0.0))),
+                "yaw": tuple(pose_range.get("yaw", (0.0, 0.0))),
+            },
+            "orientations": [
+                (_tilted_door_rot(self.tilt_slanted_deg), self.slanted_lift),
+                (_tilted_door_rot(self.tilt_flat_deg), self.flat_lift),
+            ],
+            "table_top_z": dexverse_base_env.DEFAULT_TABLE_TOP_HEIGHT,
+            "weights": list(self.tilt_weights),
+            "buffer_name": "door_tilt_choice",
+        }
+
+        # Corner posts: top face at the frame corner, world-vertical at any
+        # tilt (``quat`` pins the world orientation; only the corner point
+        # follows the door's frame). Added after super().__post_init__() so
+        # they fire after ``reset_articulation`` reads the drawn tilt.
+        post_h = float(self.pad_post_size[2])
+        for i, corner in enumerate(self.pad_corner_offsets_local):
+            setattr(
+                self.scene,
+                f"door_pad_post_{i}",
+                _build_pad_post_cfg(i, size=self.pad_post_size, color=self.pad_post_color),
+            )
+            setattr(
+                self.events,
+                f"reset_door_pad_{i}",
+                EventTerm(
+                    func=mdp.sync_object,
+                    mode="reset",
+                    params={
+                        "target_cfg": SceneEntityCfg(f"door_pad_post_{i}"),
+                        "source_cfg": SceneEntityCfg("articulation"),
+                        "source_local_offset": tuple(corner),
+                        "z_offset": -post_h / 2.0,
+                        "quat": (1.0, 0.0, 0.0, 0.0),
+                    },
+                ),
+            )

--- a/source/dexverse/dexverse/baseline_v1/config/articulation/opendoor_cfg.py
+++ b/source/dexverse/dexverse/baseline_v1/config/articulation/opendoor_cfg.py
@@ -1,0 +1,133 @@
+# Copyright (c) 2025-2026, The DexVerse Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Open-door task: hinge a door past a fraction of its open range.
+
+Inherits :class:`ArticulationBaseEnvFloatingDexHandRightCfg`; only the
+reward (``joint_open_fraction_reward``) and termination
+(``joint_relative_move`` with ``mode="ratio"``) are task-specific.
+"""
+
+from __future__ import annotations
+
+from dexverse.assets import DEXVERSE_AUTHORED_ARTICULATIONS_DIR
+from isaaclab.actuators.actuator_cfg import ImplicitActuatorCfg
+from isaaclab.managers import RewardTermCfg as RewTerm
+from isaaclab.managers import SceneEntityCfg
+from isaaclab.managers import TerminationTermCfg as DoneTerm
+from isaaclab.utils import configclass
+
+from ... import dexverse_base_env_cfg as dexverse_base_env
+from ... import mdp
+from .articulation_base import ArticulationBaseEnvFloatingDexHandRightCfg
+from .articulation_base.articulation_base_cfg import ARTICULATION_KEY
+
+# The door articulation lives in dexverse_authored (it has been there since
+# the initial commit); the old partnet_mobility/door dir holds raw source
+# assets without a combined door.usd.
+ASSET_DIR = DEXVERSE_AUTHORED_ARTICULATIONS_DIR / "door"
+DOOR_USD_PATH = str(ASSET_DIR / "door.usd")
+DOOR_SCALE = (1.5, 1.5, 1.5)
+DOOR_ROT = (0.7071067811865476, 0.0, 0.0, 0.7071067811865476)
+OPEN_ANGLE_RAD = 1.4
+CLOSE_ANGLE_RAD = 0.0
+INIT_ANGLE_RAD = CLOSE_ANGLE_RAD
+DOOR_JOINT_NAME = "door_hinge"
+HANDLE_JOINT_NAME = "handle_hinge"
+
+SUCCESS_OPEN_RATIO = 0.8
+
+
+@configclass
+class OpenDoorRewardsCfg(dexverse_base_env.RewardsCfg):
+    """Reward proportional to fraction of door opening (close → open)."""
+
+    open_angle = RewTerm(
+        func=mdp.joint_open_fraction_reward,
+        weight=5.0,
+        params={
+            "close_angle_rad": CLOSE_ANGLE_RAD,
+            "open_angle_rad": OPEN_ANGLE_RAD,
+            "asset_cfg": SceneEntityCfg(ARTICULATION_KEY, joint_names=[DOOR_JOINT_NAME]),
+        },
+    )
+
+
+@configclass
+class OpenDoorTerminationsCfg(dexverse_base_env.TerminationsCfg):
+    """Success when door rotated past ``SUCCESS_OPEN_RATIO`` of its range."""
+
+    success = DoneTerm(
+        func=mdp.joint_relative_move,
+        params={
+            "threshold": SUCCESS_OPEN_RATIO,
+            "mode": "ratio",
+            "asset_cfg": SceneEntityCfg(ARTICULATION_KEY, joint_names=[DOOR_JOINT_NAME]),
+        },
+    )
+
+
+@configclass
+class OpenDoorEnvFloatingDexHandRightCfg(ArticulationBaseEnvFloatingDexHandRightCfg):
+    """Open-door env (floating dex-hand variant)."""
+
+    articulation_usd_path: str = DOOR_USD_PATH
+    articulation_scale: tuple[float, float, float] = DOOR_SCALE
+    articulation_init_pos: tuple[float, float, float] = (0.3, 0.0, 0.0)
+    articulation_init_rot: tuple[float, float, float, float] = DOOR_ROT
+    articulation_half_height_est: float = 0.0
+    articulation_fix_root_link: bool | None = True
+    articulation_hinge_stiffness: float = 0.0
+    articulation_hinge_damping: float = 1.0
+    articulation_handle_damping: float = 0.2
+    articulation_handle_friction: float = 0.05
+
+    success_joint_names: list[str] = [DOOR_JOINT_NAME]
+    # success_threshold left at None (the base default): opendoor's
+    # termination is a ratio-mode ``joint_relative_move`` and its reward is
+    # ``joint_open_fraction_reward``, neither of which use the base's
+    # absolute-radian threshold.
+
+    rewards: OpenDoorRewardsCfg = OpenDoorRewardsCfg()
+    terminations: OpenDoorTerminationsCfg = OpenDoorTerminationsCfg()
+
+    def __post_init__(self):
+        # Start fully closed and latched. Set BEFORE super so it's wired
+        # into the articulation.
+        self.articulation_init_joint_pos = {
+            DOOR_JOINT_NAME: INIT_ANGLE_RAD,
+            HANDLE_JOINT_NAME: 0.0,
+        }
+        self.articulation_reset_pose_range = {
+            "x": [0.0, 0.0],
+            "y": [-0.1, 0.1],
+            "z": [0.0, 0.0],
+            "roll": [0.0, 0.0],
+            "pitch": [0.0, 0.0],
+            "yaw": [0.0, 0.0],
+        }
+        super().__post_init__()
+        self.scene.articulation.actuators = {
+            "door_hinge": ImplicitActuatorCfg(
+                joint_names_expr=[DOOR_JOINT_NAME],
+                effort_limit_sim=100.0,
+                velocity_limit_sim=100.0,
+                stiffness=self.articulation_hinge_stiffness,
+                damping=self.articulation_hinge_damping,
+            ),
+            "handle_hinge": ImplicitActuatorCfg(
+                joint_names_expr=[HANDLE_JOINT_NAME],
+                effort_limit_sim=100.0,
+                velocity_limit_sim=100.0,
+                stiffness=0.0,
+                damping=self.articulation_handle_damping,
+                friction=self.articulation_handle_friction,
+            ),
+        }
+
+
+# Backward-compat alias. ``multigraspenvs.opendoor_rigid_variants_cfg`` (to be
+# refactored next) and the gym registration imported the old class name.
+OpenDoorEnvCfg = OpenDoorEnvFloatingDexHandRightCfg

--- a/source/dexverse/dexverse/baseline_v1/config/articulation/openfaucet_cfg.py
+++ b/source/dexverse/dexverse/baseline_v1/config/articulation/openfaucet_cfg.py
@@ -1,0 +1,279 @@
+# Copyright (c) 2025-2026, The DexVerse Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Open-faucet task: turn a fixed faucet handle past a target angle.
+
+A static sink basin is parented in front of and below the faucet (re-synced to
+the faucet's pose every reset) so the scene reads like a real sink. The whole
+faucet + sink + pedestal assembly spawns at a random position on the table
+**and a uniform random yaw**, so the handle can face any direction and the
+hand may have to reach around it. The faucet joint is passive — zero drive
+stiffness (no spring-back) plus elevated joint friction and a small armature,
+so the handle holds whatever angle it is turned to, like a real valve.
+The assembly stays near the initial wrist: root X is 0.10–0.20 m and Y is
+±0.10 m. Its full yaw-swept footprint remains inside the main tabletop.
+"""
+
+import math
+
+import isaaclab.sim as sim_utils
+from dexverse.assets import SYNTHESIS_DIR
+from isaaclab.actuators import ImplicitActuatorCfg
+from isaaclab.assets import RigidObjectCfg
+from isaaclab.managers import EventTermCfg as EventTerm
+from isaaclab.managers import SceneEntityCfg
+from isaaclab.utils import configclass
+from scipy.spatial.transform import Rotation as R
+
+from ... import dexverse_base_env_cfg as dexverse_base_env
+from ... import mdp
+from .articulation_base import ArticulationBaseEnvFloatingDexHandRightCfg
+from .rewards import DenseArticulationRewardsCfg
+
+FAUCET_USD_PATH = str(SYNTHESIS_DIR / "faucet001" / "model_faucet_3.usd")
+SINK_USD_PATH = str(SYNTHESIS_DIR / "sink" / "sink.usd")
+
+
+def _build_sink_cfg(
+    *,
+    scale: tuple[float, float, float],
+    init_rot: tuple[float, float, float, float],
+    init_pos: tuple[float, float, float],
+) -> RigidObjectCfg:
+    """Static (kinematic) sink-basin prop.
+
+    The sink is a plain converted mesh (no joints), so it spawns as a kinematic
+    rigid object anchored in place; the ``reset_sink`` event re-syncs it under
+    the faucet each reset. The asset's authored convex-decomposition colliders
+    are kept (``collision_props=None``) so the basin is solid.
+    """
+    return RigidObjectCfg(
+        prim_path="{ENV_REGEX_NS}/Sink",
+        spawn=sim_utils.UsdFileCfg(
+            func=dexverse_base_env.spawn_usd_with_rigid_properties,
+            usd_path=SINK_USD_PATH,
+            scale=scale,
+            rigid_props=sim_utils.RigidBodyPropertiesCfg(
+                rigid_body_enabled=True,
+                kinematic_enabled=True,
+                disable_gravity=True,
+                solver_position_iteration_count=16,
+                solver_velocity_iteration_count=0,
+            ),
+            collision_props=None,
+            mass_props=sim_utils.MassPropertiesCfg(mass=1.0),
+        ),
+        init_state=RigidObjectCfg.InitialStateCfg(pos=init_pos, rot=init_rot),
+    )
+
+
+def _build_support_cfg(
+    *,
+    size: tuple[float, float, float],
+    color: tuple[float, float, float],
+    init_pos: tuple[float, float, float],
+) -> RigidObjectCfg:
+    """Purely cosmetic pedestal under the (elevated) faucet.
+
+    A plain primitive cuboid (no USD): a kinematic, gravity-free rigid body
+    with **collision disabled**, so it never touches the hand, faucet, or sink
+    — it only fills the visible gap between the tabletop and the lifted faucet
+    base. It is still a rigid object (not a bare visual prim) so the
+    ``reset_support`` event can re-seat it under the faucet each reset via
+    ``mdp.sync_object``. The box spawns axis-aligned; the sync then rotates it
+    with the faucet's randomized yaw so the rectangular footprint stays
+    aligned with the assembly.
+    """
+    return RigidObjectCfg(
+        prim_path="{ENV_REGEX_NS}/FaucetSupport",
+        spawn=sim_utils.CuboidCfg(
+            size=size,
+            visual_material=sim_utils.PreviewSurfaceCfg(diffuse_color=color),
+            rigid_props=sim_utils.RigidBodyPropertiesCfg(
+                rigid_body_enabled=True,
+                kinematic_enabled=True,
+                disable_gravity=True,
+            ),
+            collision_props=sim_utils.CollisionPropertiesCfg(collision_enabled=False),
+            mass_props=sim_utils.MassPropertiesCfg(mass=1.0),
+        ),
+        init_state=RigidObjectCfg.InitialStateCfg(pos=init_pos, rot=(1.0, 0.0, 0.0, 0.0)),
+    )
+
+
+@configclass
+class OpenFaucetEnvFloatingDexHandRightCfg(ArticulationBaseEnvFloatingDexHandRightCfg):
+    """Faucet anchored on the tabletop; success = handle joint reaches target angle."""
+
+    articulation_usd_path: str = FAUCET_USD_PATH
+    # Slightly larger than the original 0.6 so the handle is easier to grasp.
+    articulation_scale: tuple = (0.75, 0.75, 0.75)
+    articulation_init_pos: tuple = (0.15, 0.0, 0.0)
+    # -90 degrees about +z: (cos(45 deg), 0, 0, -sin(45 deg)).
+    articulation_init_rot: tuple = (math.sqrt(0.5), 0.0, 0.0, -math.sqrt(0.5))
+    # Elevate the faucet off the tabletop so it stands above the sink basin.
+    # The base seats the articulation at ``table_top_z + this offset`` (was 0.0,
+    # i.e. the base sat flush on the table). Tune so the spout clears the rim.
+    articulation_half_height_est: float = 0.1
+    articulation_fix_root_link: bool | None = True
+
+    # Faucet reset pose randomization (offsets from its init pose). The
+    # sink/support are re-synced to the faucet each reset (``quat_local``, so
+    # they rotate rigidly with it) — this sets how the whole scene jitters.
+    # Uniform yaw: the faucet assembly can face any direction on the table,
+    # so the hand may have to reach around to the handle.
+    # Keep the root close to the initial wrist (-0.25, 0.0). The sink's
+    # offset + rotated/scaled bounds sweep a radius <0.48 m about the root;
+    # these ranges leave >=0.07 m clearance on the 1.5 x 1.5 m main table
+    # for every yaw, including the sink and support rather than just the tap.
+    articulation_reset_pose_range: dict[str, list[float]] = {
+        "x": [-0.05, 0.05],
+        "y": [-0.1, 0.1],
+        "z": [0.0, 0.0],
+        "roll": [0.0, 0.0],
+        "pitch": [0.0, 0.0],
+        "yaw": [-3.14159, 3.14159],
+    }
+
+    success_joint_names: str = ".*"
+    success_threshold: float = math.radians(80)
+
+    # PPO-ready dense preset: keeps the auto-wired ``open_amount`` and adds
+    # fingertip reach toward the faucet (small, fixed-root asset — the
+    # all-links mean target is fine, so ``dense_reach_body_names`` stays None).
+    rewards: DenseArticulationRewardsCfg = DenseArticulationRewardsCfg()
+
+    # ---- Passive faucet joint (valve-like) -------------------------------
+    # Zero drive stiffness (handled in __post_init__) means no spring-back;
+    # elevated joint friction makes the handle hold its angle, and a small
+    # armature keeps the solver stable. ``friction`` is the static coefficient
+    # and ``dynamic_friction`` the sliding one (Isaac Sim 5.x models both as
+    # resisting efforts). Tune magnitudes to taste.
+    faucet_joint_static_friction: float = 0.4
+    faucet_joint_dynamic_friction: float = 0.3
+    faucet_joint_armature: float = 0.01
+
+    # ---- Sink basin prop --------------------------------------------------
+    sink_usd_path: str = SINK_USD_PATH
+    sink_scale: tuple[float, float, float] = (0.83, 0.83, 0.83)  # TODO: tune to faucet size
+    # 90 degrees about +z: (cos(45 deg), 0, 0, sin(45 deg)). Flip the sign of
+    # the last component for the other 90deg direction.
+    sink_init_rot: tuple[float, float, float, float] = tuple(R.from_euler("z", math.pi / 2).as_quat().tolist())
+    # Placement of the sink relative to the faucet, applied every reset via
+    # ``mdp.sync_object`` so the basin always tracks the faucet. (x, y) are in
+    # the faucet's local frame (rotated by ``articulation_init_rot``); z is a
+    # world-frame drop ("below"). Defaults put the basin a bit in front of and
+    # ~0.2 m below the elevated faucet root — i.e. roughly at table height.
+    # TODO: tune after previewing; which horizontal axis is "in front" depends
+    # on the asset's authored orientation.
+    sink_offset_from_faucet: tuple[float, float, float] = (0.0, -0.25, -0.1)
+
+    # ---- Cosmetic faucet support pedestal --------------------------------
+    # Purely visual rectangular cuboid that fills the gap between the tabletop
+    # and the elevated faucet base (the faucet is lifted
+    # ``articulation_half_height_est`` above the table, so otherwise it floats).
+    # Collision is disabled, so it never affects the hand/faucet/sink. Its
+    # height is derived from ``articulation_half_height_est`` in
+    # ``__post_init__`` so the pedestal always spans table -> faucet base; only
+    # the horizontal footprint and color are tuned here.
+    # TODO: tune footprint after previewing so it reads as a base, not a post.
+    support_footprint: tuple[float, float] = (0.12, 0.32)
+    support_color: tuple[float, float, float] = (0.8, 0.8, 0.8)
+
+    def __post_init__(self):
+        super().__post_init__()
+        # Success when any selected faucet joint moves by >= pi/4 from init.
+        self.terminations.success.func = mdp.joint_relative_move
+        self.terminations.success.params = {
+            "threshold": self.success_threshold,
+            "asset_cfg": SceneEntityCfg("articulation", joint_names=self.success_joint_names),
+            "mode": "displacement",
+            "op": ">=",
+            "reduce": "any",
+        }
+
+        # Passive faucet joint. The base spawn already zeroes the drive
+        # stiffness/damping/max_effort; this implicit actuator additionally
+        # writes joint friction + armature (which JointDrivePropertiesCfg can't)
+        # while keeping the drive at zero stiffness so there is no spring-back.
+        self.scene.articulation.actuators = {
+            "faucet_joint": ImplicitActuatorCfg(
+                joint_names_expr=[".*"],
+                stiffness=0.0,
+                damping=0.0,
+                armature=self.faucet_joint_armature,
+                friction=self.faucet_joint_static_friction,
+                dynamic_friction=self.faucet_joint_dynamic_friction,
+            )
+        }
+
+        # Spawn the sink near the faucet at table height; the reset event below
+        # is the authoritative placement, so this just avoids an off-screen
+        # spawn before the first reset.
+        table_top_z = dexverse_base_env.DEFAULT_TABLE_TOP_HEIGHT
+        fx, fy, _ = self.articulation_init_pos
+        self.scene.sink = _build_sink_cfg(
+            scale=self.sink_scale,
+            init_rot=self.sink_init_rot,
+            init_pos=(fx, fy, table_top_z),
+        )
+
+        # The sink / pedestal orientations are authored as *world* quats for
+        # the faucet's init yaw. The faucet now spawns at a uniform random
+        # yaw, so convert them to faucet-local rotations and sync with
+        # ``quat_local``: both props rotate rigidly with the faucet and, at
+        # zero yaw delta, reproduce the authored world orientation exactly.
+        # (scipy quats are xyzw; Isaac's are wxyz.)
+        faucet_rot = R.from_quat((*self.articulation_init_rot[1:], self.articulation_init_rot[0]))
+        sink_rot = R.from_quat((*self.sink_init_rot[1:], self.sink_init_rot[0]))
+        sqx, sqy, sqz, sqw = (faucet_rot.inv() * sink_rot).as_quat()
+        sink_quat_local = (float(sqw), float(sqx), float(sqy), float(sqz))
+        iqx, iqy, iqz, iqw = faucet_rot.inv().as_quat()
+        support_quat_local = (float(iqw), float(iqx), float(iqy), float(iqz))
+
+        # Lock the sink in front of / below the faucet every reset. Added after
+        # super().__post_init__() so it runs *after* ``reset_articulation`` (the
+        # event manager fires reset terms in insertion order), reading the
+        # faucet's post-randomization pose. Horizontal offset and orientation
+        # are faucet-local (the basin swings with the randomized yaw); the
+        # vertical drop is world-frame via ``z_offset``.
+        ox, oy, oz = self.sink_offset_from_faucet
+        self.events.reset_sink = EventTerm(
+            func=mdp.sync_object,
+            mode="reset",
+            params={
+                "target_cfg": SceneEntityCfg("sink"),
+                "source_cfg": SceneEntityCfg("articulation"),
+                "source_local_offset": (ox, oy, 0.0),
+                "z_offset": float(oz),
+                "quat_local": sink_quat_local,
+            },
+        )
+
+        # Cosmetic pedestal under the elevated faucet. Its height equals the
+        # faucet elevation, so the box spans table_top_z -> faucet base; its
+        # center therefore sits half that height below the faucet root, while
+        # (x, y) track the faucet exactly. Spawned here to avoid an off-screen
+        # first frame; ``reset_support`` (added after super().__post_init__(),
+        # so it fires after ``reset_articulation``) is the authoritative
+        # placement and re-seats it under the randomized faucet each reset.
+        support_height = float(self.articulation_half_height_est)
+        sx, sy = self.support_footprint
+        self.scene.faucet_support = _build_support_cfg(
+            size=(sx, sy, support_height),
+            color=self.support_color,
+            init_pos=(fx, fy, table_top_z + support_height / 2.0),
+        )
+        self.events.reset_support = EventTerm(
+            func=mdp.sync_object,
+            mode="reset",
+            params={
+                "target_cfg": SceneEntityCfg("faucet_support"),
+                "source_cfg": SceneEntityCfg("articulation"),
+                "source_local_offset": (0.0, 0.0, 0.0),
+                "z_offset": -support_height / 2.0,
+                "quat_local": support_quat_local,
+            },
+        )

--- a/source/dexverse/dexverse/baseline_v1/config/articulation/reload_stapler_cfg.py
+++ b/source/dexverse/dexverse/baseline_v1/config/articulation/reload_stapler_cfg.py
@@ -1,0 +1,436 @@
+# Copyright (c) 2025-2026, The DexVerse Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Open a free stapler and place its base on a raised target table.
+
+The stapler starts near the table centre facing either left or right. The task
+requires opening its top past the over-centre detent, moving the whole stapler
+onto a marked target area at any orientation. It must then rest on the platform
+without either hand touching it for a short dwell. Opening and placement may
+be completed in either order.
+
+The target height is randomized per episode by selecting one of several small
+tables whose feet remain seated on the main table. Four camera-visible green
+spheres mark the target footprint on the selected table. Contact with any
+target table while the stapler is still near closed immediately fails.
+"""
+
+from __future__ import annotations
+
+import math
+
+import isaaclab.sim as sim_utils
+from dexverse.assets.small_table_builder import ensure_small_table_asset
+from isaaclab.actuators import ImplicitActuatorCfg
+from isaaclab.assets import RigidObjectCfg
+from isaaclab.managers import EventTermCfg as EventTerm
+from isaaclab.managers import ObservationGroupCfg as ObsGroup
+from isaaclab.managers import ObservationTermCfg as ObsTerm
+from isaaclab.managers import RewardTermCfg as RewTerm
+from isaaclab.managers import SceneEntityCfg
+from isaaclab.managers import TerminationTermCfg as DoneTerm
+from isaaclab.sensors import ContactSensorCfg
+from isaaclab.utils import configclass
+from isaaclab.utils.noise import UniformNoiseCfg as Unoise
+
+from ... import dexverse_base_env_cfg as dexverse_base_env
+from ... import mdp
+from .articulation_base.articulation_base_cfg import ARTICULATION_KEY
+from .articulation_base.usd_helpers import replace_joint_with_fixed_parent
+from .open_stapler_cfg import STAPLER_USD_PATH, OpenStaplerEnvFloatingDexHandRightCfg
+
+TOP_HINGE = "RevoluteJoint_stapler_1_up"
+MAGAZINE_HINGE = "RevoluteJoint_stapler_1_middle"
+STAPLER_LINKS = ("E_body_2", "E_shell_1", "E_stapler_needle_3")
+FIXED_MAGAZINE_USD_PATH = replace_joint_with_fixed_parent(
+    STAPLER_USD_PATH,
+    joint_name=MAGAZINE_HINGE,
+    parent_body_path="/root/E_body_2",
+)
+TOP_HINGE_TRAVEL_DEG = 160.0
+
+# Bounds of the stapler base link in its root frame, measured from the source
+# asset. Success aligns the footprint centre (rather than the slightly
+# off-centre physics root) with the goal entity.
+STAPLER_BASE_HALF_EXTENTS = (0.09725, 0.035)
+STAPLER_BASE_CENTER_LOCAL = (-0.00415, 0.0018, 0.0)
+
+GOAL_MARKER_RADIUS = 0.012
+TARGET_TABLE_HEIGHTS = (0.08, 0.12, 0.16)
+TARGET_TABLE_HALF_EXTENTS = (
+    STAPLER_BASE_HALF_EXTENTS[0] + 0.05,
+    STAPLER_BASE_HALF_EXTENTS[1] + 0.05,
+)
+TARGET_TABLE_ASSETS = tuple(
+    ensure_small_table_asset(
+        f"stapler_target_table_{int(round(height * 100)):02d}cm",
+        depth=2.0 * TARGET_TABLE_HALF_EXTENTS[0],
+        width=2.0 * TARGET_TABLE_HALF_EXTENTS[1],
+        height=height,
+        top_thickness=0.012,
+        leg_size=0.020,
+        color=(0.48, 0.36, 0.22),
+    )[0]
+    for height in TARGET_TABLE_HEIGHTS
+)
+TARGET_TABLE_KEYS = tuple(f"stapler_target_table_{index}" for index in range(len(TARGET_TABLE_HEIGHTS)))
+TARGET_TABLE_PRIM_PATHS = tuple(
+    f"{{ENV_REGEX_NS}}/StaplerTargetTable{index}" for index in range(len(TARGET_TABLE_HEIGHTS))
+)
+GOAL_FRAME_CFG = RigidObjectCfg(
+    prim_path="{ENV_REGEX_NS}/StaplerGoalPose",
+    spawn=sim_utils.CuboidCfg(
+        size=(0.001, 0.001, 0.001),
+        rigid_props=sim_utils.RigidBodyPropertiesCfg(
+            rigid_body_enabled=True,
+            kinematic_enabled=True,
+            disable_gravity=True,
+        ),
+        collision_props=sim_utils.CollisionPropertiesCfg(collision_enabled=False),
+        visible=False,
+    ),
+    init_state=RigidObjectCfg.InitialStateCfg(pos=(0.0, 0.0, 0.0), rot=(1.0, 0.0, 0.0, 0.0)),
+)
+
+
+def _robot_contact_filter_paths(usd_path: str, prim_path: str) -> list[str]:
+    """Resolve one robot rigid-body path per contact-filter column.
+
+    PhysX requires each filter expression to match one body per environment.
+    A Robot/.* filter also matches joints/material scopes and cannot represent
+    both hands as a single column. Read the selected robot USD without editing
+    it; retain only the environment wildcard in the spawned paths.
+    """
+    from pxr import Usd, UsdPhysics
+
+    stage = Usd.Stage.Open(str(usd_path))
+    if stage is None or not stage.GetDefaultPrim():
+        raise ValueError(f"Could not resolve robot USD default prim for stapler contact filters: {usd_path}")
+    root = stage.GetDefaultPrim()
+    paths = []
+    for body in Usd.PrimRange(root, Usd.TraverseInstanceProxies()):
+        if body.HasAPI(UsdPhysics.RigidBodyAPI):
+            relative = str(body.GetPath().MakeRelativePath(root.GetPath()))
+            paths.append(prim_path if relative == "." else f"{prim_path}/{relative}")
+    if not paths:
+        raise ValueError(f"No robot rigid bodies found for stapler contact filters: {usd_path}")
+    return paths
+
+
+@configclass
+class ReloadStaplerEnvFloatingDexHandRightCfg(OpenStaplerEnvFloatingDexHandRightCfg):
+    """Open the stapler and place it on a randomly elevated target table."""
+
+    articulation_usd_path: str = FIXED_MAGAZINE_USD_PATH
+    episode_length_s_override: float = 30.0
+
+    # Tight positional variance, with a random left/right initial heading.
+    # The authored nominal rotation is +90 degrees, so yaw offsets of 0 and pi
+    # produce final world headings of +90 and -90 degrees.
+    articulation_reset_pose_range: dict[str, list[float]] = {
+        "x": [-0.025, 0.025],
+        "y": [-0.025, 0.025],
+        "z": [0.0, 0.0],
+        "roll": [0.0, 0.0],
+        "pitch": [0.0, 0.0],
+        "yaw": [math.radians(-10.0), math.radians(10.0)],
+    }
+    articulation_yaw_choices: tuple[float, float] = (0.0, math.pi)
+
+    # The goal is independently randomized on the far side of the table. Its
+    # four corners move and rotate with this pose, showing both the target area
+    # and its sampled orientation.
+    # Keep the raised furniture clear of the initial stapler footprint even at
+    # the closest sampled poses/orientations, avoiding reset-time collisions.
+    goal_init_xy: tuple[float, float] = (0.25, 0.0)
+    # Match the horizontal left/right axis used at initialization. Since the
+    # four-corner goal treats 180-degree reversals as equivalent, one +90-degree
+    # nominal frame represents both left- and right-facing placements.
+    goal_init_rot: tuple[float, float, float, float] = (
+        math.sqrt(0.5),
+        0.0,
+        0.0,
+        math.sqrt(0.5),
+    )
+    goal_xy_range: dict[str, list[float]] = {
+        "x": [-0.04, 0.04],
+        "y": [-0.12, 0.12],
+    }
+    goal_yaw_range: tuple[float, float] = (math.radians(-15.0), math.radians(15.0))
+    goal_pos_tol: float = 0.05
+    goal_z_tol: float = 0.02
+    goal_corner_marker_radius: float = GOAL_MARKER_RADIUS
+    target_table_heights: tuple[float, ...] = TARGET_TABLE_HEIGHTS
+    closed_contact_max_progress: float = 0.20
+    target_contact_force_threshold: float = 0.25
+    release_contact_force_threshold: float = 0.10
+    # A padded volume around the complete open stapler. Any robot body inside
+    # it resets the release dwell, even before physical contact occurs.
+    release_forbidden_zone_center: tuple[float, float, float] = (
+        STAPLER_BASE_CENTER_LOCAL[0],
+        STAPLER_BASE_CENTER_LOCAL[1],
+        0.10,
+    )
+    release_forbidden_zone_half_extents: tuple[float, float, float] = (
+        STAPLER_BASE_HALF_EXTENTS[0] + 0.03,
+        STAPLER_BASE_HALF_EXTENTS[1] + 0.03,
+        0.12,
+    )
+    success_hold_steps: int = 60
+
+    # Over-centre top hinge: it pulls closed before the detent and parks open
+    # after crossing it.
+    articulation_hinge_stiffness: float = 0.0
+    articulation_hinge_damping: float = 0.02
+    hinge_friction: float = 0.02
+    hinge_over_center_deg: float = 150.0
+    hinge_close_torque: float = 0.25
+    hinge_transition_deg: float = 3.0
+    hinge_lock_torque: float = 0.05
+    base_mass_kg: float = 0.25
+    top_open_deg: float = 152.0
+
+    stapler_static_friction: float = 2.0
+    stapler_dynamic_friction: float = 1.8
+
+    def __post_init__(self):
+        table_top_z = dexverse_base_env.DEFAULT_TABLE_TOP_HEIGHT
+        goal_z = table_top_z + self.target_table_heights[0] + self.articulation_half_height_est
+        self.scene.stapler_goal = GOAL_FRAME_CFG.replace(
+            init_state=RigidObjectCfg.InitialStateCfg(
+                pos=(self.goal_init_xy[0], self.goal_init_xy[1], goal_z),
+                rot=self.goal_init_rot,
+            )
+        )
+        for index, (key, prim_path, usd_path) in enumerate(
+            zip(TARGET_TABLE_KEYS, TARGET_TABLE_PRIM_PATHS, TARGET_TABLE_ASSETS, strict=True)
+        ):
+            setattr(
+                self.scene,
+                key,
+                RigidObjectCfg(
+                    prim_path=prim_path,
+                    spawn=sim_utils.UsdFileCfg(
+                        usd_path=str(usd_path),
+                        rigid_props=sim_utils.RigidBodyPropertiesCfg(
+                            rigid_body_enabled=True,
+                            kinematic_enabled=True,
+                            disable_gravity=True,
+                        ),
+                        # Collision boxes are authored in the procedural USD.
+                        collision_props=None,
+                        mass_props=None,
+                    ),
+                    init_state=RigidObjectCfg.InitialStateCfg(
+                        pos=(self.goal_init_xy[0], self.goal_init_xy[1], table_top_z if index == 0 else -2.0),
+                        rot=self.goal_init_rot,
+                    ),
+                ),
+            )
+        super().__post_init__()
+        self.events.reset_articulation.params["yaw_choices"] = self.articulation_yaw_choices
+        self.events.reset_stapler_target = EventTerm(
+            func=mdp.reset_random_support_and_goal,
+            mode="reset",
+            params={
+                "support_cfgs": tuple(SceneEntityCfg(key) for key in TARGET_TABLE_KEYS),
+                "support_heights": self.target_table_heights,
+                "goal_cfg": SceneEntityCfg("stapler_goal"),
+                "goal_xy_range": self.goal_xy_range,
+                "support_base_z": table_top_z,
+                "goal_z_clearance": self.articulation_half_height_est,
+                "yaw_range": self.goal_yaw_range,
+            },
+        )
+
+        # The filtered sensors see target-table contacts only, including hits
+        # by the shell and the fixed magazine rather than just the base.
+        self.scene.articulation.spawn.activate_contact_sensors = True
+        target_filter_paths = list(TARGET_TABLE_PRIM_PATHS)
+        robot_filter_paths = _robot_contact_filter_paths(
+            self.scene.robot.spawn.usd_path, self.scene.robot.prim_path,
+        )
+        target_contact_sensor_names = []
+        robot_contact_sensor_names = []
+        for link_name in STAPLER_LINKS:
+            sensor_name = f"{link_name}_target_tables_s"
+            setattr(
+                self.scene,
+                sensor_name,
+                ContactSensorCfg(
+                    # After the prepared USD is spawned, these rigid bodies are
+                    # direct children of /Articulation (confirmed by the live
+                    # articulation/contact-report initialization log).
+                    prim_path=f"{{ENV_REGEX_NS}}/Articulation/{link_name}",
+                    filter_prim_paths_expr=target_filter_paths,
+                ),
+            )
+            target_contact_sensor_names.append(sensor_name)
+            robot_sensor_name = f"{link_name}_robot_s"
+            setattr(
+                self.scene,
+                robot_sensor_name,
+                ContactSensorCfg(
+                    prim_path=f"{{ENV_REGEX_NS}}/Articulation/{link_name}",
+                    # Sense every rigid body below the robot root, so release
+                    # includes palms and intermediate finger links as well as
+                    # fingertips.
+                    filter_prim_paths_expr=list(robot_filter_paths),
+                ),
+            )
+            robot_contact_sensor_names.append(robot_sensor_name)
+
+        drive_props = self.scene.articulation.spawn.joint_drive_props
+        if drive_props is None:
+            self.scene.articulation.spawn.joint_drive_props = sim_utils.JointDrivePropertiesCfg(drive_type="force")
+        else:
+            drive_props.drive_type = "force"
+        self.scene.articulation.actuators = {
+            "stapler_top": ImplicitActuatorCfg(
+                joint_names_expr=[TOP_HINGE],
+                effort_limit_sim=100.0,
+                velocity_limit_sim=100.0,
+                stiffness=0.0,
+                damping=self.articulation_hinge_damping,
+                friction=self.hinge_friction,
+            ),
+        }
+        self.events.reset_stapler_hinge_target = None
+        self.events.stapler_physics_material = EventTerm(
+            func=mdp.randomize_rigid_body_material,
+            mode="startup",
+            params={
+                "asset_cfg": SceneEntityCfg(ARTICULATION_KEY),
+                "static_friction_range": (self.stapler_static_friction, self.stapler_static_friction),
+                "dynamic_friction_range": (self.stapler_dynamic_friction, self.stapler_dynamic_friction),
+                "restitution_range": (0.0, 0.0),
+                "num_buckets": 1,
+            },
+        )
+        self.events.set_stapler_base_mass = EventTerm(
+            func=mdp.randomize_rigid_body_mass,
+            mode="startup",
+            params={
+                "asset_cfg": SceneEntityCfg(ARTICULATION_KEY, body_names=[STAPLER_LINKS[0]]),
+                "mass_distribution_params": (self.base_mass_kg, self.base_mass_kg),
+                "operation": "abs",
+                "recompute_inertia": True,
+            },
+        )
+        self.events.over_center_top_hinge = EventTerm(
+            func=mdp.over_center_hinge,
+            mode="interval",
+            interval_range_s=(0.0, 0.0),
+            is_global_time=False,
+            params={
+                "asset_cfg": SceneEntityCfg(ARTICULATION_KEY, joint_names=[TOP_HINGE]),
+                "over_center_angle": math.radians(self.hinge_over_center_deg),
+                "close_torque": self.hinge_close_torque,
+                "lock_torque": self.hinge_lock_torque,
+                "transition_width": math.radians(self.hinge_transition_deg),
+                "open_sign": -1.0,
+                "max_open_angle": math.radians(TOP_HINGE_TRAVEL_DEG),
+            },
+        )
+
+        # Success requires opening, placement with physical platform contact,
+        # and complete hand release for a consecutive dwell. The explicit
+        # spatial zone catches nearby hand links; contact sensors remain a
+        # second safeguard for geometries whose body origins sit outside it.
+        forbidden_center = self.release_forbidden_zone_center
+        forbidden_half = self.release_forbidden_zone_half_extents
+        self.terminations.success.func = mdp.joint_pose_contact_release_hold_success
+        self.terminations.success.params = {
+            "threshold": self.top_open_deg / TOP_HINGE_TRAVEL_DEG,
+            "goal_cfg": SceneEntityCfg("stapler_goal"),
+            "support_sensor_names": target_contact_sensor_names,
+            "robot_sensor_names": robot_contact_sensor_names,
+            "forbidden_box_zones": [(*forbidden_center, *forbidden_half)],
+            "forbidden_asset_cfg": SceneEntityCfg(
+                "robot",
+                body_names=self.robot_config.forbidden_zone_body_names,
+            ),
+            "asset_cfg": SceneEntityCfg(ARTICULATION_KEY, joint_names=[TOP_HINGE]),
+            "center_local": STAPLER_BASE_CENTER_LOCAL,
+            "pos_tol": self.goal_pos_tol,
+            "z_tol": self.goal_z_tol,
+            # Placement orientation is unrestricted.
+            "yaw_tol": None,
+            "mode": "progress",
+            "op": ">=",
+            "reduce": "any",
+            "support_force_threshold": self.target_contact_force_threshold,
+            "robot_force_threshold": self.release_contact_force_threshold,
+            "hold_steps": self.success_hold_steps,
+        }
+        self.terminations.unsafe_slam = None
+        self.terminations.closed_on_target_table = DoneTerm(
+            func=mdp.joint_near_init_and_contact,
+            params={
+                "sensor_names": target_contact_sensor_names,
+                "asset_cfg": SceneEntityCfg(ARTICULATION_KEY, joint_names=[TOP_HINGE]),
+                "max_progress": self.closed_contact_max_progress,
+                "force_threshold": self.target_contact_force_threshold,
+            },
+        )
+
+        # Replace loading-stage reward with a sparse bonus for this task.
+        self.rewards.stage_bonus = RewTerm(
+            func=mdp.joint_moved_and_pose_near_goal,
+            weight=5.0,
+            params={
+                key: value
+                for key, value in self.terminations.success.params.items()
+                if key
+                not in {
+                    "support_sensor_names",
+                    "robot_sensor_names",
+                    "forbidden_box_zones",
+                    "forbidden_asset_cfg",
+                    "support_force_threshold",
+                    "robot_force_threshold",
+                    "hold_steps",
+                }
+            },
+        )
+
+        @configclass
+        class GoalObsCfg(ObsGroup):
+            goal_pos_b = ObsTerm(
+                func=mdp.asset_pos_b,
+                params={"asset_cfg": SceneEntityCfg("stapler_goal")},
+                noise=Unoise(n_min=-0.0, n_max=0.0),
+            )
+            goal_quat_b = ObsTerm(
+                func=mdp.object_quat_b,
+                params={"object_cfg": SceneEntityCfg("stapler_goal")},
+                noise=Unoise(n_min=-0.0, n_max=0.0),
+            )
+
+            def __post_init__(self):
+                self.enable_corruption = True
+                self.concatenate_terms = True
+                self.history_length = 0
+
+        self.observations.goal = GoalObsCfg()
+
+        hx, hy = TARGET_TABLE_HALF_EXTENTS
+        marker_z = self.goal_corner_marker_radius - self.articulation_half_height_est
+        corners = [(sx * hx, sy * hy, marker_z) for sx in (-1.0, 1.0) for sy in (-1.0, 1.0)]
+        self.add_scene_vis_term(
+            "stapler_goal_corners",
+            ObsTerm(
+                func=mdp.local_points_vis,
+                params={
+                    "asset_cfg": SceneEntityCfg("stapler_goal"),
+                    "local_points": corners,
+                    "radius": self.goal_corner_marker_radius,
+                    "color": (0.15, 0.75, 0.25),
+                    "opacity": 1.0,
+                    "prim_path": "/Visuals/StaplerGoalCorners",
+                    "hide_from_cameras": False,
+                },
+            ),
+        )

--- a/source/dexverse/dexverse/baseline_v1/config/articulation/rewards.py
+++ b/source/dexverse/dexverse/baseline_v1/config/articulation/rewards.py
@@ -1,0 +1,96 @@
+# Copyright (c) 2025-2026, The DexVerse Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Reward configurations for the articulation task family.
+
+The ``Dense*`` presets are the PPO-ready variants. Term param wiring
+(fingertip body names, ``success_joint_names``, ``dense_reach_body_names``)
+happens generically in ``ArticulationBaseEnvCfg.__post_init__`` — see the
+"dense reward wiring" block there — so leaves only pick a preset and, where
+needed, name the moving link via ``dense_reach_body_names``.
+"""
+
+from __future__ import annotations
+
+from isaaclab.managers import RewardTermCfg as RewTerm
+from isaaclab.managers import SceneEntityCfg
+from isaaclab.utils import configclass
+
+from ... import mdp
+from .articulation_base.articulation_base_cfg import ARTICULATION_KEY, ArticulationBaseRewardsCfg
+
+
+@configclass
+class DenseArticulationRewardsCfg(ArticulationBaseRewardsCfg):
+    """PPO-ready preset for fixed-root articulations (faucet, cabinet, ...).
+
+    Keeps the threshold-normalized ``open_amount`` term (auto-wired from
+    ``success_threshold``) and adds fingertip reach shaping toward the
+    articulation so exploration finds the handle at all.
+    """
+
+    fingers_to_part = RewTerm(
+        func=mdp.fingertips_to_body_distance,
+        weight=1.5,
+        params={
+            # target body names come from ``dense_reach_body_names`` (None ->
+            # mean over all links); fingertip body names are wired from the
+            # active robot config.
+            "target_cfg": SceneEntityCfg(ARTICULATION_KEY),
+            "asset_cfg": SceneEntityCfg("robot", body_names=None),
+            "distance_gain": 5.0,
+            "reduce": "mean",
+        },
+    )
+
+
+@configclass
+class DenseFixateArticulationRewardsCfg(DenseArticulationRewardsCfg):
+    """PPO-ready preset for free-root fixate-then-manipulate articulations.
+
+    * ``open_amount`` is swapped to init-relative range progress, matching the
+      ``joint_relative_move(mode="progress")`` success criterion these tasks
+      use (the ``articulation_base`` threshold auto-wiring only applies to
+      ``joint_open_reward`` and skips this term by design).
+    * ``stabilize_lin``/``stabilize_ang`` penalize root motion of the free
+      articulation — the pin-the-base sub-behavior is otherwise unrewarded
+      (a toppled/slid object only shows up as an ``out_of_bound`` termination).
+      Keep these small relative to the positive terms so ending the episode
+      early never beats making progress.
+    """
+
+    open_amount = RewTerm(
+        func=mdp.joint_range_progress_from_init,
+        weight=5.0,
+        params={"asset_cfg": SceneEntityCfg(ARTICULATION_KEY, joint_names=".*")},
+    )
+
+    stabilize_lin = RewTerm(
+        func=mdp.root_lin_vel_norm,
+        weight=-0.5,
+        params={"asset_cfg": SceneEntityCfg(ARTICULATION_KEY)},
+    )
+
+    stabilize_ang = RewTerm(
+        func=mdp.root_ang_vel_norm,
+        weight=-0.05,
+        params={"asset_cfg": SceneEntityCfg(ARTICULATION_KEY)},
+    )
+
+
+@configclass
+class DenseSlideKnifeRewardsCfg(DenseFixateArticulationRewardsCfg):
+    """Utility-knife preset: fixate shaping plus the lift the success requires.
+
+    ``joint_moved_and_object_lifted`` success also demands the knife be held
+    above the table; ``knife_lift`` grades that sub-goal (``min_height`` is
+    wired from ``success_lift_min_height`` in the leaf ``__post_init__``).
+    """
+
+    knife_lift = RewTerm(
+        func=mdp.object_lift_height,
+        weight=1.0,
+        params={"asset_cfg": SceneEntityCfg(ARTICULATION_KEY), "min_height": 0.2},
+    )

--- a/source/dexverse/dexverse/baseline_v1/config/articulation/slide_utility_knife_cfg.py
+++ b/source/dexverse/dexverse/baseline_v1/config/articulation/slide_utility_knife_cfg.py
@@ -1,0 +1,273 @@
+# Copyright (c) 2025-2026, The DexVerse Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Fixate-then-manipulate: extend a utility-knife blade (synthesis/utility knife002)."""
+
+import isaaclab.sim as sim_utils
+from dexverse.assets import SYNTHESIS_DIR
+from isaaclab.actuators import ImplicitActuatorCfg
+from isaaclab.managers import EventTermCfg as EventTerm
+from isaaclab.managers import SceneEntityCfg
+from isaaclab.utils import configclass
+
+from ... import mdp
+from .base_cfg import FixateArticulationEnvFloatingDexHandRightCfg
+from .rewards import DenseSlideKnifeRewardsCfg
+
+UTILITY_KNIFE_USD_PATH = str(SYNTHESIS_DIR / "utility knife002" / "model_utility_knife_3.usd")
+
+
+@configclass
+class SlideUtilityKnifeEnvFloatingDexHandRightCfg(FixateArticulationEnvFloatingDexHandRightCfg):
+    """Extend a retractable utility-knife blade along its slider.
+
+    The current USD exposes one actuable joint: the prismatic blade slider
+    (``PrismaticJoint_utility_knife_3_middle``). Keep success scoped to this
+    joint explicitly for stable reward shaping.
+
+    Small, thin asset: scaled 1.5x and rested on a pair of padding blocks
+    so fingers can slip underneath.
+    """
+
+    robot_type: str = "floating_shadow_bimanual"
+    articulation_usd_path: str = UTILITY_KNIFE_USD_PATH
+    # 1.2x for easier grasping; the authored knife is ~16 cm long so
+    # this lands around 19 cm.
+    articulation_scale: tuple = (1.3, 1.3, 1.3)
+    # Slightly under 50 g so the floating hands can lift / slide it more easily.
+    articulation_mass_kg: float = 0.035
+    articulation_init_pos: tuple = (0.0, 0.0, 0.0)
+    # Net 0 deg yaw: the previous -90 deg plus a +90 deg CCW rotation. The
+    # knife's native long axis is world-y, so it now lies along y.
+    articulation_init_rot: tuple = (1.0, 0.0, 0.0, 0.0)
+    # Implicit actuator owns this prismatic joint's drive; keep the base
+    # joint-drive damping off so it doesn't double up.
+    articulation_joint_damping: float = 0.0
+    # Scaled with the mesh (~0.022 * 1.2) so the knife still spawns flush on
+    # the support blocks instead of clipping into them.
+    articulation_half_height_est: float = 0.022
+
+    # Elevated contact friction so the knife body grips the hands / padding
+    # blocks instead of sliding around while the blade is driven out. The
+    # base disables friction randomization, so __post_init__ re-attaches a
+    # physics material that applies these ranges. Collapsed (low == high)
+    # bounds make it a deterministic coefficient on every collision shape.
+    articulation_static_friction_range: tuple[float, float] = (2.0, 2.0)
+    articulation_dynamic_friction_range: tuple[float, float] = (2.0, 2.0)
+
+    # Robot-hand contact friction. The robot here is a floating Shadow hand, so
+    # this is the grip friction of the fingers / palm. The base nulls robot
+    # physics-material randomization, so __post_init__ re-attaches a
+    # deterministic (low == high) material with these ranges. Raise to grip the
+    # knife more firmly; lower if the hand sticks. Set to None to leave the
+    # robot at its default (PhysX ~0.5) material.
+    robot_static_friction_range: tuple[float, float] | None = (1.5, 1.5)
+    robot_dynamic_friction_range: tuple[float, float] | None = (1.5, 1.5)
+
+    # --- Per-task wrist drive override (scoped to this knife task) -----------
+    # The knife rests on kinematic (infinite-mass) support stands and is gripped
+    # firmly with high contact friction, so the floating hand's default wrist
+    # drive (effort_limit 15 N, stiffness 2000, damping 400) stalls under the
+    # grasp+contact load -- the hand "locks" once it grabs the knife. Stiffen the
+    # wrist and raise its force ceiling so it can drag / lift the loaded grip.
+    #
+    # Only the wrist DOFs (the ``*_translation_joint`` / ``*_rotation_joint``
+    # prismatic+revolute chain) are touched; the fingers stay at their defaults.
+    # Applied in __post_init__ to ``self.scene.robot``, which is a deep copy made
+    # by ``ArticulationCfg.replace()`` in the robot-setup builder, so this does
+    # NOT mutate the shared FLOATING_SHADOW_*_CFG globals used by other tasks.
+    # Set any value to None to leave that field at the robot default.
+    wrist_effort_limit: float | None = 60.0
+    wrist_stiffness: float | None = 4000.0
+    # Bumped alongside stiffness so the drive stays roughly critically damped
+    # (critical damping ~ sqrt(stiffness)). Lower if the wrist feels sluggish;
+    # raise if it oscillates / overshoots.
+    wrist_damping: float | None = 600.0
+
+    # Detent / "stays where you push it" hold for the blade slider.
+    #
+    # A real utility knife holds the blade at whatever notch you slide it to.
+    # We model this with the implicit PD actuator below at *zero stiffness*
+    # (so there is no restoring force pulling the blade back to a target) plus
+    # PhysX joint friction, which supplies the Coulomb "stays put" force.
+    #
+    # NOTE: PhysX joint *static* friction is load-proportional -- the holding
+    # force scales with the spatial force transmitted through the joint, not a
+    # fixed value. On this light, horizontal blade that transmitted force is
+    # small, so the hold is gentle. Raise these if the blade drifts under
+    # contact; lower them if the robot can't slide it out. ``dynamic_friction``
+    # only takes effect on Isaac Sim >= 5.0; ``blade_damping`` is the
+    # version-agnostic viscous term (applied through the implicit actuator).
+    articulation_blade_static_friction: float = 1.0
+    articulation_blade_dynamic_friction: float = 0.8
+    articulation_blade_damping: float = 1.2
+
+    # Per-episode pose variation. Applied to the knife AND its support stands as
+    # one shared rigid transform (see __post_init__) so the knife always lands
+    # cradled on the stands. Keep roll/pitch/z at 0 to stay flat on the table;
+    # widen x/y (metres) and yaw (radians) for more spatial robustness.
+    articulation_reset_pose_range: dict[str, list[float]] = {
+        "x": [-0.05, 0.05],
+        "y": [-0.15, 0.05],
+        "z": [0.0, 0.0],
+        "roll": [0.0, 0.0],
+        "pitch": [0.0, 0.0],
+        # Reset audit (Aug 2026): uniform yaw -- the object can face any way,
+        # like the functional tasks; the two floating hands can approach from
+        # any side.
+        "yaw": [-3.14159, 3.14159],
+    }
+
+    # The knife's long axis lies along world-y after the init rotation, so the
+    # two stands are separated along y -- one under each end -- and centered on
+    # the knife's spawn xy, so the knife lies flat across both.
+    articulation_use_padding_blocks: bool = True
+    # Taller stand (height 0.04 vs the 0.015 base default) so there is more
+    # clearance under the knife for fingers to slip in and grasp. The block
+    # height also sets how far the knife is lifted off the table. Footprint
+    # (0.04 x 0.04) kept from the base.
+    articulation_padding_block_size: tuple[float, float, float] = (0.06, 0.02, 0.06)
+    # (dx, dy) from the knife spawn xy. Separated ~14 cm along y (the long
+    # axis) so each stand sits near an end of the ~19 cm knife; same x so both
+    # stay centered under it.
+    articulation_padding_block_offsets: tuple[tuple[float, float], ...] = (
+        (0.0, 0.0),
+        (0.0, 0.2),
+    )
+
+    success_joint_names: list[str] = ["PrismaticJoint_utility_knife_3_middle"]
+    success_threshold: float = 0.4
+    # The knife must also be lifted at least this far (m) above its spawn height
+    # (i.e. off the support stands) for success -- this prevents the policy from
+    # driving the blade while the knife is still pinned to the table / stands.
+    success_lift_min_height: float = 0.2
+
+    # Fixate preset plus graded lift toward ``success_lift_min_height``.
+    rewards: DenseSlideKnifeRewardsCfg = DenseSlideKnifeRewardsCfg()
+
+    def __post_init__(self):
+        super().__post_init__()
+        # Grade the dense lift term to the same height success requires.
+        self.rewards.knife_lift.params["min_height"] = self.success_lift_min_height
+        # Stiffen / raise the wrist force ceiling so the hand can move while
+        # gripping the knife (see the wrist_* attributes above). Done first so
+        # it runs regardless of the active robot_type's actuator layout.
+        self._boost_wrist_drive()
+        self.scene.articulation.spawn.mass_props = sim_utils.MassPropertiesCfg(mass=self.articulation_mass_kg)
+        # Re-enable a PhysX material on the knife's collision shapes (the base
+        # nulls articulation friction randomization) so the elevated friction
+        # ranges above actually take effect on the table / hand contacts.
+        self.events.articulation_physics_material = EventTerm(
+            func=mdp.randomize_rigid_body_material,
+            mode="startup",
+            params={
+                "asset_cfg": SceneEntityCfg("articulation"),
+                "static_friction_range": self.articulation_static_friction_range,
+                "dynamic_friction_range": self.articulation_dynamic_friction_range,
+                "restitution_range": (0.0, 0.0),
+                "num_buckets": 1,
+            },
+        )
+        # Set the robot hand's contact friction (the base nulls
+        # ``robot_physics_material``). ``SceneEntityCfg("robot")`` covers every
+        # collision shape of the floating hand(s); pass ``body_names=[...]`` to
+        # scope it to just the fingertips. Skipped when the ranges are None.
+        if self.robot_static_friction_range is not None:
+            self.events.robot_physics_material = EventTerm(
+                func=mdp.randomize_rigid_body_material,
+                mode="startup",
+                params={
+                    "asset_cfg": SceneEntityCfg("robot"),
+                    "static_friction_range": self.robot_static_friction_range,
+                    "dynamic_friction_range": self.robot_dynamic_friction_range,
+                    "restitution_range": (0.0, 0.0),
+                    "num_buckets": 1,
+                },
+            )
+        # Implicit actuator owns the blade-slider drive. With an implicit
+        # actuator the stiffness/damping/friction go straight into the PhysX
+        # joint drive, so the Coulomb friction is actually applied -- unlike the
+        # explicit IdealPDActuator, whose effort is clipped to the USD joint's
+        # authored maxForce (0 here), which is why the blade wouldn't hold. Zero
+        # stiffness => no restoring force toward any target, so the blade never
+        # springs back to the retracted start; the detent "hold" is the joint
+        # friction below.
+        self.scene.articulation.actuators = {
+            "utility_knife_slider_stabilizer": ImplicitActuatorCfg(
+                joint_names_expr=self.success_joint_names,
+                effort_limit_sim=100.0,
+                velocity_limit_sim=100.0,
+                stiffness=0.0,
+                damping=self.articulation_blade_damping,
+                friction=self.articulation_blade_static_friction,
+                dynamic_friction=self.articulation_blade_dynamic_friction,
+            ),
+        }
+        # The blade starts retracted via the base ``reset_articulation_joints``
+        # (``reset_joints_to_init`` seats every joint at its init position). With
+        # stiffness=0 the drive target is irrelevant, so no reset/startup
+        # target-writing events are needed -- the joint friction holds the blade
+        # wherever it is left.
+        # Randomize the knife and its stands together with a single shared
+        # transform so the stands keep cradling the knife at any sampled
+        # position / yaw. The base reset would move only the knife, dropping it
+        # off the (static) stands.
+        if self.articulation_use_padding_blocks:
+            support_cfgs = [
+                SceneEntityCfg(f"padding_block_{i}") for i in range(len(self.articulation_padding_block_offsets))
+            ]
+            self.events.reset_articulation.func = mdp.reset_articulation_with_supports_uniform
+            self.events.reset_articulation.params = {
+                "asset_cfg": SceneEntityCfg("articulation"),
+                "support_cfgs": support_cfgs,
+                "pose_range": self.articulation_reset_pose_range,
+            }
+        # Success requires BOTH: the blade slid past the stroke threshold AND
+        # the knife lifted off its supports (so it can't be driven while pinned
+        # to the table / stands).
+        self.terminations.success.func = mdp.joint_moved_and_object_lifted
+        self.terminations.success.params = {
+            "threshold": self.success_threshold,
+            "min_height": self.success_lift_min_height,
+            "asset_cfg": SceneEntityCfg("articulation", joint_names=self.success_joint_names),
+            "mode": "progress",
+            "op": ">=",
+            "reduce": "any",
+        }
+
+    def _boost_wrist_drive(self) -> None:
+        """Override the floating-hand wrist drive for this task only.
+
+        Writes ``wrist_effort_limit`` / ``wrist_stiffness`` / ``wrist_damping``
+        onto every wrist DOF (the ``*_translation_joint`` / ``*_rotation_joint``
+        prismatic+revolute chain) of ``self.scene.robot``. Works for both the
+        single-hand (``(x|y|z)_..._joint``) and bimanual
+        (``(lh|rh)_(x|y|z)_..._joint``) key forms; finger joints are left alone.
+
+        Only per-joint dict fields are edited, so a scalar field that would also
+        cover the fingers is skipped. ``self.scene.robot`` is a deep copy from
+        ``ArticulationCfg.replace()``, so this stays scoped to this task.
+        """
+        overrides = {
+            "effort_limit_sim": self.wrist_effort_limit,
+            "stiffness": self.wrist_stiffness,
+            "damping": self.wrist_damping,
+        }
+        if all(value is None for value in overrides.values()):
+            return
+
+        actuators = getattr(getattr(self.scene, "robot", None), "actuators", None) or {}
+        for actuator in actuators.values():
+            for attr_name, new_value in overrides.items():
+                if new_value is None:
+                    continue
+                limits = getattr(actuator, attr_name, None)
+                if not isinstance(limits, dict):
+                    # Scalar field would also cover the fingers; skip so we only
+                    # ever touch the wrist DOFs via their explicit dict entries.
+                    continue
+                for joint_expr in limits:
+                    if "translation_joint" in joint_expr or "rotation_joint" in joint_expr:
+                        limits[joint_expr] = float(new_value)

--- a/source/dexverse/dexverse/baseline_v1/config/articulation/squeeze_scissors_cfg.py
+++ b/source/dexverse/dexverse/baseline_v1/config/articulation/squeeze_scissors_cfg.py
@@ -1,0 +1,153 @@
+# Copyright (c) 2025-2026, The DexVerse Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Fixate-then-manipulate: open / close scissors (synthesis/scissors001)."""
+
+from dexverse.assets import SYNTHESIS_DIR
+from isaaclab.actuators import ImplicitActuatorCfg
+from isaaclab.managers import SceneEntityCfg
+from isaaclab.utils import configclass
+
+from ... import mdp
+from .base_cfg import FixateArticulationEnvFloatingDexHandRightCfg
+
+SCISSORS_USD_PATH = str(SYNTHESIS_DIR / "scissors010" / "scissors_backup.usd")
+
+
+@configclass
+class SqueezeScissorsEnvFloatingDexHandRightCfg(FixateArticulationEnvFloatingDexHandRightCfg):
+    """Open / close scissor blades while the body is free on the table.
+
+    The scissors have two blades hinged about a central pivot
+    (``E_scissors_l_2`` and ``E_scissors_r_3``). Success fires when the
+    larger of the two hinge angles crosses ``success_threshold``. A typical
+    bimanual solution: one hand pins one handle, the other squeezes / pulls
+    on the opposite handle.
+
+    Scissors are small and thin, so we scale them up 1.5x and rest them
+    on a pair of padding blocks for finger clearance.
+    """
+
+    robot_type: str = "floating_shadow_bimanual"
+    articulation_usd_path: str = SCISSORS_USD_PATH
+    # 1.5x to compensate for small authored scale + give finger-width.
+    articulation_scale: tuple = (1.2, 1.2, 1.2)
+    articulation_init_pos: tuple = (0.0, 0.05, 0.0)
+    # Rotated +90 deg CCW about world z from the prior R_z(-90) so the
+    # scissors' long axis (asset +y) lies along world y, aligned with the
+    # padding stands. The +90 cancels the -90, netting out to identity.
+    articulation_init_rot: tuple = (1.0, 0.0, 0.0, 0.0)
+    articulation_init_joint_pos: dict[str, float] = {
+        "RevoluteJoint_scissors_backup_left": 0.0,
+        "RevoluteJoint_scissors_backup_right": 0.0,
+    }
+    # Implicit actuator (set in __post_init__) owns the hinge drive; keep the
+    # base implicit joint-drive damping off so it doesn't double up.
+    articulation_joint_damping: float = 0.0
+    # Scissors are thin; small half-height seats them on the table.
+    articulation_half_height_est: float = 0.007  # reset audit (Aug 2026): seated ~3 mm above rest instead of dropping (was 0.012)
+
+    # Detent / "stays where you leave it" hold for the two scissor hinges --
+    # the same friction-based model as the phone / knife / laptop. The implicit
+    # PD actuator below runs at *zero stiffness* (no restoring spring, so a blade
+    # never snaps back to closed) and PhysX joint friction supplies the Coulomb
+    # "stays put" force. The hinge axis is vertical (the scissors lie flat), so
+    # gravity does not load the joint -- friction only resists incidental
+    # contact, so a gentle coefficient holds. Raise it if a blade drifts under
+    # contact; lower it if the robot can't swing it open. ``dynamic_friction``
+    # only takes effect on Isaac Sim >= 5.0; ``hinge_damping`` is the
+    # version-agnostic viscous term.
+    articulation_hinge_static_friction: float = 0.8
+    articulation_hinge_dynamic_friction: float = 0.6
+    articulation_hinge_damping: float = 1.0
+
+    # Yaw the scissors about world +z, just like slide_utility_knife_cfg. The
+    # reset uses ``reset_articulation_with_supports_uniform`` (wired in
+    # __post_init__), which co-rotates the support stands about the scissors'
+    # pivot, so the stands keep cradling them at any sampled yaw. The same
+    # reset also translates the stands with the scissors, so x/y offsets are
+    # safe. Reset audit (Aug 2026): x/y were pinned (yaw-only randomization);
+    # now a 0.2 x 0.3 m box around the default spot.
+    articulation_reset_pose_range: dict[str, list[float]] = {
+        "x": [-0.1, 0.1],
+        "y": [-0.15, 0.15],
+        "z": [0.0, 0.0],
+        "roll": [0.0, 0.0],
+        "pitch": [0.0, 0.0],
+        # Reset audit (Aug 2026): uniform yaw -- the object can face any way,
+        # like the functional tasks; the two floating hands can approach from
+        # any side.
+        "yaw": [-3.14159, 3.14159],
+    }
+
+    # Padding blocks: scaled scissors are ~25–30 cm long after yaw,
+    # oriented along world y. Two blocks spaced ~16 cm apart along y
+    # support them near the handle and the blade tip.
+    articulation_use_padding_blocks: bool = True
+    articulation_padding_block_size: tuple[float, float, float] = (0.06, 0.02, 0.06)
+    articulation_padding_block_offsets: tuple[tuple[float, float], ...] = (
+        (0.0, -0.09),
+        (0.0, 0.09),
+    )
+
+    success_joint_names: list[str] = [
+        "RevoluteJoint_scissors_backup_left",
+        "RevoluteJoint_scissors_backup_right",
+    ]
+    # ~40 deg of a 50 deg blade range (progress fraction). 1.0 would require
+    # driving a blade all the way to its hard stop.
+    success_threshold: float = 0.5
+
+    def __post_init__(self):
+        super().__post_init__()
+        # Friction-detent hinge drive (matches phone / knife / laptop): an
+        # implicit actuator at zero stiffness + PhysX Coulomb joint friction.
+        # Implicit (not IdealPDActuator) so the friction reaches the PhysX joint
+        # and the holding torque is actually applied -- an explicit actuator's
+        # effort is clipped to the USD joint's authored maxForce. Zero stiffness
+        # => no restoring spring, so the blades stay wherever they are left.
+        self.scene.articulation.actuators = {
+            "scissors_hinge_stabilizer": ImplicitActuatorCfg(
+                joint_names_expr=self.success_joint_names,
+                effort_limit_sim=100.0,
+                velocity_limit_sim=100.0,
+                stiffness=0.0,
+                damping=self.articulation_hinge_damping,
+                friction=self.articulation_hinge_static_friction,
+                dynamic_friction=self.articulation_hinge_dynamic_friction,
+                armature=0.005,
+            ),
+        }
+        # The blades start closed via the base ``reset_articulation_joints``
+        # (``reset_joints_to_init`` seats both hinges at their 0 deg init). With
+        # stiffness 0 the drive target is irrelevant, so no target-writing
+        # reset/startup events are needed -- the joint friction holds the blades
+        # wherever they are left.
+
+        # Reset the scissors AND their padding stands as one rigid rig (a single
+        # shared transform), like slide_utility_knife_cfg / open_huawei_phone_cfg,
+        # so the stands stay cradling the scissors at any sampled yaw. The base
+        # reset moves only the articulation, which would yaw the scissors off the
+        # (static) stands.
+        if self.articulation_use_padding_blocks:
+            support_cfgs = [
+                SceneEntityCfg(f"padding_block_{i}") for i in range(len(self.articulation_padding_block_offsets))
+            ]
+            self.events.reset_articulation.func = mdp.reset_articulation_with_supports_uniform
+            self.events.reset_articulation.params = {
+                "asset_cfg": SceneEntityCfg("articulation"),
+                "support_cfgs": support_cfgs,
+                "pose_range": self.articulation_reset_pose_range,
+            }
+
+        self.terminations.success.func = mdp.joint_relative_move
+        # ~40 deg over a 50 deg blade range.
+        self.terminations.success.params = {
+            "threshold": self.success_threshold,
+            "asset_cfg": SceneEntityCfg("articulation", joint_names=self.success_joint_names),
+            "mode": "progress",
+            "op": ">=",
+            "reduce": "any",
+        }

--- a/source/dexverse/dexverse/baseline_v1/config/bimanual/__init__.py
+++ b/source/dexverse/dexverse/baseline_v1/config/bimanual/__init__.py
@@ -1,0 +1,1 @@
+"""Version-one baseline task implementation package."""

--- a/source/dexverse/dexverse/baseline_v1/config/bimanual/base_cfg.py
+++ b/source/dexverse/dexverse/baseline_v1/config/bimanual/base_cfg.py
@@ -1,0 +1,352 @@
+# Copyright (c) 2025-2026, The DexVerse Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Shared base for bimanual coordinated lift tasks.
+
+Success is height-based: the object root must rise by ``lift_height`` above
+its reset pose.  A green cube visualises the target height.
+
+Subclass ``BimanualLiftObjectEnvCfg`` (or the concrete Shadow-bimanual
+variant below) and override the class attributes that describe the object:
+
+    usd_path, scale, mass, object_half_height, table_clearance,
+    object_init_rot, object_init_x_offset, lift_height, obj_y_range,
+    obj_yaw_range, episode_length_s_override.
+
+The rewards skip the single-hand ``lift_when_grasping`` term (which assumes
+four fingertips) and rely on ``object_ee_distance`` (summed over all
+fingertips from both hands) plus the continuous ``object_lift_height``
+signal.  Both-hand contact naturally drives the reach term down to zero.
+"""
+
+from __future__ import annotations
+
+import isaaclab.sim as sim_utils
+from isaaclab.assets import RigidObjectCfg
+from isaaclab.devices.openxr import XrCfg
+from isaaclab.managers import EventTermCfg as EventTerm
+from isaaclab.managers import ObservationGroupCfg as ObsGroup
+from isaaclab.managers import ObservationTermCfg as ObsTerm
+from isaaclab.managers import RewardTermCfg as RewTerm
+from isaaclab.managers import SceneEntityCfg
+from isaaclab.managers import TerminationTermCfg as DoneTerm
+from isaaclab.sensors import TiledCameraCfg
+from isaaclab.utils import configclass
+from isaaclab.utils.noise import UniformNoiseCfg as Unoise
+
+from ... import dexverse_base_env_cfg as dexverse_base_env
+from ... import mdp
+from ..floating_teleop import DEFAULT_FLOATING_SHADOW_XR_CFG, setup_floating_teleop
+from .rewards import BimanualLiftRewardsCfg, DenseBimanualLiftRewardsCfg, wire_bimanual_reward_fingertips
+from .usd_helpers import ensure_single_rigid_body
+
+SUCCESS_MARKER_SIZE = (0.03, 0.03, 0.03)
+SUCCESS_MARKER_COLOR = (0.1, 0.9, 0.1)
+SUCCESS_MARKER_QUAT = (1.0, 0.0, 0.0, 0.0)
+
+
+def make_lift_object_cfg(
+    usd_path: str,
+    scale: tuple[float, float, float] = (1.0, 1.0, 1.0),
+    mass: float = 0.5,
+    init_rot: tuple[float, float, float, float] = (1.0, 0.0, 0.0, 0.0),
+) -> RigidObjectCfg:
+    """Build a ``RigidObjectCfg`` for a lift target from a USD file."""
+    usd_path = ensure_single_rigid_body(usd_path)
+    return RigidObjectCfg(
+        prim_path="{ENV_REGEX_NS}/Object",
+        spawn=sim_utils.UsdFileCfg(
+            func=dexverse_base_env.spawn_usd_with_rigid_properties,
+            usd_path=usd_path,
+            scale=scale,
+            rigid_props=sim_utils.RigidBodyPropertiesCfg(
+                rigid_body_enabled=True,
+                solver_position_iteration_count=16,
+                solver_velocity_iteration_count=0,
+                disable_gravity=False,
+            ),
+            # None since the USD already was processed to have collision properties.
+            collision_props=None,
+            mass_props=sim_utils.MassPropertiesCfg(mass=mass),
+        ),
+        init_state=RigidObjectCfg.InitialStateCfg(pos=(0.0, 0.0, 0.0), rot=init_rot),
+    )
+
+
+SUCCESS_MARKER_CFG = RigidObjectCfg(
+    prim_path="{ENV_REGEX_NS}/SuccessMarker",
+    spawn=sim_utils.CuboidCfg(
+        size=SUCCESS_MARKER_SIZE,
+        rigid_props=sim_utils.RigidBodyPropertiesCfg(
+            rigid_body_enabled=True,
+            kinematic_enabled=True,
+            disable_gravity=True,
+        ),
+        collision_props=sim_utils.CollisionPropertiesCfg(collision_enabled=False),
+        visual_material=sim_utils.PreviewSurfaceCfg(
+            diffuse_color=SUCCESS_MARKER_COLOR,
+            emissive_color=(0.0, 0.3, 0.0),
+            roughness=1.0,
+            metallic=0.0,
+        ),
+        visible=False,
+    ),
+    init_state=RigidObjectCfg.InitialStateCfg(pos=(0.0, 0.0, 0.0), rot=SUCCESS_MARKER_QUAT),
+)
+
+
+@configclass
+class BimanualLiftObservationsCfg(dexverse_base_env.ObservationsCfg):
+    """Observation layout for bimanual coordinated lift tasks.
+
+    ``state`` (observable, no velocities): object pose + ``object_lift_height``
+    (the height the object has risen above its spawn — the height-based success
+    signal). ``privileged``: object linear / angular velocities (+ inherited
+    robot ``joint_vel`` / ``hand_tips``). ``proprio`` stays joint-pos-only.
+
+    No ``goal`` group: success is "rise by a per-task constant ``lift_height``"
+    (uninformative as a constant for imitation learning, and would otherwise need
+    a reward-side value); the current lift height in ``state`` plus the
+    demonstrated motion carry the objective.
+    """
+
+    @configclass
+    class StateObsCfg(ObsGroup):
+        object_pos_b = ObsTerm(func=mdp.object_pos_b, noise=Unoise(n_min=-0.0, n_max=0.0))
+        object_quat_b = ObsTerm(func=mdp.object_quat_b, noise=Unoise(n_min=-0.0, n_max=0.0))
+        object_lift_height = ObsTerm(func=mdp.object_height_delta, noise=Unoise(n_min=-0.0, n_max=0.0))
+
+        def __post_init__(self):
+            self.enable_corruption = True
+            self.concatenate_terms = True
+            self.history_length = 0
+
+    @configclass
+    class PrivilegedObsCfg(dexverse_base_env.ObservationsCfg.PrivilegedObsCfg):
+        object_lin_vel_b = ObsTerm(func=mdp.object_lin_vel_b, noise=Unoise(n_min=-0.0, n_max=0.0))
+        object_ang_vel_b = ObsTerm(func=mdp.object_ang_vel_b, noise=Unoise(n_min=-0.0, n_max=0.0))
+
+    state: StateObsCfg = StateObsCfg()
+    privileged: PrivilegedObsCfg = PrivilegedObsCfg()
+
+
+@configclass
+class BimanualLiftTerminationsCfg(dexverse_base_env.TerminationsCfg):
+    """Bounding-box termination + height-based success."""
+
+    object_out_of_bound = DoneTerm(
+        func=mdp.out_of_bound,
+        params={
+            "in_bound_range": {"x": (-1.0, 1.0), "y": (-1.0, 1.0), "z": (-0.2, 1.5)},
+            "asset_cfg": SceneEntityCfg("object"),
+        },
+    )
+
+    success = DoneTerm(
+        func=mdp.object_lifted,
+        params={
+            "asset_cfg": SceneEntityCfg("object"),
+            # overwritten from lift_height in __post_init__
+            "min_height": 0.2,
+        },
+    )
+
+
+@configclass
+class BimanualLiftEventCfg(dexverse_base_env.EventCfg):
+    """Syncs the success marker to the object spawn at each reset."""
+
+    reset_success_marker = EventTerm(
+        func=mdp.sync_object,
+        mode="reset",
+        params={
+            "target_cfg": SceneEntityCfg("success_marker"),
+            "source_cfg": SceneEntityCfg("object"),
+            # overwritten from lift_height in __post_init__
+            "z_offset": 0.2,
+            "quat": SUCCESS_MARKER_QUAT,
+        },
+    )
+
+
+@configclass
+class BimanualLiftObjectEnvCfg(dexverse_base_env.DexVerseBaseEnvCfg):
+    """Robot-agnostic base for bimanual coordinated lift tasks.
+
+    Concrete tasks set ``usd_path`` and tune scale / mass / geometry.
+    """
+
+    # Object parameters -- subclasses should override.
+    usd_path: str = ""
+    scale: tuple[float, float, float] = (1.0, 1.0, 1.0)
+    mass: float = 0.5
+    object_half_height: float = 0.05
+    """Distance from the mesh root to the geometric bottom (meters).
+
+    Used together with ``table_clearance`` to place the object flush on the
+    tabletop.  For USDs whose root is at the geometric centre, set this to
+    half the object height; otherwise tune until the object sits cleanly.
+    """
+    table_clearance: float = 0.0
+    """Extra lift above the estimated bottom (meters)."""
+    object_init_rot: tuple[float, float, float, float] = (1.0, 0.0, 0.0, 0.0)
+    object_init_x_offset: float = 0.0
+    object_init_y_offset: float = 0.0
+
+    # Task parameters.
+    lift_height: float = 0.15
+    """Height above the reset pose that marks success (meters)."""
+
+    # ---- Object reset randomization (per-axis ranges) ----
+    # ``obj_y_range`` and ``obj_yaw_range`` keep their historical defaults so
+    # existing configs are unaffected. The remaining axes default to no
+    # randomization; subclasses can override.
+    obj_x_range: tuple[float, float] = (0.0, 0.0)
+    obj_y_range: tuple[float, float] = (-0.1, 0.1)
+    obj_z_range: tuple[float, float] = (0.0, 0.0)
+    obj_roll_range: tuple[float, float] = (0.0, 0.0)
+    obj_pitch_range: tuple[float, float] = (0.0, 0.0)
+    obj_yaw_range: tuple[float, float] = (-0.2, 0.2)
+
+    episode_length_s_override: float = 10.0
+
+    observations: BimanualLiftObservationsCfg = BimanualLiftObservationsCfg()
+    rewards: BimanualLiftRewardsCfg = DenseBimanualLiftRewardsCfg()
+    terminations: BimanualLiftTerminationsCfg = BimanualLiftTerminationsCfg()
+    events: BimanualLiftEventCfg = BimanualLiftEventCfg()
+
+    @configclass
+    class BimanualLiftSceneCfg(dexverse_base_env.SceneCfg):
+        object: RigidObjectCfg | None = None
+        success_marker: RigidObjectCfg = SUCCESS_MARKER_CFG
+        wrist_camera: TiledCameraCfg | None = None
+        right_wrist_camera: TiledCameraCfg = TiledCameraCfg(
+            prim_path="{ENV_REGEX_NS}/Robot/rh_palm/wrist_cam",
+            update_period=0.0,
+            width=256,
+            height=256,
+            data_types=["rgb", "distance_to_image_plane"],
+            spawn=sim_utils.PinholeCameraCfg(
+                focal_length=24.0,
+                focus_distance=400.0,
+                horizontal_aperture=20.955,
+                clipping_range=(0.01, 2.0),
+            ),
+            offset=TiledCameraCfg.OffsetCfg(
+                pos=(0.0, -0.1355, -0.1875),
+                rot=(0.0, 0.0, 0.04997916927067833, 0.9987502603949663),
+                convention="ros",
+            ),
+        )
+        left_wrist_camera: TiledCameraCfg = TiledCameraCfg(
+            prim_path="{ENV_REGEX_NS}/Robot/lh_palm/wrist_cam",
+            update_period=0.0,
+            width=256,
+            height=256,
+            data_types=["rgb", "distance_to_image_plane"],
+            spawn=sim_utils.PinholeCameraCfg(
+                focal_length=24.0,
+                focus_distance=400.0,
+                horizontal_aperture=20.955,
+                clipping_range=(0.01, 2.0),
+            ),
+            offset=TiledCameraCfg.OffsetCfg(
+                pos=(0.0, -0.1355, -0.1875),
+                rot=(0.0, 0.0, 0.04997916927067833, 0.9987502603949663),
+                convention="ros",
+            ),
+        )
+
+    scene: BimanualLiftSceneCfg = BimanualLiftSceneCfg(
+        num_envs=4096,
+        env_spacing=3,
+        replicate_physics=False,
+        success_marker=SUCCESS_MARKER_CFG,
+    )
+
+    def __post_init__(self):
+        if not self.usd_path:
+            raise ValueError(f"{type(self).__name__}: `usd_path` must be set before __post_init__.")
+
+        # Build the object scene entity so the base class sees it.
+        self.scene.object = make_lift_object_cfg(
+            usd_path=self.usd_path,
+            scale=self.scale,
+            mass=self.mass,
+            init_rot=self.object_init_rot,
+        )
+
+        super().__post_init__()
+
+        self.episode_length_s = self.episode_length_s_override
+        if hasattr(self.commands, "object_pose"):
+            self.commands.object_pose = None
+
+        # Some imported USDs do not support dynamic material randomisation.
+        self.events.object_physics_material = None
+
+        # Place the object flush on the table surface (apply xy offsets).
+        table_top_z = dexverse_base_env.DEFAULT_TABLE_TOP_HEIGHT
+        target_z = table_top_z + self.object_half_height + self.table_clearance
+        ox, oy, _ = self.scene.object.init_state.pos
+        spawn_x = ox + self.object_init_x_offset
+        spawn_y = oy + self.object_init_y_offset
+        self.scene.object.init_state.pos = (spawn_x, spawn_y, target_z)
+        self.scene.success_marker.init_state.pos = (
+            spawn_x,
+            spawn_y,
+            target_z + self.lift_height,
+        )
+        self.scene.success_marker.init_state.rot = SUCCESS_MARKER_QUAT
+
+        # Clamp out-of-bound range to the table footprint.
+        if self.terminations.object_out_of_bound is not None:
+            table_size = self.scene.table.spawn.size
+            self.terminations.object_out_of_bound.params["in_bound_range"] = {
+                "x": (-table_size[0] * 0.5, table_size[0] * 0.5),
+                "y": (-table_size[1] * 0.5, table_size[1] * 0.5),
+                "z": (-0.2, 1.5),
+            }
+
+        # Propagate lift height into success termination and marker reset.
+        self.terminations.success.params["min_height"] = self.lift_height
+        self.events.reset_success_marker.params["z_offset"] = self.lift_height
+
+        # Reset-time pose randomisation for the object.
+        if self.events.reset_object is not None:
+            self.events.reset_object.params["pose_range"] = {
+                "x": list(self.obj_x_range),
+                "y": list(self.obj_y_range),
+                "z": list(self.obj_z_range),
+                "roll": list(self.obj_roll_range),
+                "pitch": list(self.obj_pitch_range),
+                "yaw": list(self.obj_yaw_range),
+            }
+
+        # Contact sensors covering all fingertips of both hands.
+        mdp.setup_fingertip_contact_observation(self)
+        wire_bimanual_reward_fingertips(self.rewards, self.robot_config.fingertip_body_names)
+
+        # Grade the dense lift terms toward the same height success requires.
+        lift_term = getattr(self.rewards, "object_lift_height", None)
+        if lift_term is not None and lift_term.params.get("min_height", 0.0) != 0.0:
+            lift_term.params["min_height"] = self.lift_height
+        grasp_lift = getattr(self.rewards, "bimanual_grasp_lift", None)
+        if grasp_lift is not None:
+            grasp_lift.params["min_height"] = self.lift_height
+
+        # Success remains pure height-based for bimanual lift tasks.
+
+
+@configclass
+class BimanualLiftObjectEnvFloatingShadowBimanualCfg(BimanualLiftObjectEnvCfg):
+    """Bimanual lift concrete config using the floating Shadow bimanual hand."""
+
+    robot_type: str = "floating_shadow_bimanual"
+    xr: XrCfg = DEFAULT_FLOATING_SHADOW_XR_CFG
+
+    def __post_init__(self):
+        super().__post_init__()
+        setup_floating_teleop(self)

--- a/source/dexverse/dexverse/baseline_v1/config/bimanual/carton_face_cue.py
+++ b/source/dexverse/dexverse/baseline_v1/config/bimanual/carton_face_cue.py
@@ -1,0 +1,62 @@
+# Copyright (c) 2025-2026, The DexVerse Project Developers.
+# All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Task geometry for the carton's recorded target face, visible in RGB/depth."""
+
+import torch
+from isaaclab.managers import ManagerTermBase, SceneEntityCfg
+
+
+class CartonFaceCornerCue(ManagerTermBase):
+    """Four ordinary, non-colliding spheres parented to the carton rigid body.
+
+    Parenting follows both physics and set-state replay without per-step world
+    transforms or Fabric changes. Only a changed/restored face choice updates
+    local offsets. That choice is already recorded as an episode task buffer.
+    """
+
+    def __init__(self, cfg, env):
+        super().__init__(cfg, env)
+        import isaaclab.sim as sim_utils
+        import omni.usd
+        from pxr import Gf, Usd, UsdGeom
+
+        self._buffer_name = cfg.params["buffer_name"]
+        self._points = cfg.params["points_per_choice"]
+        obj = env.scene[cfg.params["object_cfg"].name]
+        stage = omni.usd.get_context().get_stage()
+        sphere_cfg = sim_utils.SphereCfg(
+            radius=cfg.params["radius"],
+            visual_material=sim_utils.PreviewSurfaceCfg(diffuse_color=cfg.params["color"]),
+        )
+        self._translations = []
+        for body_path in obj.root_physx_view.prim_paths:
+            # Local geometry constants are in metres after carton scaling.
+            # Remove inherited scale for the cue, retaining rigid-body pose.
+            body = stage.GetPrimAtPath(body_path)
+            transform = Gf.Transform(UsdGeom.Xformable(body).ComputeLocalToWorldTransform(Usd.TimeCode.Default()))
+            scale = tuple(float(value) for value in transform.GetScale())
+            root = UsdGeom.Xform.Define(stage, f"{body_path}/TargetFaceCorners")
+            root.AddScaleOp().Set(Gf.Vec3f(*(1.0 / value for value in scale)))
+            ops = []
+            for index in range(4):
+                prim = sphere_cfg.func(f"{root.GetPath()}/Corner_{index}", sphere_cfg)
+                ops.append(next(op for op in UsdGeom.Xformable(prim).GetOrderedXformOps()
+                                if op.GetOpType() == UsdGeom.XformOp.TypeTranslate))
+            self._translations.append(ops)
+        self._last_choice = [-1] * env.num_envs
+        self(env, **cfg.params)
+
+    def __call__(self, env, points_per_choice: list, buffer_name: str,
+                 object_cfg: SceneEntityCfg, radius: float, color: tuple) -> torch.Tensor:
+        from pxr import Gf
+
+        choice = getattr(env, self._buffer_name, None)
+        choices = [0] * env.num_envs if choice is None else choice.detach().cpu().tolist()
+        for index, face in enumerate(choices):
+            if face != self._last_choice[index]:
+                for op, point in zip(self._translations[index], self._points[face], strict=True):
+                    op.Set(Gf.Vec3d(*point))
+                self._last_choice[index] = face
+        return torch.zeros(env.num_envs, 0, device=env.device)

--- a/source/dexverse/dexverse/baseline_v1/config/bimanual/carton_regrasp_cfg.py
+++ b/source/dexverse/dexverse/baseline_v1/config/bimanual/carton_regrasp_cfg.py
@@ -1,0 +1,277 @@
+# Copyright (c) 2025-2026, The DexVerse Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Bimanual carton hold by a per-episode **target face** into a goal box.
+
+The plain :mod:`lift_carton_cfg` only asks for the box to rise, which any fixed
+two-hand hold satisfies. Here every episode draws ONE target face of the carton
+(``[+x, -x, +y, -y, +z, -z]`` of the box frame, marked by four red spheres). Contact is not
+restricted; the sampled face specifies which face must point down at the goal.
+
+The goal is a **carton-shaped cue in the air**: an invisible goal frame is
+snapped next to the carton's spawn (small offset, mostly toward the hands) and
+a cue box -- the carton's own shape enlarged to ``goal_cue_scale`` (0.85 vs the
+carton's 0.65), oriented for the required pose -- floats ``goal_center_height``
+above it. Success = the carton's centre inside the cue's slack (it fits when
+correctly oriented), its yaw within ``yaw_tol_deg`` of the cue's (a cuboid),
+**standing on its target face** (that face's normal points down within
+``upright_tol_deg`` -- so a sideways friction pinch never counts), slowly,
+for ``hold_steps`` consecutive env steps.
+Eight green spheres mark the cue's corners (camera-visible, per-episode
+orientation -- a vision-policy landmark).
+
+Success :func:`mdp.object_fit_in_cue_success`; failure: box out of
+bounds. Rewards are inherited from the bimanual lift base (reach + lift
+shaping); a task-specific dense preset (goal-box shaping) is TODO before RL.
+"""
+
+from __future__ import annotations
+
+import math
+
+import isaaclab.sim as sim_utils
+from isaaclab.assets import RigidObjectCfg
+from isaaclab.managers import EventTermCfg as EventTerm
+from isaaclab.managers import ObservationGroupCfg as ObsGroup
+from isaaclab.managers import ObservationTermCfg as ObsTerm
+from isaaclab.managers import SceneEntityCfg
+from isaaclab.utils import configclass
+from isaaclab.utils.noise import UniformNoiseCfg as Unoise
+
+from ... import dexverse_base_env_cfg as dexverse_base_env
+from ... import mdp
+from .carton_face_cue import CartonFaceCornerCue
+from .lift_carton_cfg import LiftCartonEnvFloatingShadowBimanualCfg
+
+# Carton (model_carton.usd) in the object frame (root on the bottom face,
+# footprint centred). At unit scale: x in [-0.199, 0.203], y in [-0.235, 0.236],
+# z in [0, 0.285]; this task uses ``CARTON_SCALE`` (0.65 -- slightly smaller
+# than the lift task's 0.75, teleop feedback Aug 2026) and derives every
+# dimension from it.
+CARTON_SCALE = 0.65
+_UNIT_HALF_X, _UNIT_HALF_Y, _UNIT_HEIGHT = 0.150 / 0.75, 0.176 / 0.75, 0.214 / 0.75
+_UNIT_CENTER_XY = (0.0015 / 0.75, 0.0005 / 0.75)
+CARTON_HALF_X, CARTON_HALF_Y, CARTON_HEIGHT = _UNIT_HALF_X * CARTON_SCALE, _UNIT_HALF_Y * CARTON_SCALE, _UNIT_HEIGHT * CARTON_SCALE
+CARTON_CENTER_XY = (_UNIT_CENTER_XY[0] * CARTON_SCALE, _UNIT_CENTER_XY[1] * CARTON_SCALE)
+# Four non-colliding red spheres mark the selected face's rectangle. Their
+# centres sit at its corners, exposing a 2 cm radius silhouette to depth/XYZ.
+FACE_CORNER_RADIUS = 0.020
+_cx, _cy, _cz = CARTON_CENTER_XY[0], CARTON_CENTER_XY[1], CARTON_HEIGHT / 2.0
+_HALF = {"x": CARTON_HALF_X, "y": CARTON_HALF_Y, "z": CARTON_HEIGHT / 2.0}
+_CENTER = {"x": _cx, "y": _cy, "z": _cz}
+# faces ordered [+x, -x, +y, -y, +z, -z]
+_FACES = [("x", +1), ("x", -1), ("y", +1), ("y", -1), ("z", +1), ("z", -1)]
+_AXES = ("x", "y", "z")
+GRASP_FACE_BUFFER = "carton_grasp_face"
+
+
+def _vec(**kw):
+    return tuple(kw.get(a, 0.0) for a in _AXES)
+
+
+def _face_corners() -> list:
+    """Four object-frame corners per target face, ordered [+x,-x,+y,-y,+z,-z]."""
+    out = []
+    for axis, sign in _FACES:
+        others = [a for a in _AXES if a != axis]
+        corners = []
+        for first in (-1, 1):
+            for second in (-1, 1):
+                c = dict(_CENTER)
+                c[axis] += sign * _HALF[axis]
+                c[others[0]] += first * _HALF[others[0]]
+                c[others[1]] += second * _HALF[others[1]]
+                corners.append(_vec(**c))
+        out.append(corners)
+    return out
+
+
+# Object-frame outward normal of each face (must point DOWN at the goal).
+DOWN_NORMAL_PER_FACE = [_vec(**{axis: float(sign)}) for axis, sign in _FACES]
+# Object-frame axis that maps to the goal frame's +x in the required pose (see
+# ``cue_half_extents_per_face``): carton z for +-x faces, carton x otherwise.
+HORIZONTAL_AXIS_PER_FACE = [_vec(z=1.0) if axis == "x" else _vec(x=1.0) for axis, _ in _FACES]
+
+
+def cue_half_extents_per_face(cue_scale: float) -> list:
+    """Half extents (goal frame, world-aligned) of the carton-shaped cue at
+    ``cue_scale`` for each target face being the bottom: the face's axis is
+    vertical; the other two carton axes map to world x/y as (x->x, y->y) for
+    +-z, (z->x, y->y) for +-x and (x->x, z->y) for +-y."""
+    r = cue_scale / CARTON_SCALE
+    hx, hy, hz = CARTON_HALF_X * r, CARTON_HALF_Y * r, CARTON_HEIGHT / 2.0 * r
+    out = []
+    for axis, _ in _FACES:
+        if axis == "x":
+            out.append((hz, hy, hx))
+        elif axis == "y":
+            out.append((hx, hz, hy))
+        else:
+            out.append((hx, hy, hz))
+    return out
+FACE_CORNERS_PER_FACE = _face_corners()
+
+# Invisible, non-colliding goal frame on the table; the goal box hangs above it.
+GOAL_FRAME_CFG = RigidObjectCfg(
+    prim_path="{ENV_REGEX_NS}/GoalFrame",
+    spawn=sim_utils.CuboidCfg(
+        size=(0.02, 0.02, 0.004),
+        rigid_props=sim_utils.RigidBodyPropertiesCfg(rigid_body_enabled=True, kinematic_enabled=True, disable_gravity=True),
+        collision_props=sim_utils.CollisionPropertiesCfg(collision_enabled=False),
+        visual_material=sim_utils.PreviewSurfaceCfg(diffuse_color=(0.15, 0.75, 0.25)),
+        visible=False,
+    ),
+    init_state=RigidObjectCfg.InitialStateCfg(pos=(0.0, 0.0, 0.0), rot=(1.0, 0.0, 0.0, 0.0)),
+)
+
+
+@configclass
+class CartonRegraspEnvFloatingShadowBimanualCfg(LiftCartonEnvFloatingShadowBimanualCfg):
+    """Place the carton on the sampled target face inside the aerial goal box."""
+
+    # Slightly smaller carton than the lift task.
+    scale: tuple[float, float, float] = (CARTON_SCALE, CARTON_SCALE, CARTON_SCALE)
+
+    # Box upright on the table, random position and yaw.
+    obj_x_range: tuple[float, float] = (-0.05, 0.10)
+    obj_y_range: tuple[float, float] = (-0.15, 0.15)
+    obj_yaw_range: tuple[float, float] = (-math.pi, math.pi)
+
+    # Per-face sampling weights [+x, -x, +y, -y, +z, -z]; the bottom face (-z)
+    # can only be held from below, the top (+z) from above.
+    grasp_face_weights: tuple[float, ...] = (1.0, 1.0, 1.0, 1.0, 1.0, 1.0)
+    # ---- goal box (goal-frame coordinates; the frame sits on the table) ----
+    # The frame is snapped next to the carton's spawn every reset (a small
+    # world-frame offset, mostly toward the hands): the task is about bimanual
+    # coordination on the target face, not about carrying the box across the
+    # table (teleop feedback, Aug 2026). Offsets are from the carton root.
+    goal_init_x: float = 0.0
+    goal_init_y: float = 0.0
+    goal_offset_x_range: tuple[float, float] = (-0.10, 0.0)
+    goal_offset_y_range: tuple[float, float] = (-0.08, 0.08)
+    # Carton-shaped cue: the carton's own shape at ``goal_cue_scale`` (vs
+    # CARTON_SCALE 0.65), centred ``goal_center_height`` above the goal frame,
+    # oriented for the required "target face down" pose. Success = the
+    # carton's centre within the cue's slack (cue half - carton half: at 0.85
+    # about +-4.0 / 4.7 / 2.9 cm per axis) + the target face's normal within
+    # ``upright_tol_deg`` of straight down + the carton's horizontal axis within
+    # ``yaw_tol_deg`` of the cue's (the cue is a cuboid) + slow, for hold_steps
+    # consecutive env steps. Relaxed from 0.70 / 20 deg / 0.10 m/s (no successes
+    # in teleop, Aug 2026); position, yaw and tilt are gated separately.
+    goal_cue_scale: float = 0.85
+    goal_center_height: float = 0.22
+    upright_tol_deg: float = 35.0
+    yaw_tol_deg: float = 25.0
+    goal_max_lin_speed: float = 0.15
+    hold_steps: int = 30
+    # Visual cue only: 8 spheres at the cue box corners (per-episode shape).
+    goal_corner_marker_radius: float = 0.02
+    episode_length_s_override: float = 20.0
+
+    def __post_init__(self):
+        table_top_z = dexverse_base_env.DEFAULT_TABLE_TOP_HEIGHT
+        self.scene.goal_frame = GOAL_FRAME_CFG.replace(
+            init_state=RigidObjectCfg.InitialStateCfg(pos=(self.goal_init_x, self.goal_init_y, table_top_z + 0.002), rot=(1.0, 0.0, 0.0, 0.0))
+        )
+        super().__post_init__()
+
+        # --- per-episode target face (sampled before anything reads it) ---------
+        self.events.sample_grasp_face = EventTerm(
+            func=mdp.sample_env_choice,
+            mode="reset",
+            params={"buffer_name": GRASP_FACE_BUFFER, "num_choices": 6, "weights": list(self.grasp_face_weights)},
+        )
+        # --- goal frame: snapped next to the carton after its reset (appended
+        # events run later), world-aligned, at the carton's bottom height ----------
+        self.events.reset_goal_frame = EventTerm(
+            func=mdp.sync_object,
+            mode="reset",
+            params={
+                "target_cfg": SceneEntityCfg("goal_frame"),
+                "source_cfg": SceneEntityCfg("object"),
+                "z_offset": 0.0,
+                "quat": (1.0, 0.0, 0.0, 0.0),
+                "xy_jitter_range": {"x": list(self.goal_offset_x_range), "y": list(self.goal_offset_y_range)},
+            },
+        )
+
+        # --- success: carton fits the cue, standing on the target face + slow ---
+        cue_half = cue_half_extents_per_face(self.goal_cue_scale)
+        cue_center = (0.0, 0.0, self.goal_center_height)
+        self.terminations.success.func = mdp.object_fit_in_cue_success
+        self.terminations.success.params = {
+            "cue_half_extents_per_choice": cue_half,
+            "object_half_extents_per_choice": cue_half_extents_per_face(CARTON_SCALE),
+            "down_normals_per_choice": DOWN_NORMAL_PER_FACE,
+            "horizontal_axes_per_choice": HORIZONTAL_AXIS_PER_FACE,
+            "object_center_local": (_cx, _cy, _cz),
+            "buffer_name": GRASP_FACE_BUFFER,
+            "goal_cfg": SceneEntityCfg("goal_frame"),
+            "cue_center_local": cue_center,
+            "object_cfg": SceneEntityCfg("object"),
+            "upright_cos": math.cos(math.radians(self.upright_tol_deg)),
+            "yaw_cos": math.cos(math.radians(self.yaw_tol_deg)),
+            "max_lin_speed": self.goal_max_lin_speed,
+            "hold_steps": self.hold_steps,
+        }
+        # Lift-height reward / marker graded to the cue's root height for an
+        # upright carton; the base's lift marker itself is hidden (the corner
+        # spheres are the goal).
+        self.lift_height = max(self.goal_center_height - CARTON_HEIGHT / 2.0, 0.05)
+        self.events.reset_success_marker.params["z_offset"] = self.lift_height
+        self.scene.success_marker.spawn.visible = False
+
+        # --- observations: target face + goal box in ``goal`` ---------------------
+        @configclass
+        class GoalObsCfg(ObsGroup):
+            grasp_face = ObsTerm(
+                func=mdp.env_choice_one_hot,
+                params={"buffer_name": GRASP_FACE_BUFFER, "num_choices": 6},
+                noise=Unoise(n_min=-0.0, n_max=0.0),
+            )
+            goal_frame_pos_b = ObsTerm(func=mdp.asset_pos_b, params={"asset_cfg": SceneEntityCfg("goal_frame")}, noise=Unoise(n_min=-0.0, n_max=0.0))
+            goal_height_above_frame = ObsTerm(func=mdp.scalar_obs, params={"value": self.goal_center_height})
+
+            def __post_init__(self):
+                self.enable_corruption = True
+                self.concatenate_terms = True
+                self.history_length = 0
+
+        self.observations.goal = GoalObsCfg()
+
+        # --- target face (red spheres) + goal-box corners: camera-visible -----
+        self.add_scene_vis_term(
+            "graspable_face",
+            ObsTerm(
+                func=CartonFaceCornerCue,
+                params={
+                    "points_per_choice": FACE_CORNERS_PER_FACE,
+                    "buffer_name": GRASP_FACE_BUFFER,
+                    "object_cfg": SceneEntityCfg("object"),
+                    "radius": FACE_CORNER_RADIUS,
+                    "color": (0.9, 0.03, 0.03),
+                },
+            ),
+        )
+        corners_per_face = [
+            [(cue_center[0] + sx * h[0], cue_center[1] + sy * h[1], cue_center[2] + sz * h[2]) for sx in (-1.0, 1.0) for sy in (-1.0, 1.0) for sz in (-1.0, 1.0)]
+            for h in cue_half
+        ]
+        self.add_scene_vis_term(
+            "goal_box_corners",
+            ObsTerm(
+                func=mdp.env_choice_points_vis,
+                params={
+                    "asset_cfg": SceneEntityCfg("goal_frame"),
+                    "buffer_name": GRASP_FACE_BUFFER,
+                    "points_per_choice": corners_per_face,
+                    "radius": self.goal_corner_marker_radius,
+                    "color": (0.15, 0.75, 0.25),
+                    "opacity": 1.0,
+                    "prim_path": "/Visuals/CartonGoalCorners",
+                    "hide_from_cameras": False,
+                },
+            ),
+        )

--- a/source/dexverse/dexverse/baseline_v1/config/bimanual/lift_carton_cfg.py
+++ b/source/dexverse/dexverse/baseline_v1/config/bimanual/lift_carton_cfg.py
@@ -1,0 +1,37 @@
+# Copyright (c) 2025-2026, The DexVerse Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Bimanual lift of a carton (functional/carton001)."""
+
+
+from dexverse.assets import SYNTHESIS_DIR
+from isaaclab.utils import configclass
+
+from .base_cfg import BimanualLiftObjectEnvFloatingShadowBimanualCfg
+
+CARTON_USD_PATH = str(SYNTHESIS_DIR / "carton001" / "model_carton.usd")
+
+
+@configclass
+class LiftCartonEnvFloatingShadowBimanualCfg(BimanualLiftObjectEnvFloatingShadowBimanualCfg):
+    """Lift a carton off the tabletop with two Shadow hands."""
+
+    usd_path: str = CARTON_USD_PATH
+    scale: tuple[float, float, float] = (0.75, 0.75, 0.75)
+    mass: float = 0.6
+    # Reset audit (Aug 2026): the carton root is on its bottom face; it used to spawn
+    # 4 cm up and drop. Seat it ~3 mm above the table instead.
+    object_half_height: float = 0.0
+    table_clearance: float = 0.003
+    object_init_x_offset: float = 0.1
+    object_init_y_offset: float = 0.0
+    object_init_rot: tuple[float, float, float, float] = (1.0, 0.0, 0.0, 0.0)
+    lift_height: float = 0.2
+    obj_x_range: tuple[float, float] = (0.05, 0.1)
+    obj_y_range: tuple[float, float] = (-0.1, 0.1)
+    obj_z_range: tuple[float, float] = (0.0, 0.0)
+    obj_roll_range: tuple[float, float] = (0.0, 0.0)
+    obj_pitch_range: tuple[float, float] = (0.0, 0.0)
+    obj_yaw_range: tuple[float, float] = (0.0, 0.0)

--- a/source/dexverse/dexverse/baseline_v1/config/bimanual/lift_tray_cfg.py
+++ b/source/dexverse/dexverse/baseline_v1/config/bimanual/lift_tray_cfg.py
@@ -1,0 +1,130 @@
+# Copyright (c) 2025-2026, The DexVerse Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Bimanual lift of a flat tray (synthesis/tray001).
+
+The tray carries a decorative ``micro_food`` prop (beef stew) so the scene
+reads as a real tray of food.  The food is a *separate* rigid body resting on
+the tray rather than a fixed decoration: it can slide or spill if the tray is
+tilted, which reinforces the "keep the tray level" success criterion.
+"""
+
+from dexverse.assets import SYNTHESIS_DIR
+from isaaclab.managers import EventTermCfg as EventTerm
+from isaaclab.managers import SceneEntityCfg
+from isaaclab.utils import configclass
+
+from ... import mdp
+from .base_cfg import (
+    BimanualLiftObjectEnvFloatingShadowBimanualCfg,
+    make_lift_object_cfg,
+)
+
+TRAY_USD_PATH = str(SYNTHESIS_DIR / "tray001" / "model_redtray.usd")
+TRAY_SUCCESS_MAX_TILT_RAD = 0.174532925  # 10 degrees.
+
+# --- micro_food prop placed on the tray ----------------------------------
+# Use the physics-prepped variant: it references the heavy mesh and already
+# carries a convex-hull collider, matching what ``make_lift_object_cfg``
+# expects (it re-applies the top-level rigid body and assumes collision is
+# already authored).
+FOOD_USD_PATH = str(
+    SYNTHESIS_DIR / "micro_food" / "Meshy_AI_Beef_stew_with_vegeta_0520120030_texture__convexHull_rigidprep.usd"
+)
+FOOD_SCALE: tuple[float, float, float] = (2.0, 2.0, 2.0)
+FOOD_MASS: float = 0.15
+# Lay the prop flat: its authored thin axis (y, ~2cm) becomes vertical.
+# Quaternion is 90 deg about x, ordered (w, x, y, z).
+FOOD_REST_QUAT: tuple[float, float, float, float] = (
+    0.7071067811865476,
+    0.7071067811865476,
+    0.0,
+    0.0,
+)
+# Height of the prop centre above the tray root when it is (re)seated; it
+# then settles the last centimetre onto the tray surface under gravity.
+# (reset audit, Aug 2026: was 0.03 -> the prop fell 2.3 cm onto the tray; it rests
+# ~0.7 cm above the tray root, so 0.010 leaves ~3 mm to settle)
+FOOD_Z_OFFSET: float = 0.010
+
+
+@configclass
+class LiftTrayEnvFloatingShadowBimanualCfg(BimanualLiftObjectEnvFloatingShadowBimanualCfg):
+    """Lift a flat tray off the tabletop with two Shadow hands."""
+
+    usd_path: str = TRAY_USD_PATH
+    # Tune to the authored mesh extent.  The tray meshes are typically small
+    # relative to the tabletop; scale up until the tray spans a useful area.
+    scale: tuple[float, float, float] = (1.0, 1.0, 1.0)
+    mass: float = 0.4
+    # Tray is flat; the root tends to sit on the geometric bottom.
+    # Reset audit (Aug 2026): tray root is on its bottom face; seat ~3 mm above the
+    # table instead of dropping 3 cm.
+    object_half_height: float = 0.0
+    table_clearance: float = 0.003
+    object_init_x_offset: float = 0.05
+    object_init_y_offset: float = 0.0
+    # positive 90 degrees around z-axis (yaw), w,x,y,z -- keeps the tray flat.
+    object_init_rot: tuple[float, float, float, float] = (0.7071067811865476, 0.0, 0.0, 0.7071067811865476)
+    lift_height: float = 0.2
+    # Trays are symmetric enough to allow modest yaw randomisation.
+    obj_x_range: tuple[float, float] = (-0.03, 0.03)
+    obj_y_range: tuple[float, float] = (-0.1, 0.1)
+    obj_z_range: tuple[float, float] = (0.0, 0.0)
+    obj_roll_range: tuple[float, float] = (0.0, 0.0)
+    obj_pitch_range: tuple[float, float] = (0.0, 0.0)
+    obj_yaw_range: tuple[float, float] = (-0.2, 0.2)
+
+    # Success requires both lifting the tray and keeping its top surface nearly level.
+    success_max_tilt_rad: float = TRAY_SUCCESS_MAX_TILT_RAD
+
+    def __post_init__(self):
+        super().__post_init__()
+        self.terminations.success.func = mdp.object_upright_and_lifted
+        self.terminations.success.params = {
+            "object_cfg": SceneEntityCfg("object"),
+            "min_height": self.lift_height,
+            "max_tilt_rad": self.success_max_tilt_rad,
+        }
+
+        # --- Add the micro_food prop resting on the tray ------------------
+        # A separate rigid body (prim ".../Food") so it behaves like real
+        # cargo.  ``make_lift_object_cfg`` hardcodes the ".../Object" prim
+        # path, so override it to avoid clobbering the tray.
+        food_cfg = make_lift_object_cfg(
+            usd_path=FOOD_USD_PATH,
+            scale=FOOD_SCALE,
+            mass=FOOD_MASS,
+            init_rot=FOOD_REST_QUAT,
+        )
+        food_cfg.prim_path = "{ENV_REGEX_NS}/Food"
+        # Initial (pre-first-reset) spawn: sit it just above the tray spawn
+        # pose that the base class already computed for the object.
+        ox, oy, oz = self.scene.object.init_state.pos
+        food_cfg.init_state.pos = (ox, oy, oz + FOOD_Z_OFFSET)
+        self.scene.food = food_cfg
+
+        # Re-seat the food on the (randomised) tray at every reset.  Zero its
+        # velocity first, then snap its pose onto the tray.  These run after
+        # `reset_object`/`reset_success_marker`, so the tray pose is final.
+        self.events.reset_food_velocity = EventTerm(
+            func=mdp.reset_root_state_uniform,
+            mode="reset",
+            params={
+                "pose_range": {},
+                "velocity_range": {},
+                "asset_cfg": SceneEntityCfg("food"),
+            },
+        )
+        self.events.reset_food = EventTerm(
+            func=mdp.sync_object,
+            mode="reset",
+            params={
+                "target_cfg": SceneEntityCfg("food"),
+                "source_cfg": SceneEntityCfg("object"),
+                "z_offset": FOOD_Z_OFFSET,
+                "quat": FOOD_REST_QUAT,
+            },
+        )

--- a/source/dexverse/dexverse/baseline_v1/config/bimanual/retrieve_tray_from_rack_cfg.py
+++ b/source/dexverse/dexverse/baseline_v1/config/bimanual/retrieve_tray_from_rack_cfg.py
@@ -1,0 +1,366 @@
+# Copyright (c) 2025-2026, The DexVerse Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Bimanual: retrieve a food tray from a random level of a rack and set it
+level over a target on the tabletop -- without spilling the food.
+
+Builds on :mod:`lift_tray_cfg` (same tray + loose ``food`` prop, same Shadow
+bimanual robot) and adds
+
+* a procedural multi-level **rack** (:mod:`dexverse.assets.rack_builder`, one
+  kinematic rigid body, open at the front and both sides) standing at the far
+  side of the table with the opening toward the robot; x/y/yaw jitter per reset;
+* a per-reset **spawn level**: :func:`mdp.reset_object_on_rack_level` puts the
+  tray on a uniformly chosen shelf (manifest gives every shelf-top height), the
+  food is then re-seated on the tray;
+* a flat **goal pad** on the tabletop, randomised in front of the rack;
+* success :func:`mdp.carrier_held_aloft_with_cargo` -- tray within
+  ``goal_xy_threshold`` of the pad, held in the aerial height band, level, still, food still
+  on the tray; failure :func:`mdp.cargo_off_carrier` -- food slid off / fell.
+
+Compared to the plain lift the grasp is constrained by the shelf above/below
+(only side/front access, limited clearance) and the episode needs a level carry
+plus a stable aerial hold. Rewards are inherited from the bimanual lift base for
+now (reach + lift shaping); a task-specific dense preset is TODO before RL.
+"""
+
+from __future__ import annotations
+
+import isaaclab.sim as sim_utils
+from isaaclab.assets import RigidObjectCfg
+from isaaclab.managers import EventTermCfg as EventTerm
+from isaaclab.managers import ObservationGroupCfg as ObsGroup
+from isaaclab.managers import ObservationTermCfg as ObsTerm
+from isaaclab.managers import SceneEntityCfg
+from isaaclab.managers import TerminationTermCfg as DoneTerm
+from isaaclab.utils import configclass
+from isaaclab.utils.noise import UniformNoiseCfg as Unoise
+
+from dexverse.assets.rack_builder import ensure_rack_asset
+
+from ... import dexverse_base_env_cfg as dexverse_base_env
+from ... import mdp
+from .base_cfg import SUCCESS_MARKER_QUAT, BimanualLiftObservationsCfg, BimanualLiftTerminationsCfg
+from .lift_tray_cfg import FOOD_REST_QUAT, FOOD_Z_OFFSET, LiftTrayEnvFloatingShadowBimanualCfg
+
+
+def _quat_mul_wxyz(a, b):
+    """Hamilton product of two (w, x, y, z) quaternions (a * b)."""
+    aw, ax, ay, az = a
+    bw, bx, by, bz = b
+    return (
+        aw * bw - ax * bx - ay * by - az * bz,
+        aw * bx + ax * bw + ay * bz - az * by,
+        aw * by - ax * bz + ay * bw + az * bx,
+        aw * bz + ax * by - ay * bx + az * bw,
+    )
+
+
+def food_rest_quat_yawed(yaw_rad: float) -> tuple[float, float, float, float]:
+    """``FOOD_REST_QUAT`` (lying flat) rotated by ``yaw_rad`` about the z axis.
+
+    Used as the food's orientation *in the tray's frame*: the tray asset's
+    long side is its local x, the flat-lying food's long side is its local x
+    too, so ``yaw_rad=0`` lays the food along the tray's long side.
+    """
+    import math
+
+    qz = (math.cos(yaw_rad / 2.0), 0.0, 0.0, math.sin(yaw_rad / 2.0))
+    return _quat_mul_wxyz(qz, FOOD_REST_QUAT)
+
+# ---------------------------------------------------------------------------
+# Rack (generated on first use; the assets tree is not tracked by git)
+# ---------------------------------------------------------------------------
+RACK_NAME = "rack_3level"
+# Aug 2026 (after teleop feedback): lower and smaller rack -- level spacing 0.15
+# (13 cm clearance above each shelf), 0.36 x 0.48 m footprint, lowest shelf 8 cm
+# above the table -- placed closer to the hands (see rack_init_x below).
+RACK_PARAMS = dict(levels=3, spacing=0.15, depth=0.36, width=0.48, board_thickness=0.02, post_size=0.03, bottom_gap=0.08, top_margin=0.03)
+RACK_USD_PATH, RACK_MANIFEST = ensure_rack_asset(RACK_NAME, **RACK_PARAMS)
+RACK_LEVEL_Z_TOPS: list[float] = [float(lvl["z_top"]) for lvl in RACK_MANIFEST["levels"]]
+
+# Tray footprint (asset frame, before the Rz(90) rest rotation): 0.335 x 0.265 m.
+TRAY_HALF_EXTENTS_XY: tuple[float, float] = (0.15, 0.115)  # slightly inside the rim
+GOAL_PAD_SIZE: tuple[float, float, float] = (0.30, 0.30, 0.004)
+
+
+def make_rack_cfg(usd_path: str, init_pos: tuple[float, float, float]) -> RigidObjectCfg:
+    return RigidObjectCfg(
+        prim_path="{ENV_REGEX_NS}/Rack",
+        spawn=sim_utils.UsdFileCfg(
+            func=dexverse_base_env.spawn_usd_with_rigid_properties,
+            usd_path=usd_path,
+            rigid_props=sim_utils.RigidBodyPropertiesCfg(
+                rigid_body_enabled=True,
+                kinematic_enabled=True,
+                disable_gravity=True,
+            ),
+            # collision is authored per box prim in the generated USD
+            collision_props=None,
+            mass_props=None,
+        ),
+        init_state=RigidObjectCfg.InitialStateCfg(pos=init_pos, rot=(1.0, 0.0, 0.0, 0.0)),
+    )
+
+
+GOAL_PAD_CFG = RigidObjectCfg(
+    prim_path="{ENV_REGEX_NS}/GoalPad",
+    spawn=sim_utils.CuboidCfg(
+        size=GOAL_PAD_SIZE,
+        rigid_props=sim_utils.RigidBodyPropertiesCfg(rigid_body_enabled=True, kinematic_enabled=True, disable_gravity=True),
+        collision_props=sim_utils.CollisionPropertiesCfg(collision_enabled=False),
+        visual_material=sim_utils.PreviewSurfaceCfg(diffuse_color=(0.15, 0.75, 0.25), emissive_color=(0.0, 0.15, 0.0), roughness=1.0),
+        visible=True,
+    ),
+    init_state=RigidObjectCfg.InitialStateCfg(pos=(0.0, 0.0, 0.0), rot=(1.0, 0.0, 0.0, 0.0)),
+)
+
+
+@configclass
+class RetrieveTrayObservationsCfg(BimanualLiftObservationsCfg):
+    """Lift-tray observations + rack pose / spawn level in ``state`` and the goal
+    pad position in ``goal``."""
+
+    @configclass
+    class StateObsCfg(BimanualLiftObservationsCfg.StateObsCfg):
+        rack_pos_b = ObsTerm(func=mdp.asset_pos_b, params={"asset_cfg": SceneEntityCfg("rack")}, noise=Unoise(n_min=-0.0, n_max=0.0))
+        rack_quat_b = ObsTerm(func=mdp.object_quat_b, params={"object_cfg": SceneEntityCfg("rack")}, noise=Unoise(n_min=-0.0, n_max=0.0))
+        rack_level_height = ObsTerm(func=mdp.rack_level_height, noise=Unoise(n_min=-0.0, n_max=0.0))
+        food_pos_b = ObsTerm(func=mdp.asset_pos_b, params={"asset_cfg": SceneEntityCfg("food")}, noise=Unoise(n_min=-0.0, n_max=0.0))
+
+    @configclass
+    class GoalObsCfg(ObsGroup):
+        goal_pad_pos_b = ObsTerm(func=mdp.asset_pos_b, params={"asset_cfg": SceneEntityCfg("goal_pad")}, noise=Unoise(n_min=-0.0, n_max=0.0))
+
+        def __post_init__(self):
+            self.enable_corruption = True
+            self.concatenate_terms = True
+            self.history_length = 0
+
+    state: StateObsCfg = StateObsCfg()
+    goal: GoalObsCfg = GoalObsCfg()
+
+
+@configclass
+class RetrieveTrayEventCfg(dexverse_base_env.EventCfg):
+    """Reset order matters: rack -> tray on a level of the rack -> goal pad ->
+    food re-seated on the tray -> (invisible) success marker."""
+
+    reset_object = None  # replaced by reset_tray_on_rack below
+
+    # Rack anywhere in a band across the far half of the table (offsets from its
+    # init pose), always turned so its open front faces the hands' start position
+    # (midpoint of the two palms at their reset pose -- a fixed env-frame point,
+    # set from ``rack_face_point`` in __post_init__), plus a little yaw jitter.
+    reset_rack = EventTerm(
+        func=mdp.reset_root_pose_uniform_facing,
+        mode="reset",
+        params={
+            "asset_cfg": SceneEntityCfg("rack"),
+            "pose_range": {"x": [-0.03, 0.03], "y": [-0.22, 0.22], "z": [0.0, 0.0]},
+            "face_asset_cfg": None,
+            "face_point": (-0.25, 0.0),
+            "open_dir_local": (-1.0, 0.0),
+            "yaw_jitter": (-0.1, 0.1),
+        },
+    )
+    reset_tray_on_rack = EventTerm(
+        func=mdp.reset_object_on_rack_level,
+        mode="reset",
+        params={
+            "asset_cfg": SceneEntityCfg("object"),
+            "rack_cfg": SceneEntityCfg("rack"),
+            "level_z_tops": RACK_LEVEL_Z_TOPS,
+            "level_x_range": (-0.05, -0.01),  # toward the shelf front (open side is -x): closer to the hands
+            "level_y_range": (-0.04, 0.04),
+            "yaw_range": (-0.1, 0.1),
+            "z_offset": 0.03,  # tray root-to-bottom + clearance, overwritten in __post_init__
+        },
+    )
+    reset_goal_pad = EventTerm(
+        func=mdp.reset_root_pose_uniform_excluding,
+        mode="reset",
+        params={
+            "asset_cfg": SceneEntityCfg("goal_pad"),
+            # offsets from the pad's init pose (env origin, on the tabletop); rejection-
+            # sampled to stay clear of the (randomly placed, yawed) rack footprint.
+            # Band pulled toward the rack (teleop feedback Aug 2026) for a shorter carry.
+            "pose_range": {"x": [-0.28, -0.02], "y": [-0.30, 0.30], "z": [0.0, 0.0], "roll": [0.0, 0.0], "pitch": [0.0, 0.0], "yaw": [0.0, 0.0]},
+            "reference_asset_cfg": SceneEntityCfg("rack"),
+            "min_xy_distance": 0.35,  # rack front face 0.18 + pad half 0.15 + 2 cm slack
+            "max_attempts": 40,
+        },
+    )
+    # placeholders: lift_tray_cfg.__post_init__ assigns the real terms (order kept)
+    reset_food_velocity = EventTerm(func=mdp.reset_root_state_uniform, mode="reset", params={"pose_range": {}, "velocity_range": {}, "asset_cfg": SceneEntityCfg("food")})
+    reset_food = EventTerm(func=mdp.sync_object, mode="reset", params={"target_cfg": SceneEntityCfg("food"), "source_cfg": SceneEntityCfg("object"), "z_offset": FOOD_Z_OFFSET, "quat": FOOD_REST_QUAT})
+    reset_success_marker = EventTerm(
+        func=mdp.sync_object,
+        mode="reset",
+        params={"target_cfg": SceneEntityCfg("success_marker"), "source_cfg": SceneEntityCfg("object"), "z_offset": 0.2, "quat": SUCCESS_MARKER_QUAT},
+    )
+
+
+@configclass
+class RetrieveTrayTerminationsCfg(BimanualLiftTerminationsCfg):
+    cargo_dropped = DoneTerm(
+        func=mdp.cargo_off_carrier,
+        params={
+            "cargo_cfg": SceneEntityCfg("food"),
+            "carrier_cfg": SceneEntityCfg("object"),
+            "carrier_half_extents_xy": TRAY_HALF_EXTENTS_XY,
+            "z_min": -0.03,
+            "z_max": 0.20,
+        },
+    )
+
+
+@configclass
+class RetrieveTrayFromRackEnvFloatingShadowBimanualCfg(LiftTrayEnvFloatingShadowBimanualCfg):
+    """Retrieve the loaded tray and hold it level in the goal region above the pad."""
+
+    # ---- rack placement (env frame; the rack's -x face is the open front) ----
+    # Band centre; reset_rack samples x +-0.05, y +-0.25 around it and aims the open
+    # front at the hands' start. With the smaller rack (0.36 x 0.48) this band keeps
+    # the front posts >= ~6 cm from the fingertips at their start pose and the far
+    # corners on the table (audit-checked, Aug 2026).
+    # Moved closer to the hands (0.29 -> 0.26, teleop feedback Aug 2026); the tighter
+    # x/y jitter above caps the aim yaw so the front posts stay clear of the
+    # fingertips' start pose (audit-checked).
+    # Pulled closer again (0.27 -> 0.25, teleop feedback Aug 2026); audit-checked
+    # against the palms' start pose.
+    rack_init_x: float = 0.25
+    rack_init_y: float = 0.0
+    # PhysX collision offsets authored on the tray's collision meshes at spawn
+    # (shared ``author_collision_offsets`` mechanism, same as the articulation
+    # tasks' ``articulation_contact_offset``): ``tray_contact_offset`` is the
+    # distance at which contacts are generated, ``tray_rest_offset`` lifts the
+    # effective resting surface above the visual mesh.
+    tray_contact_offset: float | None = 0.02
+    tray_rest_offset: float | None = 0.002
+    # Food heading ON THE TRAY (tray-frame yaw, rad). The food is re-seated
+    # with ``sync_object(quat_local=...)`` so it follows the tray's yaw on the
+    # rack; 0 lays the 23.6 cm prop along the tray's 33.5 cm long side. The
+    # previous world-fixed placement had it across the tray's 26.5 cm short
+    # side (inner bed ~23 cm) -> it overlapped the rim at spawn (teleop
+    # feedback, Aug 2026); relative to that, 0 here is the requested 90 deg
+    # turn. Applied to the spawn pose too.
+    food_yaw_offset_rad: float = 0.0
+    # Seat height of the food root above the tray root at spawn / re-seat.
+    # Laid in the bed (not propped on the rim) the prop rests ~2 mm above the
+    # tray root, so 5 mm leaves ~3 mm to settle under gravity (audit, Aug 2026;
+    # the parent's 10 mm was tuned for the rim-propped rest height).
+    food_z_offset: float = 0.005
+    # Env-frame point the rack's open front is aimed at: the hands' start (midpoint of
+    # the two Shadow palms at their reset pose, x=-0.25, y=+-0.3). Body poses are not
+    # refreshed between reset events, so this is a fixed point rather than a live read.
+    rack_face_point: tuple[float, float] = (-0.25, 0.0)
+    # ---- task thresholds (in-air hold goal) ----
+    # The goal is to HOLD the tray level in the air over the pad, not to set it
+    # down (a table pad was too easy to slam onto; teleop feedback Aug 2026):
+    # tray root within ``goal_xy_threshold`` of the pad centre, between
+    # ``goal_z_above_pad`` above the pad root, tilt < ``goal_max_tilt_rad``,
+    # slow, food aboard -- for ``goal_hold_steps`` consecutive env steps.
+    goal_xy_threshold: float = 0.08
+    goal_z_above_pad: tuple[float, float] = (0.12, 0.28)
+    goal_hold_steps: int = 30
+    goal_max_tilt_rad: float = 0.174532925  # 10 deg, same as the lift-tray level gate
+    goal_max_lin_speed: float = 0.10
+    goal_rest_z_tol: float = 0.03  # legacy (table-rest success), unused by the hold goal
+    # Radius of the 8 corner spheres marking the hold band (vision cue).
+    goal_corner_marker_radius: float = 0.012
+    episode_length_s_override: float = 20.0
+
+    observations: RetrieveTrayObservationsCfg = RetrieveTrayObservationsCfg()
+    events: RetrieveTrayEventCfg = RetrieveTrayEventCfg()
+    terminations: RetrieveTrayTerminationsCfg = RetrieveTrayTerminationsCfg()
+
+    def __post_init__(self):
+        table_top_z = dexverse_base_env.DEFAULT_TABLE_TOP_HEIGHT
+        # Scene additions must exist before the base builds the scene.
+        self.scene.rack = make_rack_cfg(str(RACK_USD_PATH), (self.rack_init_x, self.rack_init_y, table_top_z))
+        self.scene.goal_pad = GOAL_PAD_CFG.replace(
+            init_state=RigidObjectCfg.InitialStateCfg(pos=(0.0, 0.0, table_top_z + GOAL_PAD_SIZE[2] / 2.0), rot=(1.0, 0.0, 0.0, 0.0))
+        )
+
+        super().__post_init__()  # lift_tray: tray + food, base: table placement, cameras, rewards, teleop
+
+        # Re-spawn the tray through the offset-authoring func (same USD/props,
+        # plus the collision offsets above).
+        tray_spawn = self.scene.object.spawn
+        self.scene.object.spawn = dexverse_base_env.CollisionOffsetUsdFileCfg(
+            func=dexverse_base_env.spawn_usd_with_rigid_properties_and_collision_offsets,
+            usd_path=tray_spawn.usd_path,
+            scale=tray_spawn.scale,
+            rigid_props=tray_spawn.rigid_props,
+            collision_props=None,
+            mass_props=tray_spawn.mass_props,
+            contact_offset=self.tray_contact_offset,
+            rest_offset=self.tray_rest_offset,
+        )
+
+        # Food laid along the tray's long side, following the tray's yaw: the
+        # re-seat uses a tray-frame quat (``quat_local``) instead of the parent's
+        # world-fixed ``quat``; the spawn pose composes it with the tray's init
+        # rotation so the first frame already matches.
+        food_quat_local = food_rest_quat_yawed(self.food_yaw_offset_rad)
+        self.scene.food.init_state.rot = _quat_mul_wxyz(tuple(self.scene.object.init_state.rot), food_quat_local)
+        self.events.reset_food.params.pop("quat", None)
+        self.events.reset_food.params["quat_local"] = food_quat_local
+        self.events.reset_food.params["z_offset"] = self.food_z_offset
+        fx, fy, _ = self.scene.food.init_state.pos
+        self.scene.food.init_state.pos = (fx, fy, float(self.scene.object.init_state.pos[2]) + self.food_z_offset)
+
+        # Tray on the shelf: same root-to-bottom + clearance as on the table.
+        self.events.reset_tray_on_rack.params["z_offset"] = self.object_half_height + self.table_clearance
+        self.events.reset_rack.params["face_point"] = tuple(self.rack_face_point)
+
+        # Success: tray held level IN THE AIR over the pad (height band above the
+        # pad root), slow, food aboard, for ``goal_hold_steps`` consecutive steps.
+        self.terminations.success.func = mdp.carrier_held_aloft_with_cargo
+        self.terminations.success.params = {
+            "carrier_cfg": SceneEntityCfg("object"),
+            "goal_cfg": SceneEntityCfg("goal_pad"),
+            "cargo_cfg": SceneEntityCfg("food"),
+            "xy_threshold": self.goal_xy_threshold,
+            "z_above_goal": tuple(self.goal_z_above_pad),
+            "max_tilt_rad": self.goal_max_tilt_rad,
+            "max_lin_speed": self.goal_max_lin_speed,
+            "hold_steps": self.goal_hold_steps,
+            "carrier_half_extents_xy": TRAY_HALF_EXTENTS_XY,
+            "cargo_z_min": -0.03,
+            "cargo_z_max": 0.20,
+        }
+        # Tell the policy the target height band (mid), next to the pad position.
+        if getattr(self.observations, "goal", None) is not None:
+            self.observations.goal.goal_height_above_pad = ObsTerm(
+                func=mdp.scalar_obs, params={"value": 0.5 * (self.goal_z_above_pad[0] + self.goal_z_above_pad[1])}
+            )
+        # Vision-policy cue (always on, camera-visible): small spheres at the 8
+        # corners of the hold band over the pad. The filled box and the pad on
+        # the table were removed -- both blocked the view (teleop feedback).
+        z_lo, z_hi = self.goal_z_above_pad
+        hx, hy = GOAL_PAD_SIZE[0] / 2.0, GOAL_PAD_SIZE[1] / 2.0
+        corners = [(sx * hx, sy * hy, z) for z in (z_lo, z_hi) for sx in (-1.0, 1.0) for sy in (-1.0, 1.0)]
+        self.add_scene_vis_term(
+            "hold_band_corners",
+            ObsTerm(
+                func=mdp.local_points_vis,
+                params={
+                    "asset_cfg": SceneEntityCfg("goal_pad"),
+                    "local_points": corners,
+                    "radius": self.goal_corner_marker_radius,
+                    "color": (0.15, 0.75, 0.25),
+                    "opacity": 1.0,
+                    "prim_path": "/Visuals/HoldBandCorners",
+                    "hide_from_cameras": False,
+                },
+            ),
+        )
+        # The pad stays as the (invisible, non-colliding) goal frame the corners
+        # and the success term hang off.
+        self.scene.goal_pad.spawn.visible = False
+        # The invisible lift marker is meaningless here; keep it parked out of the way.
+        self.scene.success_marker.spawn.visible = False

--- a/source/dexverse/dexverse/baseline_v1/config/bimanual/rewards.py
+++ b/source/dexverse/dexverse/baseline_v1/config/bimanual/rewards.py
@@ -1,0 +1,178 @@
+# Copyright (c) 2025-2026, The DexVerse Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Reward configurations for the bimanual task family.
+
+Holds the coordinated-lift reward presets plus the two-hand reward functions
+they use. The ``Dense*`` preset is the PPO-ready variant: per-hand reach (so
+each hand is independently pulled to the object), lift progress graded toward
+the success height, a both-hands grasp-gated lift term, and keep-level
+shaping. Fingertip wiring happens via :func:`wire_bimanual_reward_fingertips`
+from ``BimanualLiftObjectEnvCfg.__post_init__``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import torch
+from isaaclab.managers import RewardTermCfg as RewTerm
+from isaaclab.managers import SceneEntityCfg
+from isaaclab.utils import configclass
+
+from ... import dexverse_base_env_cfg as dexverse_base_env
+from ... import mdp
+from ...mdp.utils import root_height_delta
+
+if TYPE_CHECKING:
+    from isaaclab.envs import ManagerBasedRLEnv
+
+
+def two_hand_reach_reward(
+    env: ManagerBasedRLEnv,
+    right_fingers_cfg: SceneEntityCfg,
+    left_fingers_cfg: SceneEntityCfg,
+    object_cfg: SceneEntityCfg = SceneEntityCfg("object"),
+    distance_gain: float = 5.0,
+) -> torch.Tensor:
+    """Mean of per-hand exponential reach rewards.
+
+    Each hand's mean fingertip distance decays independently, so one hand
+    parked on the object cannot satisfy the term alone — unlike a single
+    reach summed/meaned over all ten fingertips.
+    """
+    object_pos = env.scene[object_cfg.name].data.root_pos_w
+    reward = torch.zeros(env.num_envs, device=env.device)
+    for fingers_cfg in (right_fingers_cfg, left_fingers_cfg):
+        asset = env.scene[fingers_cfg.name]
+        tips = asset.data.body_pos_w[:, fingers_cfg.body_ids]
+        distance = torch.norm(tips - object_pos[:, None, :], dim=-1).mean(dim=-1)
+        reward = reward + 0.5 * torch.exp(-distance_gain * distance)
+    return reward
+
+
+def bimanual_grasp_lift_reward(
+    env: ManagerBasedRLEnv,
+    right_fingers_cfg: SceneEntityCfg,
+    left_fingers_cfg: SceneEntityCfg,
+    object_cfg: SceneEntityCfg = SceneEntityCfg("object"),
+    threshold: float = 0.08,
+    min_fingers_per_hand: int = 2,
+    min_height: float = 0.15,
+) -> torch.Tensor:
+    """Lift progress gated on both hands being in contact range of the object.
+
+    A hand counts as grasping when at least ``min_fingers_per_hand`` of its
+    fingertips are within ``threshold`` of the object root. Deliberately does
+    not read the lift action: bimanual action layouts make a fixed action
+    index unreliable, and the height delta itself is the trusted signal.
+    """
+    object_asset = env.scene[object_cfg.name]
+    object_pos = object_asset.data.root_pos_w
+    grasping = torch.ones(env.num_envs, dtype=torch.bool, device=env.device)
+    for fingers_cfg in (right_fingers_cfg, left_fingers_cfg):
+        asset = env.scene[fingers_cfg.name]
+        tips = asset.data.body_pos_w[:, fingers_cfg.body_ids]
+        distance = torch.norm(tips - object_pos[:, None, :], dim=-1)
+        grasping = grasping & ((distance <= threshold).sum(dim=1) >= min_fingers_per_hand)
+    lift = torch.clamp(root_height_delta(object_asset) / max(min_height, 1e-6), 0.0, 1.0)
+    return grasping * lift
+
+
+def wire_bimanual_reward_fingertips(rewards, fingertip_body_names: list[str]) -> None:
+    """Point the bimanual reward terms at the active robot's fingertip bodies.
+
+    Handles both reach-term shapes: the legacy all-tips ``object_ee_distance``
+    (``asset_cfg``) and the per-hand terms (``right_fingers_cfg`` /
+    ``left_fingers_cfg``, split by the Shadow bimanual ``rh_``/``lh_`` body
+    name prefixes; a hand with no prefixed names falls back to all tips).
+    """
+    right = [name for name in fingertip_body_names if name.startswith("rh_")]
+    left = [name for name in fingertip_body_names if name.startswith("lh_")]
+    for term_name in ("fingers_to_object", "bimanual_grasp_lift"):
+        term = getattr(rewards, term_name, None)
+        if term is None:
+            continue
+        if "asset_cfg" in term.params:
+            term.params["asset_cfg"].body_names = fingertip_body_names
+        else:
+            term.params["right_fingers_cfg"] = SceneEntityCfg("robot", body_names=right or fingertip_body_names)
+            term.params["left_fingers_cfg"] = SceneEntityCfg("robot", body_names=left or fingertip_body_names)
+
+
+@configclass
+class BimanualLiftRewardsCfg(dexverse_base_env.RewardsCfg):
+    """Reach + height-based lift signal (works with any fingertip count)."""
+
+    fingers_to_object = RewTerm(
+        func=mdp.object_ee_distance,
+        params={
+            "std": 0.4,
+            "distance_gain": 10.0,
+            # body_names wired to fingertip_body_names in __post_init__.
+            "asset_cfg": SceneEntityCfg("robot", body_names=None),
+        },
+        weight=2.0,
+    )
+
+    object_lift_height = RewTerm(
+        func=mdp.object_lift_height,
+        weight=2.0,
+        params={"asset_cfg": SceneEntityCfg("object"), "min_height": 0.0},
+    )
+
+
+@configclass
+class DenseBimanualLiftRewardsCfg(BimanualLiftRewardsCfg):
+    """PPO-ready dense preset for bimanual coordinated lifts.
+
+    ``min_height`` on the lift terms is graded toward ``lift_height`` (wired
+    in ``BimanualLiftObjectEnvCfg.__post_init__``), and the fingertip cfgs of
+    the per-hand terms are wired by :func:`wire_bimanual_reward_fingertips`.
+    """
+
+    fingers_to_object = RewTerm(
+        func=two_hand_reach_reward,
+        weight=2.0,
+        params={
+            "right_fingers_cfg": SceneEntityCfg("robot", body_names=None),
+            "left_fingers_cfg": SceneEntityCfg("robot", body_names=None),
+            "object_cfg": SceneEntityCfg("object"),
+            "distance_gain": 5.0,
+        },
+    )
+
+    object_lift_height = RewTerm(
+        func=mdp.object_lift_height,
+        weight=3.0,
+        params={"asset_cfg": SceneEntityCfg("object"), "min_height": 0.15},
+    )
+
+    bimanual_grasp_lift = RewTerm(
+        func=bimanual_grasp_lift_reward,
+        weight=1.0,
+        params={
+            "right_fingers_cfg": SceneEntityCfg("robot", body_names=None),
+            "left_fingers_cfg": SceneEntityCfg("robot", body_names=None),
+            "object_cfg": SceneEntityCfg("object"),
+            "threshold": 0.08,
+            "min_fingers_per_hand": 2,
+            "min_height": 0.15,
+        },
+    )
+
+    # Keep the object level while carrying it (trays/cartons tip easily);
+    # rises from 0 at ~20 deg of tilt to 1 when upright.
+    keep_level = RewTerm(
+        func=mdp.tilt_angle_reward,
+        weight=1.0,
+        params={
+            "threshold_rad": 0.35,
+            "axis_local": (0.0, 0.0, 1.0),
+            "world_axis": (0.0, 0.0, 1.0),
+            "tilt_ge": False,
+            "object_cfg": SceneEntityCfg("object"),
+        },
+    )

--- a/source/dexverse/dexverse/baseline_v1/config/bimanual/usd_helpers.py
+++ b/source/dexverse/dexverse/baseline_v1/config/bimanual/usd_helpers.py
@@ -1,0 +1,135 @@
+# Copyright (c) 2025-2026, The DexVerse Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Asset-time USD cleanup utilities for bimanual lift tasks.
+
+Some synthesis / scanned USDs ship as fully authored articulations: a root
+prim carries :class:`UsdPhysics.ArticulationRootAPI`, several child meshes
+carry :class:`UsdPhysics.RigidBodyAPI`, and joint prims (Revolute / Prismatic /
+Fixed) glue them together.  For tasks that just want to *lift* the asset as
+a single rigid body, all of that internal structure is wrong in three ways
+when IsaacLab spawns the USD under a ``prim_path`` and applies its own
+top-level ``RigidBodyAPI`` via ``spawn_usd_with_rigid_properties``:
+
+* The :class:`RigidObject` resolver aborts with
+  ``Failed to find a single rigid body when resolving '<prim>'. Found
+  multiple '[...]' under '<prim>'`` (multiple authored rigid bodies).
+* The resolver also aborts with
+  ``Found an articulation root when resolving '<prim>' for rigid objects``
+  (authored :class:`ArticulationRootAPI`).
+* PhysX logs
+  ``CreateJoint - you cannot create a joint between a body and itself``
+  because, after stripping the internal RigidBodyAPIs, both endpoints of
+  each authored joint collapse onto the single top-level rigid body.
+
+:func:`ensure_single_rigid_body` rewrites a cached copy of the USD that has
+all three classes of offending authoring removed, so IsaacLab can spawn it
+cleanly as one rigid body.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# Bumped from ``__rb_cleaned`` when joint/articulation stripping was added,
+# so stale single-purpose caches are regenerated with the broader cleanup.
+_CLEANED_SUFFIX = "__rigid_collapsed.usd"
+
+
+def ensure_single_rigid_body(usd_path: str | Path) -> str:
+    """Return a USD path cleaned for use as a single rigid body.
+
+    Strips, in place on a cached copy of the source USD:
+
+    * every authored :class:`UsdPhysics.RigidBodyAPI` (so only the
+      spawn-applied top-level rigid body survives),
+    * every authored :class:`UsdPhysics.ArticulationRootAPI` (so the
+      RigidObject resolver doesn't see an articulation under the prim),
+    * every authored physics joint prim (Revolute / Prismatic / Fixed /
+      Spherical / Distance / generic ``Joint``), by deactivating it —
+      deactivation leaves the prim in the layer for diffing but keeps the
+      physics plugin from trying to realise it.
+
+    If ``pxr`` is unavailable or the source has no authored physics
+    schemas to clean, the original path is returned unchanged.  Otherwise
+    the cleaned copy is cached next to the original as
+    ``<name>__rigid_collapsed.usd`` and regenerated whenever the source is
+    newer than the cache.
+    """
+    src = Path(usd_path)
+    if not src.is_file():
+        return str(src)
+
+    try:
+        from pxr import Usd, UsdPhysics  # type: ignore
+    except ImportError:
+        return str(src)
+
+    cleaned = src.with_name(f"{src.stem}{_CLEANED_SUFFIX}")
+    if cleaned.exists() and cleaned.stat().st_mtime >= src.stat().st_mtime:
+        return str(cleaned)
+
+    stage = Usd.Stage.Open(str(src))
+    if stage is None:
+        return str(src)
+
+    # Joint prim types we want to silence. ``Joint`` is the base type; the
+    # typed subclasses get caught by ``IsA(UsdPhysics.Joint)`` too, but
+    # iterating a concrete list keeps the intent explicit and makes logs
+    # easier to read.
+    joint_types: tuple[type, ...] = tuple(
+        t
+        for t in (
+            getattr(UsdPhysics, "Joint", None),
+            getattr(UsdPhysics, "RevoluteJoint", None),
+            getattr(UsdPhysics, "PrismaticJoint", None),
+            getattr(UsdPhysics, "SphericalJoint", None),
+            getattr(UsdPhysics, "DistanceJoint", None),
+            getattr(UsdPhysics, "FixedJoint", None),
+        )
+        if t is not None
+    )
+
+    removed_rigid: list[str] = []
+    removed_art_root: list[str] = []
+    deactivated_joints: list[str] = []
+
+    for prim in stage.Traverse():
+        if prim.HasAPI(UsdPhysics.RigidBodyAPI):
+            prim.RemoveAPI(UsdPhysics.RigidBodyAPI)
+            removed_rigid.append(str(prim.GetPath()))
+        if prim.HasAPI(UsdPhysics.ArticulationRootAPI):
+            prim.RemoveAPI(UsdPhysics.ArticulationRootAPI)
+            removed_art_root.append(str(prim.GetPath()))
+        if joint_types and any(prim.IsA(t) for t in joint_types):
+            # Deactivating is preferable to deleting: it survives USD
+            # composition edge cases (referenced layers, variant sets)
+            # and is trivially reversible if a subsequent task needs the
+            # joints back.
+            prim.SetActive(False)
+            deactivated_joints.append(str(prim.GetPath()))
+
+    if not (removed_rigid or removed_art_root or deactivated_joints):
+        return str(src)
+
+    stage.GetRootLayer().Export(str(cleaned))
+    logger.info(
+        "Collapsed %s -> %s (rigid APIs: %d, articulation roots: %d, joints: %d).",
+        src.name,
+        cleaned.name,
+        len(removed_rigid),
+        len(removed_art_root),
+        len(deactivated_joints),
+    )
+    if removed_rigid:
+        logger.debug("  removed RigidBodyAPI from: %s", removed_rigid)
+    if removed_art_root:
+        logger.debug("  removed ArticulationRootAPI from: %s", removed_art_root)
+    if deactivated_joints:
+        logger.debug("  deactivated joints: %s", deactivated_joints)
+    return str(cleaned)

--- a/source/dexverse/dexverse/baseline_v1/config/contact_rich/__init__.py
+++ b/source/dexverse/dexverse/baseline_v1/config/contact_rich/__init__.py
@@ -1,0 +1,1 @@
+"""Version-one baseline task implementation package."""

--- a/source/dexverse/dexverse/baseline_v1/config/contact_rich/base_cfg.py
+++ b/source/dexverse/dexverse/baseline_v1/config/contact_rich/base_cfg.py
@@ -1,0 +1,45 @@
+# Copyright (c) 2025-2026, The DexVerse Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Shared base configuration for contact-rich insertion / assembly tasks.
+
+All insertion tasks (nut-thread, peg/pen/pipette insert, gear-mesh,
+plug-charger) share the same teleop-first wiring in ``__post_init__``:
+
+* fingertip → object **contact sensors** plus a ``contact`` observation term
+  (via :func:`setup_fingertip_contact_observation`), and
+* **disabling the default free-object machinery** (the ``object_pose`` command,
+  the object reset / scale / physics-material events, and the
+  ``object_out_of_bound`` termination), since each task fixes its own assets and
+  defines its own success logic.
+
+Subclasses set :attr:`contact_object_prim` (the prim under ``{ENV_REGEX_NS}``
+the fingertip contact sensors filter against) and override scene / observations
+/ rewards / terminations / events as needed. Task-specific asset placement and
+``episode_length_s`` stay in each task's ``__post_init__`` after ``super()``.
+"""
+
+from isaaclab.utils import configclass
+
+from ... import dexverse_base_env_cfg as dexverse_base_env
+from ... import mdp
+
+
+@configclass
+class ContactRichEnvCfg(dexverse_base_env.DexVerseBaseEnvCfg):
+    """Base config for contact-rich insertion / assembly tasks (robot-agnostic)."""
+
+    # Prim under ``{ENV_REGEX_NS}`` that the fingertip contact sensors filter against.
+    contact_object_prim: str = "Object"
+
+    def __post_init__(self):
+        super().__post_init__()
+
+        self.commands.object_pose = None
+        mdp.setup_fingertip_contact_observation(self, target_prim=self.contact_object_prim)
+        self.events.object_physics_material = None
+        self.events.object_scale_mass = None
+        self.events.reset_object = None
+        self.terminations.object_out_of_bound = None

--- a/source/dexverse/dexverse/baseline_v1/config/contact_rich/insertpen_cfg.py
+++ b/source/dexverse/dexverse/baseline_v1/config/contact_rich/insertpen_cfg.py
@@ -1,0 +1,436 @@
+# Copyright (c) 2025-2026, The DexVerse Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Task configuration for placing a pen into a pen-holder.
+
+Mirrors the ``insertpeg`` / ``plugcharger`` factory-insertion family, but uses
+two ``synthesis`` assets:
+
+* a **pen** (held object) that starts lying on the tabletop, and
+* a **pen-holder** cup (fixed receptacle, kinematic) standing upright.
+
+The robot must pick up the pen, bring it vertical, and drop it into the holder.
+Success is the factory-style insertion test: the pen's lower tip is centered
+over the holder opening (XY) and pushed below the rim (Z).
+
+Geometry (from the authored USDs, metersPerUnit=1.0, Z-up):
+* pen: ~0.185 m long along local +X, tube centerline at local z~0.0095, one tip
+  at the local -X end (~-0.090 m); lies flat on the table.
+* pen_holder001: ~0.120 m tall along local +Z, bottom at local z=0, opening at
+  the top with an inner radius of ~0.038 m.
+"""
+
+import math
+
+import isaaclab.sim as sim_utils
+from dexverse.assets import SYNTHESIS_DIR
+from isaaclab.assets import RigidObjectCfg
+from isaaclab.devices.openxr import XrCfg
+from isaaclab.managers import EventTermCfg as EventTerm
+from isaaclab.managers import ObservationGroupCfg as ObsGroup
+from isaaclab.managers import ObservationTermCfg as ObsTerm
+from isaaclab.managers import RewardTermCfg as RewTerm
+from isaaclab.managers import SceneEntityCfg
+from isaaclab.managers import TerminationTermCfg as DoneTerm
+from isaaclab.utils import configclass
+from isaaclab.utils.noise import UniformNoiseCfg as Unoise
+
+from ... import dexverse_base_env_cfg as dexverse_base_env
+from ... import mdp
+from ..floating_teleop import DEFAULT_FLOATING_SHADOW_XR_CFG, setup_floating_teleop
+from .base_cfg import ContactRichEnvCfg
+from .rewards import (
+    pen_axis_vertical_alignment_reward,
+    pen_insertion_depth_reward,
+    pen_tip_to_opening_reward,
+)
+from .synthesis_insertion_assets import prepare_insertion_usd
+
+# Collapse the multi-body synthesis USDs to a single rigid body. For the
+# kinematic pen-holder we also re-author the colliders to an exact triangle mesh
+# so the cup cavity stays hollow and the pen can actually be inserted.
+PEN_USD_PATH = prepare_insertion_usd(SYNTHESIS_DIR / "pen" / "model_pen_0.usd")
+PEN_HOLDER_USD_PATH = prepare_insertion_usd(
+    SYNTHESIS_DIR / "pen_holder001" / "model_pen_holder001_0.usd",
+    collision_approximation="none",
+)
+
+ASSET_SCALE = 1.0
+
+# --- Authored geometry (meters, before scale) ---
+PEN_LENGTH = 0.1851 * ASSET_SCALE
+PEN_RADIUS = 0.0095 * ASSET_SCALE
+PEN_CENTERLINE_Z = 0.0095 * ASSET_SCALE  # tube axis height in the local frame
+PEN_HOLDER_HEIGHT = 0.1200 * ASSET_SCALE
+PEN_HOLDER_OPENING_INNER_RADIUS = 0.038 * ASSET_SCALE
+TABLE_CLEARANCE = -0.006  # reset audit (Aug 2026): the pen root/radius estimate sat 8 mm high; net ~3 mm settle
+
+# Root offsets from the table top.
+PEN_ROOT_OFFSET = PEN_RADIUS + TABLE_CLEARANCE  # lies flat on its side
+PEN_HOLDER_ROOT_OFFSET = TABLE_CLEARANCE  # stands on its flat bottom (local z=0)
+
+# Reference points in each asset's local frame.
+# The pen runs along local +X (measured extent ~[-0.0907, +0.0944]); a tip sits
+# at each end. Insertion counts as success when *either* end goes into the
+# holder, so both tips are tracked (see the success / engaged terms below).
+PEN_TIP_LOCAL_OFFSET = (-0.090 * ASSET_SCALE, 0.0, PEN_CENTERLINE_Z)  # -X end
+PEN_TIP2_LOCAL_OFFSET = (0.0944 * ASSET_SCALE, 0.0, PEN_CENTERLINE_Z)  # +X end
+PEN_HOLDER_OPENING_LOCAL_OFFSET = (0.0, 0.0, PEN_HOLDER_HEIGHT)  # opening rim center
+
+# Engaged (shaping) tolerances: pen tip near/above the opening and roughly centered.
+ENGAGE_CENTER_DIST_THRESH = PEN_HOLDER_OPENING_INNER_RADIUS  # ~0.038 m
+ENGAGE_Z_THRESHOLD = 0.03  # tip within 3 cm above the rim counts as engaged
+
+# Success tolerances: pen tip clearly inside the holder and pushed below the rim.
+# XY tolerance set to ~the holder's inner radius: the cavity lets a seated pen's
+# tip sit up to (inner_radius - pen_radius) ~= 0.0285 m off-center, and a long
+# pen in this wide/shallow cup naturally leans toward the wall, so a tighter
+# bound (the old 0.025) rejected pens that are genuinely inserted. The Z gate
+# below (tip >= 3 cm under the rim) still prevents a pen merely resting on top
+# from counting, so loosening XY alone is safe.
+SUCCESS_CENTER_DIST_THRESH = 0.038
+SUCCESS_Z_THRESHOLD = -0.03  # tip at least 3 cm below the rim
+
+PEN_CFG = RigidObjectCfg(
+    prim_path="{ENV_REGEX_NS}/Pen",
+    spawn=sim_utils.UsdFileCfg(
+        func=dexverse_base_env.spawn_usd_with_rigid_properties,
+        usd_path=PEN_USD_PATH,
+        scale=(ASSET_SCALE, ASSET_SCALE, ASSET_SCALE),
+        activate_contact_sensors=True,
+        rigid_props=sim_utils.RigidBodyPropertiesCfg(
+            disable_gravity=False,
+            max_depenetration_velocity=5.0,
+            linear_damping=0.0,
+            angular_damping=0.0,
+            max_linear_velocity=1000.0,
+            max_angular_velocity=3666.0,
+            enable_gyroscopic_forces=True,
+            solver_position_iteration_count=64,
+            solver_velocity_iteration_count=4,
+            max_contact_impulse=1.0e32,
+        ),
+        mass_props=sim_utils.MassPropertiesCfg(mass=0.02),
+        # Collision is authored in the (collapsed) USD; keep convexDecomposition.
+        collision_props=None,
+    ),
+    init_state=RigidObjectCfg.InitialStateCfg(
+        pos=(-0.15, 0.0, 0.62),
+        rot=(1.0, 0.0, 0.0, 0.0),
+    ),
+)
+
+PEN_HOLDER_CFG = RigidObjectCfg(
+    prim_path="{ENV_REGEX_NS}/PenHolder",
+    spawn=sim_utils.UsdFileCfg(
+        func=dexverse_base_env.spawn_usd_with_rigid_properties,
+        usd_path=PEN_HOLDER_USD_PATH,
+        scale=(ASSET_SCALE, ASSET_SCALE, ASSET_SCALE),
+        activate_contact_sensors=True,
+        rigid_props=sim_utils.RigidBodyPropertiesCfg(
+            # Keep the holder fixed during simulation (still resettable on
+            # episode reset).
+            kinematic_enabled=True,
+            disable_gravity=True,
+            max_depenetration_velocity=5.0,
+            linear_damping=0.0,
+            angular_damping=0.0,
+            max_linear_velocity=1000.0,
+            max_angular_velocity=3666.0,
+            enable_gyroscopic_forces=True,
+            solver_position_iteration_count=64,
+            solver_velocity_iteration_count=4,
+            max_contact_impulse=1.0e32,
+        ),
+        mass_props=sim_utils.MassPropertiesCfg(mass=0.2),
+        # Exact triangle-mesh collision authored on the cleaned USD; do not
+        # override it with a convex hull here.
+        collision_props=None,
+    ),
+    init_state=RigidObjectCfg.InitialStateCfg(
+        pos=(0.10, 0.0, 0.62),
+        rot=(1.0, 0.0, 0.0, 0.0),
+    ),
+)
+
+
+@configclass
+class InsertPenObservationsCfg(dexverse_base_env.ObservationsCfg):
+    """Observation layout for the insert-pen task.
+
+    Two-part assembly: pen (held) and pen-holder (fixed). Absolute and relative
+    body states live in ``privileged``; the goal group exposes the pen-holder
+    opening position in the robot base frame.
+    """
+
+    @configclass
+    class PrivilegedObsCfg(dexverse_base_env.ObservationsCfg.PrivilegedObsCfg):
+        pen_state_b = ObsTerm(
+            func=mdp.body_state_b,
+            noise=Unoise(n_min=-0.0, n_max=0.0),
+            params={"body_asset_cfg": SceneEntityCfg("pen"), "base_asset_cfg": SceneEntityCfg("table")},
+        )
+        pen_holder_state_b = ObsTerm(
+            func=mdp.body_state_b,
+            noise=Unoise(n_min=-0.0, n_max=0.0),
+            params={"body_asset_cfg": SceneEntityCfg("pen_holder"), "base_asset_cfg": SceneEntityCfg("table")},
+        )
+        pen_state_rel_holder = ObsTerm(
+            func=mdp.body_state_b,
+            noise=Unoise(n_min=-0.0, n_max=0.0),
+            params={"body_asset_cfg": SceneEntityCfg("pen"), "base_asset_cfg": SceneEntityCfg("pen_holder")},
+        )
+
+    @configclass
+    class GoalObsCfg(ObsGroup):
+        """Insertion target: pen-holder position in the robot base frame."""
+
+        goal_pos_b = ObsTerm(
+            func=mdp.asset_pos_b,
+            noise=Unoise(n_min=-0.0, n_max=0.0),
+            params={"asset_cfg": SceneEntityCfg("pen_holder")},
+        )
+
+        def __post_init__(self):
+            self.enable_corruption = True
+            self.concatenate_terms = True
+            self.history_length = 0
+
+    privileged: PrivilegedObsCfg = PrivilegedObsCfg()
+    goal: GoalObsCfg = GoalObsCfg()
+
+
+@configclass
+class InsertPenRewardsCfg(dexverse_base_env.RewardsCfg):
+    """Rewards for the insert-pen task."""
+
+    engaged = RewTerm(
+        func=mdp.factory_insert_engaged_reward,
+        weight=2.0,
+        params={
+            "held_cfg": SceneEntityCfg("pen"),
+            "fixed_cfg": SceneEntityCfg("pen_holder"),
+            "held_base_local_offset": PEN_TIP_LOCAL_OFFSET,
+            "held_base_local_offset_2": PEN_TIP2_LOCAL_OFFSET,
+            "target_local_offset": PEN_HOLDER_OPENING_LOCAL_OFFSET,
+            "center_dist_thresh": ENGAGE_CENTER_DIST_THRESH,
+            "z_threshold": ENGAGE_Z_THRESHOLD,
+        },
+    )
+
+    success = RewTerm(
+        func=mdp.factory_insert_success_reward,
+        weight=10.0,
+        params={
+            "held_cfg": SceneEntityCfg("pen"),
+            "fixed_cfg": SceneEntityCfg("pen_holder"),
+            "held_base_local_offset": PEN_TIP_LOCAL_OFFSET,
+            "held_base_local_offset_2": PEN_TIP2_LOCAL_OFFSET,
+            "target_local_offset": PEN_HOLDER_OPENING_LOCAL_OFFSET,
+            "center_dist_thresh": SUCCESS_CENTER_DIST_THRESH,
+            "z_threshold": SUCCESS_Z_THRESHOLD,
+        },
+    )
+
+
+# Minimum rise of the pen above its spawn height before the carry / orient /
+# depth shaping activates (prevents the terms from pulling the hand toward the
+# holder before a grasp exists), and the graded lift target itself.
+PEN_LIFT_MIN_HEIGHT = 0.10
+PEN_LIFT_GATE = 0.03
+
+
+@configclass
+class DenseInsertPenRewardsCfg(InsertPenRewardsCfg):
+    """PPO-ready dense preset for insert-pen.
+
+    Keeps the sparse ``engaged``/``success`` bonuses and adds the missing
+    stages: reach the pen, lift it, carry a tip to the holder opening, bring
+    the pen vertical, and grade the insertion depth. The lift gates keep the
+    carry/orient terms inert until the pen is actually off the table, and the
+    depth term's XY gate means a pen resting on the rim scores nothing.
+    """
+
+    fingers_to_pen = RewTerm(
+        func=mdp.object_ee_distance,
+        weight=1.0,
+        params={
+            "std": 0.4,
+            "distance_gain": 10.0,
+            "object_cfg": SceneEntityCfg("pen"),
+            # body_names wired to the robot's fingertips in __post_init__.
+            "asset_cfg": SceneEntityCfg("robot", body_names=None),
+            "reduce": "mean",
+        },
+    )
+
+    pen_lift = RewTerm(
+        func=mdp.object_lift_height,
+        weight=1.0,
+        params={"asset_cfg": SceneEntityCfg("pen"), "min_height": PEN_LIFT_MIN_HEIGHT},
+    )
+
+    tip_to_opening = RewTerm(
+        func=pen_tip_to_opening_reward,
+        weight=2.0,
+        params={
+            "held_cfg": SceneEntityCfg("pen"),
+            "fixed_cfg": SceneEntityCfg("pen_holder"),
+            "tip_local_offsets": (PEN_TIP_LOCAL_OFFSET, PEN_TIP2_LOCAL_OFFSET),
+            "target_local_offset": PEN_HOLDER_OPENING_LOCAL_OFFSET,
+            "distance_gain": 8.0,
+            "min_lift": PEN_LIFT_GATE,
+        },
+    )
+
+    axis_upright = RewTerm(
+        func=pen_axis_vertical_alignment_reward,
+        weight=1.0,
+        params={
+            "held_cfg": SceneEntityCfg("pen"),
+            # The pen runs along local +X (see the geometry notes above).
+            "axis_local": (1.0, 0.0, 0.0),
+            "min_lift": PEN_LIFT_GATE,
+        },
+    )
+
+    insert_depth = RewTerm(
+        func=pen_insertion_depth_reward,
+        weight=4.0,
+        params={
+            "held_cfg": SceneEntityCfg("pen"),
+            "fixed_cfg": SceneEntityCfg("pen_holder"),
+            "tip_local_offsets": (PEN_TIP_LOCAL_OFFSET, PEN_TIP2_LOCAL_OFFSET),
+            "target_local_offset": PEN_HOLDER_OPENING_LOCAL_OFFSET,
+            "center_dist_thresh": SUCCESS_CENTER_DIST_THRESH,
+            "depth_range": 0.03,
+        },
+    )
+
+
+@configclass
+class InsertPenTerminationsCfg(dexverse_base_env.TerminationsCfg):
+    """Termination terms for the insert-pen task."""
+
+    success = DoneTerm(
+        func=mdp.factory_insert_success,
+        params={
+            "held_cfg": SceneEntityCfg("pen"),
+            "fixed_cfg": SceneEntityCfg("pen_holder"),
+            "held_base_local_offset": PEN_TIP_LOCAL_OFFSET,
+            "held_base_local_offset_2": PEN_TIP2_LOCAL_OFFSET,
+            "target_local_offset": PEN_HOLDER_OPENING_LOCAL_OFFSET,
+            "center_dist_thresh": SUCCESS_CENTER_DIST_THRESH,
+            "z_threshold": SUCCESS_Z_THRESHOLD,
+        },
+    )
+
+
+@configclass
+class InsertPenEventCfg(dexverse_base_env.EventCfg):
+    """Event configuration for the insert-pen task."""
+
+    reset_pen_holder = EventTerm(
+        func=mdp.reset_root_pose_uniform,
+        mode="reset",
+        params={
+            "asset_cfg": SceneEntityCfg("pen_holder"),
+            # Tightened for an easier task: holder stays closer to its nominal
+            # spot (world x 0.15-0.20, y +/-0.05) with little yaw, so the
+            # insertion target is more predictable. Widen back to broaden the
+            # distribution once the policy/teleop is reliable.
+            "pose_range": {
+                "x": [0.05, 0.10],
+                "y": [-0.05, 0.05],
+                "z": [0.0, 0.0],
+                "roll": [0.0, 0.0],
+                "pitch": [0.0, 0.0],
+                "yaw": [-math.radians(10.0), math.radians(10.0)],
+            },
+        },
+    )
+
+    reset_pen_on_table = EventTerm(
+        func=mdp.reset_root_state_uniform,
+        mode="reset",
+        params={
+            "asset_cfg": SceneEntityCfg("pen"),
+            # Reset audit (Aug 2026): widened from the "easy" patch (offsets x
+            # [-0.15,-0.05], y +/-0.10, yaw +/-30 deg = world x -0.30..-0.20) to
+            # world x -0.30..-0.10, y +/-0.20, yaw +/-60 deg. The pen (~15 cm long)
+            # stays clear of the holder (world x >= 0.15) at any yaw.
+            "pose_range": {
+                "x": [-0.15, 0.05],
+                "y": [-0.20, 0.20],
+                "z": [0.0, 0.0],
+                "roll": [0.0, 0.0],
+                "pitch": [0.0, 0.0],
+                "yaw": [-math.pi / 3.0, math.pi / 3.0],
+            },
+            "velocity_range": {"x": [0.0, 0.0], "y": [0.0, 0.0], "z": [0.0, 0.0]},
+        },
+    )
+
+
+@configclass
+class InsertPenSceneCfg(dexverse_base_env.SceneCfg):
+    pen: RigidObjectCfg = PEN_CFG
+    pen_holder: RigidObjectCfg = PEN_HOLDER_CFG
+    object = None
+
+
+@configclass
+class InsertPenEnvCfg(ContactRichEnvCfg):
+    """Insert-pen task configuration (base, robot-agnostic)."""
+
+    observations: InsertPenObservationsCfg = InsertPenObservationsCfg()
+    rewards: InsertPenRewardsCfg = DenseInsertPenRewardsCfg()
+    terminations: InsertPenTerminationsCfg = InsertPenTerminationsCfg()
+    events: InsertPenEventCfg = InsertPenEventCfg()
+    scene: InsertPenSceneCfg = InsertPenSceneCfg(
+        num_envs=4096,
+        env_spacing=3,
+        replicate_physics=False,
+        pen=PEN_CFG,
+        pen_holder=PEN_HOLDER_CFG,
+    )
+
+    contact_object_prim: str = "Pen"
+
+    def __post_init__(self):
+        super().__post_init__()
+
+        table_size = self.scene.table.spawn.size
+        table_pos = self.scene.table.init_state.pos
+        table_top_z = table_pos[2] + table_size[2] * 0.5
+
+        self.scene.pen_holder.init_state.pos = (0.10, 0.0, table_top_z + PEN_HOLDER_ROOT_OFFSET)
+        self.scene.pen.init_state.pos = (-0.15, 0.0, table_top_z + PEN_ROOT_OFFSET)
+
+        self.episode_length_s = 25.0
+
+        # The tabletop base nulls ``rewards.success`` when ``scene.object`` is
+        # None (this task's assets are ``pen``/``pen_holder``) — restore the
+        # sparse insertion success bonus from the class definition.
+        if self.rewards.success is None:
+            self.rewards.success = type(self.rewards)().success
+
+        # Point the dense reach term at the active robot's fingertips (term
+        # only present on the dense preset).
+        fingers_to_pen = getattr(self.rewards, "fingers_to_pen", None)
+        if fingers_to_pen is not None:
+            fingers_to_pen.params["asset_cfg"].body_names = self.robot_config.fingertip_body_names
+
+
+@configclass
+class InsertPenEnvFloatingDexHandRightCfg(InsertPenEnvCfg):
+    """Insert-pen environment configuration for floating dexterous hands."""
+
+    robot_type: str = "floating_shadow_right"
+    xr: XrCfg = DEFAULT_FLOATING_SHADOW_XR_CFG
+
+    def __post_init__(self):
+        super().__post_init__()
+        setup_floating_teleop(self)

--- a/source/dexverse/dexverse/baseline_v1/config/contact_rich/rewards.py
+++ b/source/dexverse/dexverse/baseline_v1/config/contact_rich/rewards.py
@@ -1,0 +1,114 @@
+# Copyright (c) 2025-2026, The DexVerse Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Dense reward functions for the contact-rich insertion task family.
+
+These shape the stages the sparse ``engaged``/``success`` bonuses skip: carry
+the held part toward the receptacle opening, orient it for insertion, and
+grade the insertion depth. Written for the pen/pen-holder task but generic to
+any two-ended held part with a fixed upright receptacle — offsets and
+thresholds come in as params from the task cfg (which owns the geometry
+constants), e.g. ``DenseInsertPenRewardsCfg`` in ``insertpen_cfg.py``.
+
+All terms gate on the held part being lifted off the table (``min_lift``)
+so they cannot pull the hand toward the receptacle before a grasp exists,
+and the depth term additionally gates on being XY-centered over the opening
+so resting the part on the rim scores nothing.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import torch
+from isaaclab.managers import SceneEntityCfg
+
+from ...mdp.utils import asset_axis_w, root_height_delta, world_points_from_local
+
+if TYPE_CHECKING:
+    from isaaclab.envs import ManagerBasedRLEnv
+
+
+def _held_tip_positions_w(
+    env: ManagerBasedRLEnv,
+    held_cfg: SceneEntityCfg,
+    tip_local_offsets: tuple[tuple[float, float, float], ...],
+) -> torch.Tensor:
+    """World positions of the held part's tip reference points, ``(E, T, 3)``."""
+    tips = torch.tensor(tip_local_offsets, device=env.device, dtype=torch.float32)
+    return world_points_from_local(env, held_cfg, tips)
+
+
+def _opening_position_w(
+    env: ManagerBasedRLEnv,
+    fixed_cfg: SceneEntityCfg,
+    target_local_offset: tuple[float, float, float],
+) -> torch.Tensor:
+    """World position of the receptacle opening center, ``(E, 3)``."""
+    point = torch.tensor([target_local_offset], device=env.device, dtype=torch.float32)
+    return world_points_from_local(env, fixed_cfg, point).squeeze(1)
+
+
+def _lift_gate(env: ManagerBasedRLEnv, held_cfg: SceneEntityCfg, min_lift: float) -> torch.Tensor:
+    """1.0 where the held part has risen at least ``min_lift`` above its spawn."""
+    if min_lift <= 0.0:
+        return torch.ones(env.num_envs, device=env.device)
+    return (root_height_delta(env.scene[held_cfg.name]) >= min_lift).float()
+
+
+def pen_tip_to_opening_reward(
+    env: ManagerBasedRLEnv,
+    held_cfg: SceneEntityCfg,
+    fixed_cfg: SceneEntityCfg,
+    tip_local_offsets: tuple[tuple[float, float, float], ...],
+    target_local_offset: tuple[float, float, float],
+    distance_gain: float = 8.0,
+    min_lift: float = 0.03,
+) -> torch.Tensor:
+    """Exponential decay of the closest tip-to-opening distance, lift-gated."""
+    tips_w = _held_tip_positions_w(env, held_cfg, tip_local_offsets)
+    opening_w = _opening_position_w(env, fixed_cfg, target_local_offset)
+    distance = torch.norm(tips_w - opening_w[:, None, :], dim=-1).min(dim=1).values
+    return torch.exp(-distance_gain * distance) * _lift_gate(env, held_cfg, min_lift)
+
+
+def pen_axis_vertical_alignment_reward(
+    env: ManagerBasedRLEnv,
+    held_cfg: SceneEntityCfg,
+    axis_local: tuple[float, float, float] = (1.0, 0.0, 0.0),
+    min_lift: float = 0.03,
+) -> torch.Tensor:
+    """|cos| between the held part's long axis and world up, lift-gated.
+
+    Sign-agnostic — either end may point down. The lift gate keeps a part
+    standing on the table from collecting the reward.
+    """
+    axis_w = asset_axis_w(env, asset_cfg=held_cfg, axis_local=axis_local)
+    alignment = torch.abs(axis_w[:, 2]).clamp(0.0, 1.0)
+    return alignment * _lift_gate(env, held_cfg, min_lift)
+
+
+def pen_insertion_depth_reward(
+    env: ManagerBasedRLEnv,
+    held_cfg: SceneEntityCfg,
+    fixed_cfg: SceneEntityCfg,
+    tip_local_offsets: tuple[tuple[float, float, float], ...],
+    target_local_offset: tuple[float, float, float],
+    center_dist_thresh: float,
+    depth_range: float = 0.03,
+) -> torch.Tensor:
+    """Graded insertion depth below the rim, gated on being XY-centered.
+
+    For each tip: depth = rim_z - tip_z (world frame; the receptacle stands
+    upright), clamped to ``[0, depth_range]`` and normalized, and counted only
+    while that tip is within ``center_dist_thresh`` of the opening center in
+    XY. The best tip wins, so either end of the part may be inserted.
+    """
+    tips_w = _held_tip_positions_w(env, held_cfg, tip_local_offsets)
+    opening_w = _opening_position_w(env, fixed_cfg, target_local_offset)
+    xy_dist = torch.norm(tips_w[..., :2] - opening_w[:, None, :2], dim=-1)
+    depth = (opening_w[:, None, 2] - tips_w[..., 2]).clamp(0.0, depth_range) / max(depth_range, 1e-6)
+    per_tip = depth * (xy_dist <= center_dist_thresh).float()
+    return per_tip.max(dim=1).values

--- a/source/dexverse/dexverse/baseline_v1/config/contact_rich/synthesis_insertion_assets.py
+++ b/source/dexverse/dexverse/baseline_v1/config/contact_rich/synthesis_insertion_assets.py
@@ -1,0 +1,255 @@
+# Copyright (c) 2025-2026, The DexVerse Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""USD preparation for synthesis-asset insertion tasks.
+
+The ``synthesis/*`` assets used by the pipette/glassware and pen/pen-holder
+insertion tasks ship as multi-body articulations: each part carries its own
+:class:`UsdPhysics.RigidBodyAPI` and the parts are glued together with fixed
+joints (the pipette tube + bulb, the pen body + cap, …). IsaacLab's
+``RigidObject`` resolver needs **one** rigid body under the spawn prim, so we
+strip that authored physics structure — exactly like
+``grasping/bimanual_lift/usd_helpers.ensure_single_rigid_body``.
+
+On top of the collapse, this helper can re-author the **mesh collision
+approximation**. The source assets all ship with ``convexDecomposition``, which
+is fine for a held object (it stays a dynamic convex collider) but can seal the
+narrow opening of a receptacle so nothing can be inserted. For the fixed
+glassware / pen-holder (spawned kinematic) we therefore switch the colliders to
+``"none"`` (exact triangle mesh), which keeps the cavity hollow and is a valid
+collider type for static/kinematic actors.
+
+After stripping the per-part rigid bodies, a single top-level
+:class:`UsdPhysics.RigidBodyAPI` is authored on the default prim. This makes the
+asset resolve as exactly one rigid body **and** ensures a rigid body already
+exists when IsaacLab activates contact sensors at spawn (that step runs *before*
+IsaacLab re-applies its own rigid-body properties, so a body must already be
+present). The concrete dynamic/kinematic settings are still (re)applied at spawn
+time from the task config.
+
+The cleaned stage is cached next to the source as
+``<stem>__<tag>__insertion_prepared_v2.usd`` and regenerated when the source is
+newer than the cache. If ``pxr`` is unavailable or the source has nothing to
+clean, the original path is returned unchanged.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+_SUFFIX = "__insertion_prepared_v2.usd"
+_VISIBLE_SUFFIX = "__visible_material_v1.usd"
+
+
+def _safe_usd_identifier(name: str) -> str:
+    safe = re.sub(r"[^0-9A-Za-z_]", "_", name).strip("_")
+    if not safe or safe[0].isdigit():
+        safe = f"Material_{safe}"
+    return safe
+
+
+def prepare_insertion_usd(
+    usd_path: str | Path,
+    collision_approximation: str | None = None,
+) -> str:
+    """Collapse a synthesis USD to a single rigid body for insertion tasks.
+
+    Args:
+        usd_path: Source USD.
+        collision_approximation: When given, every authored
+            ``UsdPhysics.MeshCollisionAPI`` approximation is rewritten to this
+            token (e.g. ``"none"`` for an exact triangle-mesh receptacle cavity).
+            When ``None`` the authored approximation is left untouched.
+
+    Returns:
+        Path (as ``str``) to the cleaned/cached USD, or the original path when no
+        cleanup is needed or ``pxr`` is unavailable.
+    """
+    src = Path(usd_path)
+    if not src.is_file():
+        return str(src)
+
+    try:
+        from pxr import Usd, UsdPhysics  # type: ignore
+    except ImportError:
+        return str(src)
+
+    tag = (collision_approximation or "collapsed").replace(" ", "_")
+    cleaned = src.with_name(f"{src.stem}__{tag}{_SUFFIX}")
+    if cleaned.exists() and cleaned.stat().st_mtime >= src.stat().st_mtime:
+        return str(cleaned)
+
+    stage = Usd.Stage.Open(str(src))
+    if stage is None:
+        return str(src)
+
+    joint_types: tuple[type, ...] = tuple(
+        t
+        for t in (
+            getattr(UsdPhysics, "Joint", None),
+            getattr(UsdPhysics, "RevoluteJoint", None),
+            getattr(UsdPhysics, "PrismaticJoint", None),
+            getattr(UsdPhysics, "SphericalJoint", None),
+            getattr(UsdPhysics, "DistanceJoint", None),
+            getattr(UsdPhysics, "FixedJoint", None),
+        )
+        if t is not None
+    )
+
+    removed_rigid: list[str] = []
+    removed_art_root: list[str] = []
+    deactivated_joints: list[str] = []
+    reapprox_meshes: list[str] = []
+
+    for prim in stage.Traverse():
+        if prim.HasAPI(UsdPhysics.RigidBodyAPI):
+            prim.RemoveAPI(UsdPhysics.RigidBodyAPI)
+            removed_rigid.append(str(prim.GetPath()))
+        if prim.HasAPI(UsdPhysics.ArticulationRootAPI):
+            prim.RemoveAPI(UsdPhysics.ArticulationRootAPI)
+            removed_art_root.append(str(prim.GetPath()))
+        if joint_types and any(prim.IsA(t) for t in joint_types):
+            # Deactivate (not delete): survives composition edge cases and is
+            # trivially reversible.
+            prim.SetActive(False)
+            deactivated_joints.append(str(prim.GetPath()))
+        if collision_approximation is not None and prim.HasAPI(UsdPhysics.MeshCollisionAPI):
+            UsdPhysics.MeshCollisionAPI(prim).GetApproximationAttr().Set(collision_approximation)
+            reapprox_meshes.append(str(prim.GetPath()))
+
+    # Author a single top-level rigid body on the default prim so the asset
+    # resolves as exactly one rigid body and contact-sensor activation finds it
+    # at spawn time. The concrete dynamic/kinematic flags are (re)applied later
+    # by the task's spawn cfg.
+    added_rigid = False
+    default_prim = stage.GetDefaultPrim()
+    if default_prim and default_prim.IsValid() and not default_prim.HasAPI(UsdPhysics.RigidBodyAPI):
+        UsdPhysics.RigidBodyAPI.Apply(default_prim)
+        added_rigid = True
+
+    if not (removed_rigid or removed_art_root or deactivated_joints or reapprox_meshes or added_rigid):
+        return str(src)
+
+    stage.GetRootLayer().Export(str(cleaned))
+    logger.info(
+        "Prepared %s -> %s (stripped rigid APIs: %d, art roots: %d, joints: %d, "
+        "re-approx: %d -> %s, top-level rigid added: %s).",
+        src.name,
+        cleaned.name,
+        len(removed_rigid),
+        len(removed_art_root),
+        len(deactivated_joints),
+        len(reapprox_meshes),
+        collision_approximation,
+        added_rigid,
+    )
+    return str(cleaned)
+
+
+def prepare_visible_usd(
+    usd_path: str | Path,
+    *,
+    material_name: str = "Visible_Material",
+    diffuse_color: tuple[float, float, float] = (0.2, 0.75, 1.0),
+    opacity: float = 1.0,
+    roughness: float = 0.35,
+    metallic: float = 0.0,
+    cache_tag: str | None = None,
+    target_prim_paths: tuple[str, ...] | None = None,
+) -> str:
+    """Bind a simple PreviewSurface material directly on every mesh in a USD.
+
+    This is for imported assets whose authored descendant mesh bindings are too
+    transparent or otherwise hard to see. A spawn-time visual material may not
+    override those bindings in all IsaacLab versions, so this authors a cached
+    USD with the mesh bindings changed directly and also writes
+    ``displayColor`` / ``displayOpacity`` primvars as a fallback. When
+    ``target_prim_paths`` is given, only meshes at or under those prim paths are
+    rebound.
+
+    Args:
+        usd_path: Source USD.
+        material_name: Material prim name under ``<defaultPrim>/materials``.
+        diffuse_color: RGB color in ``[0, 1]``.
+        opacity: PreviewSurface opacity.
+        roughness: PreviewSurface roughness.
+        metallic: PreviewSurface metallic value.
+        cache_tag: Optional filename tag. Bump this when changing material
+            parameters for an already cached asset.
+        target_prim_paths: Optional prim paths whose descendant meshes should be
+            rebound. When ``None``, every mesh in the USD is rebound.
+
+    Returns:
+        Path (as ``str``) to the visible/cached USD, or the original path when
+        no mesh exists, the source cannot be opened, or ``pxr`` is unavailable.
+    """
+    src = Path(usd_path)
+    if not src.is_file():
+        return str(src)
+
+    safe_material_name = _safe_usd_identifier(material_name)
+    tag = _safe_usd_identifier(cache_tag or safe_material_name).lower()
+    visible = src.with_name(f"{src.stem}__{tag}{_VISIBLE_SUFFIX}")
+    if visible.exists() and visible.stat().st_mtime >= src.stat().st_mtime:
+        return str(visible)
+
+    try:
+        from pxr import Gf, Sdf, Usd, UsdGeom, UsdShade  # type: ignore
+    except ImportError:
+        return str(src)
+
+    stage = Usd.Stage.Open(str(src))
+    if stage is None:
+        return str(src)
+
+    target_paths = tuple(Sdf.Path(path) for path in target_prim_paths or ())
+
+    default_prim = stage.GetDefaultPrim()
+    if default_prim and default_prim.IsValid():
+        material_parent_path = default_prim.GetPath().AppendChild("materials")
+    else:
+        material_parent_path = Sdf.Path("/materials")
+    UsdGeom.Scope.Define(stage, material_parent_path)
+
+    material_path = material_parent_path.AppendChild(safe_material_name)
+    shader_path = material_path.AppendChild("PreviewSurface")
+    material = UsdShade.Material.Define(stage, material_path)
+    shader = UsdShade.Shader.Define(stage, shader_path)
+    shader.CreateIdAttr("UsdPreviewSurface")
+    shader.CreateInput("diffuseColor", Sdf.ValueTypeNames.Color3f).Set(Gf.Vec3f(*diffuse_color))
+    shader.CreateInput("opacity", Sdf.ValueTypeNames.Float).Set(float(opacity))
+    shader.CreateInput("roughness", Sdf.ValueTypeNames.Float).Set(float(roughness))
+    shader.CreateInput("metallic", Sdf.ValueTypeNames.Float).Set(float(metallic))
+    shader.CreateOutput("surface", Sdf.ValueTypeNames.Token)
+    material.CreateSurfaceOutput().ConnectToSource(shader.ConnectableAPI(), "surface")
+
+    mesh_count = 0
+    for prim in stage.Traverse():
+        if not prim.IsA(UsdGeom.Mesh):
+            continue
+        prim_path = prim.GetPath()
+        if target_paths and not any(
+            prim_path == target_path or prim_path.HasPrefix(target_path) for target_path in target_paths
+        ):
+            continue
+        UsdShade.MaterialBindingAPI.Apply(prim).Bind(
+            material,
+            bindingStrength=UsdShade.Tokens.strongerThanDescendants,
+        )
+        gprim = UsdGeom.Gprim(prim)
+        gprim.CreateDisplayColorPrimvar(UsdGeom.Tokens.constant).Set([Gf.Vec3f(*diffuse_color)])
+        gprim.CreateDisplayOpacityPrimvar(UsdGeom.Tokens.constant).Set([float(opacity)])
+        mesh_count += 1
+
+    if mesh_count == 0:
+        return str(src)
+
+    stage.GetRootLayer().Export(str(visible))
+    logger.info("Prepared visible USD %s -> %s (meshes rebound: %d).", src.name, visible.name, mesh_count)
+    return str(visible)

--- a/source/dexverse/dexverse/baseline_v1/config/floating_teleop.py
+++ b/source/dexverse/dexverse/baseline_v1/config/floating_teleop.py
@@ -1,0 +1,366 @@
+# Copyright (c) 2025-2026, The DexVerse Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Shared teleoperation helpers for floating tabletop configs."""
+
+from dataclasses import fields, is_dataclass
+
+from dexverse.devices.retargeters import (
+    SimpleAbsoluteRetargeterCfg,
+    SimpleRelativeRetargeterCfg,
+)
+from dexverse.devices.retargeters.simple_relative_retargeting import (
+    SIMPLE_RETARGETER_LAYOUT_SOURCES,
+)
+from isaaclab.devices import DevicesCfg, OpenXRDeviceCfg
+from isaaclab.devices.openxr import XrCfg
+
+# Supported values for the ``--teleop_retargeter`` CLI flag / equivalent
+# ``env.teleop_retargeter=`` Hydra-style override.
+TELEOP_RETARGETER_MODES = ("relative", "absolute")
+
+# Supported values for the ``--retargeting_scheme`` CLI flag / equivalent
+# ``env.retargeting_scheme=`` Hydra-style override. This is orthogonal to the
+# relative/absolute mode above: it selects which dex-retargeting YAML the finger
+# optimizer loads (DexPilot pinch vectors vs. palm->fingertip vectors).
+TELEOP_RETARGETING_SCHEMES = ("dexpilot", "vector")
+
+# Default XR configuration for floating hands
+DEFAULT_FLOATING_SHADOW_XR_CFG = XrCfg(
+    anchor_pos=[-0.5, 0.0, 0.1],
+    anchor_rot=[0.7071068, 0.0, 0.0, -0.7071068],
+)
+
+DEFAULT_FLOATING_LEAP_XR_CFG = XrCfg(
+    anchor_pos=[-0.25, 0.0, 0.1],
+    anchor_rot=[0.7071068, 0.0, 0.0, -0.7071068],
+)
+
+# Additive world-frame offset applied to each device's ``XrCfg.anchor_pos``
+# depending on the selected retargeter mode. This is the global default used by
+# every environment; individual env cfgs can override it by setting a
+# ``retargeter_anchor_pos_offsets`` attribute to a dict of the same shape (or
+# a partial dict — unspecified modes fall back to the default).
+#
+# Rationale: the absolute retargeter drives the robot wrist to the VR hand's
+# world pose directly, so the VR hand's natural resting position should sit a
+# bit lower than in the relative retargeter (which offsets from the robot's
+# calibration pose).
+DEFAULT_RETARGETER_ANCHOR_POS_OFFSET: dict[str, tuple[float, float, float]] = {
+    "relative": (0.0, 0.0, 0.0),
+    "absolute": (0.1, 0.0, -0.3),
+}
+
+
+def maybe_set_leap_xr_cfg(env_cfg) -> None:
+    """Use Leap-style XR anchor when `robot_type` is a Leap variant."""
+    rt = getattr(env_cfg, "robot_type", None)
+    if rt in (
+        "floating_leap_right",
+        "floating_leap_bimanual",
+        "bimanual_leap",
+    ):
+        env_cfg.xr = DEFAULT_FLOATING_LEAP_XR_CFG
+
+
+def _devices_simple_relative(sim_device, xr_cfg: XrCfg, simple_robot_type: str) -> DevicesCfg:
+    """Single code path: `SimpleRelativeRetargeter` with layout from `simple_relative_retargeting.py`."""
+    return DevicesCfg(
+        devices={
+            "handtracking": OpenXRDeviceCfg(
+                retargeters=[
+                    SimpleRelativeRetargeterCfg(
+                        sim_device=sim_device,
+                        robot_type=simple_robot_type,
+                    )
+                ],
+                sim_device=sim_device,
+                xr_cfg=xr_cfg,
+            ),
+        }
+    )
+
+
+def _devices_simple_absolute(sim_device, xr_cfg: XrCfg, simple_robot_type: str) -> DevicesCfg:
+    """Single code path for :class:`SimpleAbsoluteRetargeter`.
+
+    The absolute retargeter drives the robot wrist to the VR hand's world pose
+    (the red-dot location in the XR visualization) rather than to a delta from
+    a calibration pose.
+    """
+    return DevicesCfg(
+        devices={
+            "handtracking": OpenXRDeviceCfg(
+                retargeters=[
+                    SimpleAbsoluteRetargeterCfg(
+                        sim_device=sim_device,
+                        robot_type=simple_robot_type,
+                    )
+                ],
+                sim_device=sim_device,
+                xr_cfg=xr_cfg,
+            ),
+        }
+    )
+
+
+def build_floating_teleop_devices(
+    sim_device,
+    xr_cfg: XrCfg,
+    hand_joint_names: list[str],
+    wrist_position_offset: tuple[float, float, float],
+    retargeter_config_filename: str | None,
+    retargeter_urdf_path: str | None = None,
+    apply_shadow_specific_postprocess: bool = False,
+    enable_visualization: bool = True,
+    num_open_xr_hand_joints: int = 26,
+    env_robot_type: str | None = None,
+    use_absolute_retargeter: bool = False,
+) -> DevicesCfg:
+    """Build teleoperation devices for floating tabletop robots.
+
+    All supported robots use :class:`~dexverse.devices.retargeters.simple_relative_retargeting.SimpleRelativeRetargeter`
+    so finger joint ordering matches ``SIMPLE_RELATIVE_RETARGETER_LAYOUT`` / dex specs in each robot module.
+
+    Args:
+        sim_device: Simulation device (e.g., ``cuda:0``).
+        xr_cfg: XR configuration.
+        hand_joint_names: Legacy; unused for SimpleRelative (kept for call-site compatibility).
+        wrist_position_offset: Legacy; unused for SimpleRelative.
+        retargeter_config_filename: Legacy filename hint; only used if ``env_robot_type`` is missing.
+        retargeter_urdf_path: Legacy; unused.
+        apply_shadow_specific_postprocess: Legacy; unused.
+        enable_visualization: Legacy; unused.
+        num_open_xr_hand_joints: Legacy; unused.
+        env_robot_type: Must match :attr:`DexVerseBaseEnvCfg.robot_type` (e.g. ``floating_shadow_right``).
+            This selects the layout key in ``SIMPLE_RETARGETER_LAYOUT_SOURCES``. Prefer passing this always.
+        use_absolute_retargeter: If True, use :class:`SimpleAbsoluteRetargeter`
+            so the robot wrist tracks the VR hand's world pose directly. If
+            False (default), use :class:`SimpleRelativeRetargeter` which tracks
+            displacement from the calibration pose.
+
+    Returns:
+        DevicesCfg with OpenXR + retargeter (relative or absolute based on flag).
+    """
+    # Legacy parameters above are kept for call-site compatibility; layout is driven by env_robot_type.
+    _ = (
+        hand_joint_names,
+        wrist_position_offset,
+        retargeter_urdf_path,
+        apply_shadow_specific_postprocess,
+        enable_visualization,
+        num_open_xr_hand_joints,
+    )
+
+    devices_builder = _devices_simple_absolute if use_absolute_retargeter else _devices_simple_relative
+
+    # Primary: explicit env robot type (authoritative; avoids brittle filename substring rules).
+    if env_robot_type is not None and env_robot_type in SIMPLE_RETARGETER_LAYOUT_SOURCES:
+        return devices_builder(sim_device, xr_cfg, env_robot_type)
+
+    # Legacy fallback: infer from retargeter_config_filename (e.g. custom tasks / old scripts).
+    if retargeter_config_filename:
+        name_lower = retargeter_config_filename.lower()
+        if name_lower in (
+            "floating_leap_bimanual",
+            "bimanual_leap",
+            "floating_shadow_left",
+            "floating_shadow_bimanual",
+            "floating_sharpa_right",
+            "floating_sharpa_left",
+            "floating_sharpa_bimanual",
+            "floating_wuji_right",
+            "floating_wuji_left",
+            "floating_wuji_bimanual",
+        ):
+            return devices_builder(sim_device, xr_cfg, retargeter_config_filename)
+        if "shadow" in name_lower:
+            return devices_builder(sim_device, xr_cfg, "floating_shadow_right")
+        if "leap" in name_lower:
+            return devices_builder(sim_device, xr_cfg, "floating_leap_right")
+
+    raise ValueError(
+        "Could not select a SimpleRelative retargeter layout. Pass env_robot_type= to "
+        "build_floating_teleop_devices (e.g. 'floating_shadow_right', 'floating_leap_right'). "
+        f"Supported keys: {sorted(SIMPLE_RETARGETER_LAYOUT_SOURCES.keys())}."
+    )
+
+
+def _clone_retargeter_cfg(source, target_cls):
+    """Return a new ``target_cls`` instance copying common dataclass fields from ``source``.
+
+    Fields declared on ``source`` are copied. Fields that are *only* on
+    ``target_cls`` are also copied if the source carries a matching runtime
+    attribute (e.g. an env-cfg patch attached ``wrist_joint_origin`` to a
+    relative cfg so it survives the relative→absolute swap). ``retargeter_type``
+    is left at the ``target_cls`` default so the new cfg builds the intended
+    retargeter.
+    """
+    if not (is_dataclass(source) and is_dataclass(target_cls)):
+        return source
+    src_field_names = {f.name for f in fields(source)}
+    kwargs = {}
+    for field in fields(target_cls):
+        if field.name == "retargeter_type":
+            continue
+        if field.name in src_field_names or hasattr(source, field.name):
+            kwargs[field.name] = getattr(source, field.name)
+    return target_cls(**kwargs)
+
+
+def _resolve_anchor_pos_offset(
+    mode: str,
+    anchor_pos_offsets: dict[str, tuple[float, float, float]] | None,
+) -> tuple[float, float, float]:
+    """Pick the anchor-pos offset for ``mode`` from an override dict or the default.
+
+    ``anchor_pos_offsets`` may be a partial dict; unspecified modes fall back
+    to :data:`DEFAULT_RETARGETER_ANCHOR_POS_OFFSET`.
+    """
+    if anchor_pos_offsets is not None and mode in anchor_pos_offsets:
+        offset = anchor_pos_offsets[mode]
+    else:
+        offset = DEFAULT_RETARGETER_ANCHOR_POS_OFFSET.get(mode, (0.0, 0.0, 0.0))
+    return (float(offset[0]), float(offset[1]), float(offset[2]))
+
+
+def _apply_anchor_pos_offset_to_devices(
+    devices_cfg,
+    offset: tuple[float, float, float],
+) -> None:
+    """Add ``offset`` to ``xr_cfg.anchor_pos`` on every device in ``devices_cfg``."""
+    if offset == (0.0, 0.0, 0.0):
+        return
+    devices = getattr(devices_cfg, "devices", None) or {}
+    for device_cfg in devices.values():
+        xr_cfg = getattr(device_cfg, "xr_cfg", None)
+        if xr_cfg is None:
+            continue
+        ax, ay, az = xr_cfg.anchor_pos
+        ox, oy, oz = offset
+        device_cfg.xr_cfg = xr_cfg.replace(anchor_pos=(ax + ox, ay + oy, az + oz))
+
+
+def apply_teleop_retargeter_mode(
+    devices_cfg,
+    mode: str,
+    anchor_pos_offsets: dict[str, tuple[float, float, float]] | None = None,
+) -> None:
+    """Swap retargeter cfgs in an already-built :class:`DevicesCfg` in place.
+
+    This is the entry point used by CLI scripts (``teleop_agent.py`` /
+    ``record_demos.py``) to switch between the relative and absolute retargeter
+    after a task's env cfg has been fully built by its ``__post_init__`` — it
+    avoids having every task cfg forward an extra flag.
+
+    Each device's ``xr_cfg.anchor_pos`` is also nudged by a per-mode offset so
+    the VR viewpoint matches what feels natural for that retargeter (in
+    particular, the absolute retargeter wants a slightly lower anchor than the
+    relative one). The offset comes from ``anchor_pos_offsets`` if provided,
+    otherwise from :data:`DEFAULT_RETARGETER_ANCHOR_POS_OFFSET`.
+
+    Args:
+        devices_cfg: ``DevicesCfg`` (typically ``env_cfg.teleop_devices``) that
+            may carry one or more retargeter cfgs in its device entries.
+        mode: One of :data:`TELEOP_RETARGETER_MODES`.
+        anchor_pos_offsets: Optional per-env override for the per-mode anchor
+            offsets. Partial dicts are allowed — unspecified modes fall back to
+            the module-level default.
+    """
+    if mode not in TELEOP_RETARGETER_MODES:
+        raise ValueError(f"Unknown teleop retargeter mode '{mode}'. Supported: {TELEOP_RETARGETER_MODES}.")
+    if devices_cfg is None:
+        return
+
+    offset = _resolve_anchor_pos_offset(mode, anchor_pos_offsets)
+    _apply_anchor_pos_offset_to_devices(devices_cfg, offset)
+
+    if mode == "relative":
+        return
+
+    mode_to_target = {
+        "absolute": SimpleAbsoluteRetargeterCfg,
+    }
+    target_cls = mode_to_target[mode]
+
+    devices = getattr(devices_cfg, "devices", None) or {}
+    for device_cfg in devices.values():
+        retargeters = getattr(device_cfg, "retargeters", None)
+        if not retargeters:
+            continue
+        swapped = []
+        for rtg in retargeters:
+            # Only convert the *relative* cfg family; leave unrelated retargeters
+            # (user-provided or arm-specific) untouched so this helper is safe
+            # to run on arbitrary env cfgs.
+            if isinstance(rtg, SimpleAbsoluteRetargeterCfg):
+                swapped.append(rtg)
+            elif isinstance(rtg, SimpleRelativeRetargeterCfg):
+                swapped.append(_clone_retargeter_cfg(rtg, target_cls))
+            else:
+                swapped.append(rtg)
+        device_cfg.retargeters = swapped
+
+
+def apply_teleop_retargeting_scheme(devices_cfg, scheme: str) -> None:
+    """Set the dex-retargeting ``scheme`` on every Simple retargeter cfg in place.
+
+    Companion to :func:`apply_teleop_retargeter_mode`. Where that helper swaps
+    the relative/absolute wrist behavior, this one selects which finger
+    retargeting YAML each retargeter loads (``"dexpilot"`` vs ``"vector"``).
+    Both :class:`SimpleRelativeRetargeterCfg` and
+    :class:`SimpleAbsoluteRetargeterCfg` carry the ``retargeting_scheme`` field,
+    so this is safe to call before or after the relative/absolute swap.
+
+    Args:
+        devices_cfg: ``DevicesCfg`` (typically ``env_cfg.teleop_devices``).
+        scheme: One of :data:`TELEOP_RETARGETING_SCHEMES`.
+    """
+    if scheme not in TELEOP_RETARGETING_SCHEMES:
+        raise ValueError(f"Unknown retargeting scheme '{scheme}'. Supported: {TELEOP_RETARGETING_SCHEMES}.")
+    if devices_cfg is None:
+        return
+
+    devices = getattr(devices_cfg, "devices", None) or {}
+    for device_cfg in devices.values():
+        retargeters = getattr(device_cfg, "retargeters", None)
+        if not retargeters:
+            continue
+        for rtg in retargeters:
+            # Only the Simple retargeter family understands schemes; leave any
+            # unrelated (user-provided / arm-specific) retargeters untouched.
+            if isinstance(rtg, SimpleRelativeRetargeterCfg):
+                rtg.retargeting_scheme = scheme
+
+
+def setup_floating_teleop(env_cfg) -> None:
+    """Wire up floating-hand teleoperation devices on ``env_cfg``.
+
+    Encapsulates the boilerplate shared by every floating-hand robot variant
+    (single-hand right/left and bimanual; the device layout is selected from
+    ``env_cfg.robot_type``): apply the optional Leap XR override, then build the
+    teleop devices from the env's ``_teleop_config`` (if present). Call from
+    ``__post_init__`` *after* ``super().__post_init__()`` with ``robot_type`` and
+    ``xr`` already set.
+    """
+    maybe_set_leap_xr_cfg(env_cfg)
+    if hasattr(env_cfg, "_teleop_config"):
+        teleop_config = env_cfg._teleop_config
+        env_cfg.teleop_devices = build_floating_teleop_devices(
+            sim_device=env_cfg.sim.device,
+            xr_cfg=env_cfg.xr,
+            hand_joint_names=teleop_config["hand_joint_names"],
+            wrist_position_offset=teleop_config["wrist_position_offset"],
+            retargeter_config_filename=teleop_config["retargeter_config_filename"],
+            retargeter_urdf_path=teleop_config["retargeter_urdf_path"],
+            apply_shadow_specific_postprocess=teleop_config["apply_shadow_specific_postprocess"],
+            env_robot_type=env_cfg.robot_type,
+        )
+
+    for device in env_cfg.teleop_devices.devices.values():
+        for retargeter in device.retargeters:
+            if isinstance(retargeter, SimpleRelativeRetargeterCfg):
+                retargeter.task_version = 1
+                retargeter.debug_vis = bool(env_cfg.enable_debug_vis)

--- a/source/dexverse/dexverse/baseline_v1/config/functional/__init__.py
+++ b/source/dexverse/dexverse/baseline_v1/config/functional/__init__.py
@@ -1,0 +1,1 @@
+"""Version-one baseline task implementation package."""

--- a/source/dexverse/dexverse/baseline_v1/config/functional/base_cfg.py
+++ b/source/dexverse/dexverse/baseline_v1/config/functional/base_cfg.py
@@ -1,0 +1,864 @@
+# Copyright (c) 2025-2026, The DexVerse Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Shared base for functional manipulation tasks.
+
+Each functional-grasping task pins a single USD asset (one object per task)
+because the eventual success criterion is object-specific (e.g. correct
+power-grasp on a bleach bottle, correct handle-grasp on a pan). This module
+contains both lift-to-goal and pouring variants, all built on the same
+single-object setup.
+
+Forbidden and designated contact zones
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Each task can declare a list of :class:`ForbiddenZone` entries in the
+object's local frame. Success requires reaching the goal AND keeping every
+fingertip outside every zone. Zones are also rendered as red,
+semi-transparent markers that track the object pose for inspection.
+
+Tasks can also declare :class:`DesignatedContactZone` entries. Each contact
+zone is satisfied when at least one configured body, by default a fingertip,
+lies inside that object-local region.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import field
+
+import isaaclab.sim as sim_utils
+from isaaclab.assets import RigidObjectCfg
+from isaaclab.devices.openxr import XrCfg
+from isaaclab.managers import EventTermCfg as EventTerm
+from isaaclab.managers import ObservationGroupCfg as ObsGroup
+from isaaclab.managers import ObservationTermCfg as ObsTerm
+from isaaclab.managers import RewardTermCfg as RewTerm
+from isaaclab.managers import SceneEntityCfg
+from isaaclab.managers import TerminationTermCfg as DoneTerm
+from isaaclab.markers import VisualizationMarkersCfg
+from isaaclab.utils import configclass
+from isaaclab.utils.noise import UniformNoiseCfg as Unoise
+
+from ... import dexverse_base_env_cfg as dexverse_base_env
+from ... import mdp
+from ..floating_teleop import DEFAULT_FLOATING_SHADOW_XR_CFG, setup_floating_teleop
+from ..grasping.forbidden_zones import DesignatedContactZone, ForbiddenZone, split_zones
+from .rewards import (
+    POUR_ANGLE_RAD,
+    DenseFunctionalGraspingRewardsCfg,
+    DenseFunctionalPourRewardsCfg,
+    FunctionalGraspingRewardsCfg,
+    FunctionalPourRewardsCfg,
+    wire_fingertip_reward_bodies,
+)
+
+__all__ = [
+    "FUNCTIONAL_OBJECTS_DIR",
+    "SYNTHESIS_DIR",
+    "YCB_DIR",
+    "DesignatedContactZone",
+    "ForbiddenZone",
+    "FunctionalGraspingEnvCfg",
+    "FunctionalGraspingEnvFloatingDexHandRightCfg",
+    "FunctionalPourEnvCfg",
+    "FunctionalPourEnvFloatingDexHandRightCfg",
+    "FunctionalPourEventCfg",
+    "FunctionalPourObservationsCfg",
+    "FunctionalPourRewardsCfg",
+    "FunctionalPourTerminationsCfg",
+    "POUR_ANGLE_RAD",
+    "build_object_cfg_from_usd",
+]
+
+
+# Per-object USD asset roots used by this task family. Objects are sourced from
+# the synthesis pool, except the YCB-derived drill/hammer which live under ycb/.
+from dexverse.assets import FUNCTIONAL_OBJECTS_DIR, SYNTHESIS_DIR, YCB_DIR
+
+DEFAULT_OBJECT_ROT = (0.707107, -0.707107, 0.0, 0.0)
+DEFAULT_OBJECT_MASS = 0.3
+DEFAULT_OBJECT_HALF_HEIGHT = 0.05
+CENTER_SQUARE_SIZE = 0.45
+BOUND_Z_MIN = -0.2
+BOUND_Z_MAX = 1.5
+
+POUR_LIFT_HEIGHT_M = 0.2
+SUCCESS_MARKER_SIZE = (0.01, 0.01, 0.12)
+SUCCESS_MARKER_COLOR = (0.1, 0.9, 0.1)
+SUCCESS_MARKER_QUAT = (
+    math.cos(POUR_ANGLE_RAD * 0.5),
+    -math.sin(POUR_ANGLE_RAD * 0.5),
+    0.0,
+    0.0,
+)
+
+
+SUCCESS_MARKER_CFG = RigidObjectCfg(
+    prim_path="{ENV_REGEX_NS}/SuccessMarker",
+    spawn=sim_utils.CuboidCfg(
+        size=SUCCESS_MARKER_SIZE,
+        rigid_props=sim_utils.RigidBodyPropertiesCfg(
+            rigid_body_enabled=True,
+            kinematic_enabled=True,
+            disable_gravity=True,
+        ),
+        collision_props=sim_utils.CollisionPropertiesCfg(collision_enabled=False),
+        visual_material=sim_utils.PreviewSurfaceCfg(
+            diffuse_color=SUCCESS_MARKER_COLOR,
+            emissive_color=(0.0, 0.3, 0.0),
+            roughness=1.0,
+            metallic=0.0,
+        ),
+        # Legacy green cuboid-pole indicator: permanently hidden (Aug 2026). The
+        # entity itself stays -- goal/reset logic anchors on its pose; the visible
+        # goal indicator is the red->green progress sphere below.
+        visible=False,
+    ),
+    init_state=RigidObjectCfg.InitialStateCfg(pos=(0.0, 0.0, 0.0), rot=SUCCESS_MARKER_QUAT),
+)
+
+
+def build_object_cfg_from_usd(
+    usd_path: str,
+    *,
+    mass: float = DEFAULT_OBJECT_MASS,
+    scale: tuple[float, float, float] = (1.0, 1.0, 1.0),
+    init_rot: tuple[float, float, float, float] = DEFAULT_OBJECT_ROT,
+    collision_enabled: bool = False,
+    static_friction: float | None = None,
+    dynamic_friction: float | None = None,
+    restitution: float = 0.0,
+    friction_combine_mode: str = "average",
+    prim_name: str = "Object",
+) -> RigidObjectCfg:
+    """Build a single-asset :class:`RigidObjectCfg` from a USD file path.
+
+    Note: ``collision_props`` is intentionally left ``None``. Applying
+    :class:`CollisionPropertiesCfg` here would cause the spawn pipeline to
+    apply ``UsdPhysics.CollisionAPI`` to the root Xform, and the
+    ``@apply_nested`` walk in :func:`modify_collision_properties` then stops
+    at the root before visiting the child mesh. That overrides the source
+    USD's authored :class:`MeshCollisionAPI` (e.g. ``convexDecomposition``)
+    with PhysX's default ``convexHull`` fallback. We rely on the asset USD
+    to already author CollisionAPI / MeshCollisionAPI on the mesh prim.
+    """
+    return RigidObjectCfg(
+        prim_path=f"{{ENV_REGEX_NS}}/{prim_name}",
+        spawn=sim_utils.UsdFileCfg(
+            func=dexverse_base_env.spawn_usd_with_rigid_properties,
+            usd_path=usd_path,
+            scale=scale,
+            rigid_props=sim_utils.RigidBodyPropertiesCfg(
+                rigid_body_enabled=True,
+                solver_position_iteration_count=16,
+                solver_velocity_iteration_count=0,
+                disable_gravity=False,
+            ),
+            collision_props=(sim_utils.CollisionPropertiesCfg(collision_enabled=True)) if collision_enabled else None,
+            mass_props=sim_utils.MassPropertiesCfg(mass=mass),
+        ),
+        init_state=RigidObjectCfg.InitialStateCfg(pos=(0.0, 0.0, 0.0), rot=init_rot),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Forbidden zones
+# ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# Observations
+# ---------------------------------------------------------------------------
+
+
+@configclass
+class _GoalObsCfg(ObsGroup):
+    """Goal pose pulled from the ``object_pose`` command (non-privileged)."""
+
+    target_object_pose_b = ObsTerm(
+        func=mdp.generated_commands,
+        params={"command_name": "object_pose"},
+    )
+
+    def __post_init__(self):
+        self.enable_corruption = True
+        self.concatenate_terms = True
+        self.history_length = 0
+
+
+@configclass
+class _FunctionalTiltGoalObsCfg(ObsGroup):
+    """Goal position for asset-goal functional tasks.
+
+    Position of the per-task ``success_marker`` (a scene asset, so this is
+    reward-independent). The object's *current* tilt is observed via the
+    tilt-axis vector in the ``state`` group; the target tilt threshold is a
+    per-task constant kept out of observations on purpose (this is an
+    imitation-learning benchmark — the demonstrated motion teaches the tilt).
+    """
+
+    goal_pos_b = ObsTerm(
+        func=mdp.asset_pos_b,
+        noise=Unoise(n_min=-0.0, n_max=0.0),
+        params={"asset_cfg": SceneEntityCfg("success_marker")},
+    )
+
+    def __post_init__(self):
+        self.enable_corruption = True
+        self.concatenate_terms = True
+        self.history_length = 0
+
+
+@configclass
+class FunctionalGraspingObservationsCfg(dexverse_base_env.ObservationsCfg):
+    """Observation layout for single-object functional grasping.
+
+    Extends the root layout by adding:
+      - ``state``: object pose (observable, deployable; no velocities).
+      - ``privileged``: object linear / angular velocities (sim-only).
+      - ``goal``: ``target_object_pose_b`` from the ``object_pose`` command.
+
+    Debug markers (forbidden / designated-contact / affinity zone
+    visualizers) are populated into ``scene_vis`` by ``configure_debug_vis``
+    (see ``DexVerseBaseEnvCfg.enable_debug_vis``), not a dedicated
+    group here.
+
+    ``proprio`` stays as the base's joint-pos-only group.
+    """
+
+    @configclass
+    class StateObsCfg(ObsGroup):
+        object_pos_b = ObsTerm(func=mdp.object_pos_b, noise=Unoise(n_min=-0.0, n_max=0.0))
+        object_quat_b = ObsTerm(func=mdp.object_quat_b, noise=Unoise(n_min=-0.0, n_max=0.0))
+
+        def __post_init__(self):
+            self.enable_corruption = True
+            self.concatenate_terms = True
+            self.history_length = 0
+
+    @configclass
+    class PrivilegedObsCfg(dexverse_base_env.ObservationsCfg.PrivilegedObsCfg):
+        object_lin_vel_b = ObsTerm(func=mdp.object_lin_vel_b, noise=Unoise(n_min=-0.0, n_max=0.0))
+        object_ang_vel_b = ObsTerm(func=mdp.object_ang_vel_b, noise=Unoise(n_min=-0.0, n_max=0.0))
+
+    state: StateObsCfg = StateObsCfg()
+    privileged: PrivilegedObsCfg = PrivilegedObsCfg()
+    goal: _GoalObsCfg = _GoalObsCfg()
+
+
+@configclass
+class FunctionalPourObservationsCfg(FunctionalGraspingObservationsCfg):
+    """Observation layout for pouring tasks.
+
+    Inherits the grasping layout, then:
+      - Adds task-specific functional point + tilt-axis terms to ``state``.
+        These are pure functions of the object pose plus per-asset constants
+        (pour_local_offset, pour_axis_local, …) baked in at cfg time, so they
+        are observable, deployable state. The object's *current* tilt is read
+        off ``object_functional_axis_b`` (a direction vector); the redundant
+        scalar tilt / plane angles are intentionally dropped.
+      - Replaces the command-pose goal with the success-marker goal position
+        in ``goal``.
+
+    Note: ``object_up_b`` and ``object_tilt_angle`` are intentionally NOT
+    added — they are pure trigonometric derivations of ``object_quat_b``
+    (already in ``state``) and bloat the observation vector without adding
+    information.
+    """
+
+    @configclass
+    class StateObsCfg(FunctionalGraspingObservationsCfg.StateObsCfg):
+        object_functional_point_pos_b = ObsTerm(
+            func=mdp.object_local_point_pos_b,
+            noise=Unoise(n_min=-0.0, n_max=0.0),
+        )
+        object_functional_axis_b = ObsTerm(
+            func=mdp.object_rot_axis_b,
+            noise=Unoise(n_min=-0.0, n_max=0.0),
+        )
+
+    state: StateObsCfg = StateObsCfg()
+    goal: _FunctionalTiltGoalObsCfg = _FunctionalTiltGoalObsCfg()
+
+
+# ---------------------------------------------------------------------------
+# Commands / Rewards / Terminations
+# ---------------------------------------------------------------------------
+
+
+@configclass
+class FunctionalGraspingCommandsCfg(dexverse_base_env.CommandsCfg):
+    """Goal-position command (sphere visualizer), held fixed for the episode."""
+
+    object_pose = mdp.ObjectUniformPoseCommandCfg(
+        asset_name="robot",
+        object_name="object",
+        resampling_time_range=(3.0, 5.0),
+        debug_vis=True,
+        use_world_frame=True,
+        ranges=mdp.ObjectUniformPoseCommandCfg.Ranges(
+            pos_x=(0.0, 0.0),
+            pos_y=(0.0, 0.0),
+            pos_z=(0.10, 0.20),  # overwritten in __post_init__
+            roll=(0.0, 0.0),
+            pitch=(0.0, 0.0),
+            yaw=(0.0, 0.0),
+        ),
+        success_vis_asset_name="object",
+        position_only=True,
+    )
+
+
+@configclass
+class FunctionalGraspingTerminationsCfg(dexverse_base_env.TerminationsCfg):
+    """Out-of-bound + goal-proximity success (replaced in __post_init__ when zones are set)."""
+
+    object_out_of_bound = DoneTerm(
+        func=mdp.out_of_bound,
+        params={
+            "in_bound_range": {"x": (-1.0, 1.0), "y": (-1.0, 1.0), "z": (BOUND_Z_MIN, BOUND_Z_MAX)},
+            "asset_cfg": SceneEntityCfg("object"),
+        },
+    )
+
+    success = DoneTerm(
+        func=mdp.object_at_goal_position,
+        params={"command_name": "object_pose", "threshold": 0.03},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Env config
+# ---------------------------------------------------------------------------
+
+
+@configclass
+class FunctionalGraspingEnvCfg(dexverse_base_env.DexVerseBaseEnvCfg):
+    """Robot-agnostic base for single-object functional grasping.
+
+    Subclasses must set :attr:`usd_path` to a single USD file and may
+    override :attr:`object_half_height` to match the asset's geometry.
+    Subclasses also populate :attr:`forbidden_zones` with object-specific
+    regions the hand must not touch.
+    """
+
+    supports_object_pose_command: bool = True
+
+    usd_path: str | None = None
+    object_half_height: float = DEFAULT_OBJECT_HALF_HEIGHT
+    object_mass: float = DEFAULT_OBJECT_MASS
+    object_scale: tuple[float, float, float] = (1.0, 1.0, 1.0)
+    object_init_rot: tuple[float, float, float, float] = DEFAULT_OBJECT_ROT
+    object_collision_enabled: bool = False
+    object_static_friction: float | None = None
+    object_dynamic_friction: float | None = None
+    object_restitution: float = 0.0
+    object_friction_combine_mode: str = "average"
+
+    # ---- Object initial spawn pose (offsets from table centre) ----
+    # The z spawn coordinate is always derived from
+    # ``DEFAULT_TABLE_TOP_HEIGHT + object_half_height + table_clearance`` so
+    # the object sits flush on the tabletop unless a clearance is requested.
+    object_init_x_offset: float = 0.0
+    object_init_y_offset: float = 0.0
+    table_clearance: float = 0.0
+
+    # ---- Object reset randomization (per-axis ranges in object-local frame) ----
+    # ``object_reset_y_range`` defaults to ``None``, which means "derive from
+    # ``center_square_size``" so the historical centre-square reset behaviour
+    # still applies when no explicit y-range is given. All other axes default
+    # to ``(0.0, 0.0)`` (no randomization).
+    center_square_size: float = CENTER_SQUARE_SIZE
+    object_reset_x_range: tuple[float, float] = (0.0, 0.0)
+    object_reset_y_range: tuple[float, float] | None = None
+    object_reset_z_range: tuple[float, float] = (0.0, 0.0)
+    object_reset_roll_range: tuple[float, float] = (0.0, 0.0)
+    object_reset_pitch_range: tuple[float, float] = (0.0, 0.0)
+    object_reset_yaw_range: tuple[float, float] = (0.0, 0.0)
+
+    # ---- Goal-pose randomization ----
+    # x/y are interpreted as offsets from the table centre, z as offset from
+    # the tabletop surface. Defaults of ``(0.0, 0.0)`` for x/y reproduce the
+    # original behaviour (goal directly above the table centre).
+    target_x_range: tuple[float, float] = (0.0, 0.0)
+    target_y_range: tuple[float, float] = (0.0, 0.0)
+    target_height_range: tuple[float, float] = (0.10, 0.20)
+
+    # ---- Forbidden zones ----
+    forbidden_zones: tuple[ForbiddenZone, ...] = field(default_factory=tuple)
+    success_position_threshold: float = 0.03
+    forbidden_zone_color: tuple[float, float, float] = (0.9, 0.1, 0.1)
+    forbidden_zone_opacity: float = 0.4
+
+    # ---- Designated contact zones ----
+    designated_contact_zones: tuple[DesignatedContactZone, ...] = field(default_factory=tuple)
+    designated_contact_asset_name: str = "robot"
+    designated_contact_body_names: tuple[str, ...] | None = None
+    designated_contact_object_name: str = "object"
+    designated_contact_zone_color: tuple[float, float, float] = (0.1, 0.8, 0.2)
+    designated_contact_zone_opacity: float = 0.45
+
+    @configclass
+    class FunctionalGraspingSceneCfg(dexverse_base_env.SceneCfg):
+        # Placeholder; replaced from ``usd_path`` in __post_init__.
+        object: RigidObjectCfg = build_object_cfg_from_usd(
+            usd_path=str(FUNCTIONAL_OBJECTS_DIR / "Bleach_1" / "model_Bleach_1_69323.usd"),
+            mass=DEFAULT_OBJECT_MASS,
+            init_rot=DEFAULT_OBJECT_ROT,
+        )
+
+    scene: FunctionalGraspingSceneCfg = FunctionalGraspingSceneCfg(
+        num_envs=4096,
+        env_spacing=3,
+        replicate_physics=False,
+    )
+    observations: FunctionalGraspingObservationsCfg = FunctionalGraspingObservationsCfg()
+    commands: FunctionalGraspingCommandsCfg = FunctionalGraspingCommandsCfg()
+    rewards: FunctionalGraspingRewardsCfg = DenseFunctionalGraspingRewardsCfg()
+    terminations: FunctionalGraspingTerminationsCfg = FunctionalGraspingTerminationsCfg()
+
+    def __post_init__(self):
+        # Resolve single-USD object before scene materialization so super()
+        # sees the correct ``scene.object``.
+        if self.usd_path is not None:
+            self.scene.object = build_object_cfg_from_usd(
+                self.usd_path,
+                mass=self.object_mass,
+                scale=self.object_scale,
+                init_rot=self.object_init_rot,
+                collision_enabled=self.object_collision_enabled,
+                static_friction=self.object_static_friction,
+                dynamic_friction=self.object_dynamic_friction,
+                restitution=self.object_restitution,
+                friction_combine_mode=self.object_friction_combine_mode,
+            )
+
+        super().__post_init__()
+
+        self.episode_length_s = 20.0
+
+        table_top_z = dexverse_base_env.DEFAULT_TABLE_TOP_HEIGHT
+        table_pos = self.scene.table.init_state.pos
+
+        # Place object flush on the table surface, applying x/y offsets.
+        self.scene.object.init_state.pos = (
+            table_pos[0] + self.object_init_x_offset,
+            table_pos[1] + self.object_init_y_offset,
+            table_top_z + self.object_half_height + self.table_clearance,
+        )
+
+        # Randomize object reset on the tabletop. ``object_reset_y_range``
+        # falls back to a centre-square (±center_square_size / 2) when left
+        # as ``None`` so older configs continue to behave the same.
+        if self.object_reset_y_range is None:
+            half_side = self.center_square_size * 0.5
+            y_range = (-half_side, half_side)
+        else:
+            y_range = self.object_reset_y_range
+        if self.events.reset_object is not None:
+            self.events.reset_object.params["pose_range"] = {
+                "x": list(self.object_reset_x_range),
+                "y": list(y_range),
+                "z": list(self.object_reset_z_range),
+                "roll": list(self.object_reset_roll_range),
+                "pitch": list(self.object_reset_pitch_range),
+                "yaw": list(self.object_reset_yaw_range),
+            }
+
+        # Clamp out-of-bound to table footprint.
+        if self.terminations.object_out_of_bound is not None:
+            table_size = self.scene.table.spawn.size
+            self.terminations.object_out_of_bound.params["in_bound_range"] = {
+                "x": (-table_size[0] * 0.5, table_size[0] * 0.5),
+                "y": (-table_size[1] * 0.5, table_size[1] * 0.5),
+                "z": (BOUND_Z_MIN, BOUND_Z_MAX),
+            }
+
+        # Configure goal command: fixed within episode, world-frame, table-anchored.
+        self.commands.object_pose.body_name = self.robot_config.palm_body_name
+        self.commands.object_pose.resampling_time_range = (
+            self.episode_length_s + 1.0,
+            self.episode_length_s + 1.0,
+        )
+        self.commands.object_pose.use_world_frame = True
+        self.commands.object_pose.ranges.pos_x = (
+            table_pos[0] + self.target_x_range[0],
+            table_pos[0] + self.target_x_range[1],
+        )
+        self.commands.object_pose.ranges.pos_y = (
+            table_pos[1] + self.target_y_range[0],
+            table_pos[1] + self.target_y_range[1],
+        )
+        self.commands.object_pose.ranges.pos_z = (
+            table_top_z + self.target_height_range[0],
+            table_top_z + self.target_height_range[1],
+        )
+
+        # Goal visualizers.
+        self.commands.object_pose.goal_pose_visualizer_cfg = VisualizationMarkersCfg(
+            prim_path="/Visuals/Command/goal_pose",
+            markers={
+                "target": sim_utils.SphereCfg(
+                    radius=0.03,
+                    visual_material=sim_utils.PreviewSurfaceCfg(diffuse_color=(0.2, 0.6, 0.9), opacity=0.35),
+                )
+            },
+        )
+        self.commands.object_pose.success_visualizer_cfg = VisualizationMarkersCfg(
+            prim_path="/Visuals/SuccessMarkers",
+            markers={
+                "failure": sim_utils.SphereCfg(
+                    radius=0.03,
+                    visible=False,
+                    visual_material=sim_utils.PreviewSurfaceCfg(diffuse_color=(0.8, 0.2, 0.2)),
+                ),
+                "success": sim_utils.SphereCfg(
+                    radius=0.03,
+                    visible=False,
+                    visual_material=sim_utils.PreviewSurfaceCfg(diffuse_color=(0.2, 0.8, 0.2)),
+                ),
+            },
+        )
+
+        # Contact sensors per fingertip (filtered to the object).
+        mdp.setup_fingertip_contact_observation(self)
+        wire_fingertip_reward_bodies(self.rewards, self.robot_config.fingertip_body_names)
+
+        # Replace success termination with the zone-gated version.
+        sphere_zones, box_zones, cylinder_zones = split_zones(self.forbidden_zones)
+        contact_sphere_zones, contact_box_zones, contact_cylinder_zones = split_zones(self.designated_contact_zones)
+        contact_body_names = self.designated_contact_body_names
+        if contact_body_names is None and self.designated_contact_asset_name == "robot":
+            contact_body_names = self.robot_config.fingertip_body_names
+
+        success_func = (
+            mdp.success_with_contact_zones
+            if (contact_sphere_zones or contact_box_zones or contact_cylinder_zones)
+            else mdp.success_no_forbidden_contact
+        )
+        success_params = {
+            "command_name": "object_pose",
+            "threshold": self.success_position_threshold,
+            "sphere_zones": sphere_zones,
+            "box_zones": box_zones,
+            "cylinder_zones": cylinder_zones,
+            # forbidden zones: every robot body counts (cross-embodiment); the
+            # designated *contact* zones below keep the fingertips
+            "asset_cfg": self.forbidden_zone_asset_cfg(),
+            "object_cfg": SceneEntityCfg("object"),
+        }
+        if contact_sphere_zones or contact_box_zones or contact_cylinder_zones:
+            success_params.update({
+                "contact_sphere_zones": contact_sphere_zones,
+                "contact_box_zones": contact_box_zones,
+                "contact_cylinder_zones": contact_cylinder_zones,
+                "contact_asset_cfg": SceneEntityCfg(
+                    self.designated_contact_asset_name,
+                    body_names=contact_body_names,
+                ),
+                "contact_object_cfg": SceneEntityCfg(self.designated_contact_object_name),
+            })
+        self.terminations.success = DoneTerm(
+            func=success_func,
+            params=success_params,
+        )
+
+        self.configure_debug_vis()
+
+    def configure_debug_vis(self) -> None:
+        """Populate the forbidden-zone / designated-contact-zone markers in
+        ``observations.scene_vis`` when ``self.enable_debug_vis`` is True.
+
+        Zone data comes straight from the ``forbidden_zones`` /
+        ``designated_contact_zones`` fields (set at construction time), so
+        this can be safely called at the end of ``__post_init__``.
+        """
+        if not self.enable_debug_vis:
+            return
+        sphere_zones, box_zones, cylinder_zones = split_zones(self.forbidden_zones)
+        contact_sphere_zones, contact_box_zones, contact_cylinder_zones = split_zones(self.designated_contact_zones)
+        contact_body_names = self.designated_contact_body_names
+        if contact_body_names is None and self.designated_contact_asset_name == "robot":
+            contact_body_names = self.robot_config.fingertip_body_names
+
+        want_forbidden = bool(sphere_zones or box_zones or cylinder_zones)
+        want_contact_zones = bool(contact_sphere_zones or contact_box_zones or contact_cylinder_zones)
+        if not (want_forbidden or want_contact_zones):
+            return
+
+        if self.observations.scene_vis is None:  # (add_scene_vis_term does this too; kept for the direct attribute sets below)
+            self.observations.scene_vis = dexverse_base_env.ObservationsCfg.SceneVisObsCfg()
+        if want_forbidden:
+            self.observations.scene_vis.forbidden_zones_vis = ObsTerm(
+                func=mdp.forbidden_zones_vis,
+                params={
+                    "sphere_zones": sphere_zones,
+                    "box_zones": box_zones,
+                    "cylinder_zones": cylinder_zones,
+                    "object_cfg": SceneEntityCfg("object"),
+                    "color": self.forbidden_zone_color,
+                    "opacity": self.forbidden_zone_opacity,
+                },
+            )
+        if want_contact_zones:
+            self.observations.scene_vis.designated_contact_zones_vis = ObsTerm(
+                func=mdp.contact_zones_vis,
+                params={
+                    "sphere_zones": contact_sphere_zones,
+                    "box_zones": contact_box_zones,
+                    "cylinder_zones": contact_cylinder_zones,
+                    "object_cfg": SceneEntityCfg(self.designated_contact_object_name),
+                    "color": self.designated_contact_zone_color,
+                    "opacity": self.designated_contact_zone_opacity,
+                    "prim_path_prefix": "/Visuals/DesignatedContactZone",
+                },
+            )
+
+
+@configclass
+class FunctionalPourTerminationsCfg(dexverse_base_env.TerminationsCfg):
+    """Out-of-bound plus lift-and-tilt success for pouring."""
+
+    object_out_of_bound = DoneTerm(
+        func=mdp.out_of_bound,
+        params={
+            "in_bound_range": {"x": (-1.0, 1.0), "y": (-1.0, 1.0), "z": (BOUND_Z_MIN, BOUND_Z_MAX)},
+            "asset_cfg": SceneEntityCfg("object"),
+        },
+    )
+
+    success = DoneTerm(
+        func=mdp.lift_and_tilt,
+        params={
+            "min_height": POUR_LIFT_HEIGHT_M,
+            "threshold_rad": POUR_ANGLE_RAD,
+            "axis_local": (0.0, 0.0, 1.0),
+            "world_axis": (0.0, 0.0, 1.0),
+            "tilt_ge": True,
+            "object_cfg": SceneEntityCfg("object"),
+        },
+    )
+
+
+@configclass
+class FunctionalPourEventCfg(dexverse_base_env.EventCfg):
+    """Keep the pour success marker synced to the object reset pose."""
+
+    reset_success_marker = EventTerm(
+        func=mdp.sync_object,
+        mode="reset",
+        params={
+            "target_cfg": SceneEntityCfg("success_marker"),
+            "source_cfg": SceneEntityCfg("object"),
+            "z_offset": POUR_LIFT_HEIGHT_M,
+            "quat": SUCCESS_MARKER_QUAT,
+        },
+    )
+
+
+@configclass
+class FunctionalPourEnvCfg(FunctionalGraspingEnvCfg):
+    """Robot-agnostic base for single-object functional pouring."""
+
+    pour_lift_height: float = POUR_LIFT_HEIGHT_M
+    pour_angle_rad: float = POUR_ANGLE_RAD
+    pour_axis_local: tuple[float, float, float] = (0.0, 0.0, 1.0)
+    pour_world_axis: tuple[float, float, float] = (0.0, 0.0, 1.0)
+    pour_tilt_ge: bool = True
+    # Max horizontal distance (in metres) from the success marker for the
+    # pour to count. Set to ``None`` to disable the xy gate and fall back to
+    # the lift-and-tilt-only criterion.
+    pour_goal_xy_threshold: float | None = 0.10
+    # Optional offset (in the object's local frame) for the xy-gate. When
+    # set, the xy distance is measured between
+    # ``object.root_pos + R(object.root_quat) * pour_goal_object_local_offset``
+    # and the success marker's xy. Use this to anchor the gate at e.g. the
+    # bottle's spout instead of the object's mass centre. ``None`` (the
+    # default) reproduces the previous "object root vs. goal" behaviour.
+    pour_goal_object_local_offset: tuple[float, float, float] | None = None
+    # Optional secondary tilt criterion: angle between the rotated
+    # ``pour_plane_axis_local`` of the object and the plane with normal
+    # ``pour_plane_normal`` (default = the ground plane). When both
+    # ``pour_plane_axis_local`` and ``pour_plane_angle_threshold_rad`` are set,
+    # the tilt requirement is satisfied if *either* the primary axis-vs-axis
+    # criterion (``pour_angle_rad``) or this plane-angle criterion is met. The
+    # plane-angle metric is in ``[0, π/2]`` (sign-agnostic about the plane).
+    pour_plane_axis_local: tuple[float, float, float] | None = None
+    pour_plane_normal: tuple[float, float, float] = (0.0, 0.0, 1.0)
+    pour_plane_angle_threshold_rad: float | None = None
+    # When True, hide the success-marker cuboid pole and add a sphere that
+    # tracks the goal pose with a red→green tilt-progress colour. Visual
+    # only; doesn't affect the success criterion.
+    pour_show_progress_marker: bool = True
+    pour_progress_marker_radius: float = 0.04
+    pour_progress_marker_opacity: float = 0.7
+    pour_progress_marker_num_color_steps: int = 11
+    # Camera-visible goal: swap the hidden legacy cuboid pole of ``success_marker``
+    # for an opaque sphere so the pour goal shows up in RGB/depth renders and
+    # therefore in point-cloud observations. The translucent progress sphere is
+    # a PointInstancer with opacity<1 that never reaches the depth AOV, so
+    # without this the goal is invisible to vision policies (Aug 2026: DP3
+    # training clouds had 0 points at the goal; success needs the rim within
+    # ``pour_goal_xy_threshold`` of it). Radius < progress sphere radius so the
+    # red->green colour shell still reads in the viewport.
+    pour_goal_marker_camera_visible: bool = True
+    pour_goal_marker_radius: float = 0.03
+
+    observations: FunctionalPourObservationsCfg = FunctionalPourObservationsCfg()
+    rewards: FunctionalPourRewardsCfg = DenseFunctionalPourRewardsCfg()
+    terminations: FunctionalPourTerminationsCfg = FunctionalPourTerminationsCfg()
+    events: FunctionalPourEventCfg = FunctionalPourEventCfg()
+
+    @configclass
+    class FunctionalPourSceneCfg(FunctionalGraspingEnvCfg.FunctionalGraspingSceneCfg):
+        object: RigidObjectCfg = build_object_cfg_from_usd(str(SYNTHESIS_DIR / "Bleach_1" / "model_Bleach_1_69323.usd"))
+        success_marker: RigidObjectCfg = SUCCESS_MARKER_CFG
+
+    scene: FunctionalPourSceneCfg = FunctionalPourSceneCfg(
+        num_envs=4096,
+        env_spacing=3,
+        replicate_physics=False,
+        success_marker=SUCCESS_MARKER_CFG,
+    )
+
+    def __post_init__(self):
+        super().__post_init__()
+
+        if self.pour_goal_marker_camera_visible:
+            self.scene.success_marker.spawn = sim_utils.SphereCfg(
+                radius=self.pour_goal_marker_radius,
+                rigid_props=sim_utils.RigidBodyPropertiesCfg(
+                    rigid_body_enabled=True,
+                    kinematic_enabled=True,
+                    disable_gravity=True,
+                ),
+                collision_props=sim_utils.CollisionPropertiesCfg(collision_enabled=False),
+                visual_material=sim_utils.PreviewSurfaceCfg(
+                    diffuse_color=SUCCESS_MARKER_COLOR,
+                    emissive_color=(0.0, 0.3, 0.0),
+                    roughness=1.0,
+                    metallic=0.0,
+                ),
+                visible=True,
+            )
+
+        # Pouring uses lift-and-tilt success, while keeping the shared
+        # forbidden/contact zone gates from the functional manipulation base.
+        self.commands.object_pose = None
+        sphere_zones, box_zones, cylinder_zones = split_zones(self.forbidden_zones)
+        contact_sphere_zones, contact_box_zones, contact_cylinder_zones = split_zones(self.designated_contact_zones)
+        contact_body_names = self.designated_contact_body_names
+        if contact_body_names is None and self.designated_contact_asset_name == "robot":
+            contact_body_names = self.robot_config.fingertip_body_names
+        self.terminations.success = DoneTerm(
+            func=mdp.lift_and_tilt_with_contact_zones,
+            params={
+                "min_height": self.pour_lift_height,
+                "threshold_rad": self.pour_angle_rad,
+                "axis_local": self.pour_axis_local,
+                "world_axis": self.pour_world_axis,
+                "tilt_ge": self.pour_tilt_ge,
+                "sphere_zones": sphere_zones,
+                "box_zones": box_zones,
+                "cylinder_zones": cylinder_zones,
+                "contact_sphere_zones": contact_sphere_zones,
+                "contact_box_zones": contact_box_zones,
+                "contact_cylinder_zones": contact_cylinder_zones,
+                "asset_cfg": self.forbidden_zone_asset_cfg(),  # forbidden zones: every robot body
+                "contact_asset_cfg": SceneEntityCfg(
+                    self.designated_contact_asset_name,
+                    body_names=contact_body_names,
+                ),
+                "object_cfg": SceneEntityCfg("object"),
+                "contact_object_cfg": SceneEntityCfg(self.designated_contact_object_name),
+                "goal_asset_cfg": SceneEntityCfg("success_marker"),
+                "goal_xy_threshold": self.pour_goal_xy_threshold,
+                "goal_object_local_offset": self.pour_goal_object_local_offset,
+                "plane_axis_local": self.pour_plane_axis_local,
+                "plane_normal": self.pour_plane_normal,
+                "plane_angle_threshold_rad": self.pour_plane_angle_threshold_rad,
+            },
+        )
+        self.rewards.tilt_reward.params.update({
+            "threshold_rad": self.pour_angle_rad,
+            "axis_local": self.pour_axis_local,
+            "world_axis": self.pour_world_axis,
+            "tilt_ge": self.pour_tilt_ge,
+        })
+        # Grade dense lift progress toward the same height the success
+        # criterion requires (term only present on the dense preset).
+        lift_progress = getattr(self.rewards, "lift_progress", None)
+        if lift_progress is not None:
+            lift_progress.params["min_height"] = self.pour_lift_height
+        # Functional point + tilt-axis now live in the (non-privileged)
+        # ``state`` group. ``goal_pos_b``'s ``asset_cfg`` is fixed to
+        # ``"success_marker"`` at the class level (see
+        # ``_FunctionalTiltGoalObsCfg``). The scalar tilt / plane angles were
+        # dropped — the tilt-axis vector carries the current tilt, and the
+        # target angle is a per-task constant kept out of observations.
+        self.observations.state.object_functional_point_pos_b.params["local_offset"] = (
+            self.pour_goal_object_local_offset
+        )
+        self.observations.state.object_functional_axis_b.params["axis_local"] = self.pour_axis_local
+
+        obj_pos = self.scene.object.init_state.pos
+        self.scene.success_marker.init_state.pos = (
+            obj_pos[0],
+            obj_pos[1],
+            obj_pos[2] + self.pour_lift_height,
+        )
+        self.scene.success_marker.init_state.rot = SUCCESS_MARKER_QUAT
+        self.events.reset_success_marker.params["z_offset"] = self.pour_lift_height
+
+        # Pour-progress sphere: the task's GOAL MARKER (red -> green with tilt
+        # progress) -- always on and camera-visible, independent of
+        # ``enable_debug_vis`` (Aug 2026: it used to be double-gated behind
+        # ``pour_show_progress_marker and enable_debug_vis``, so operators never
+        # saw it). The legacy cuboid pole stays as an invisible scene entity
+        # because success/reset logic anchors on its pose.
+        if self.pour_show_progress_marker:
+            if self.observations.scene_vis is None:
+                self.observations.scene_vis = dexverse_base_env.ObservationsCfg.SceneVisObsCfg()
+            self.observations.scene_vis.pour_progress_marker_vis = ObsTerm(
+                func=mdp.pour_progress_marker_vis,
+                params={
+                    "goal_asset_cfg": SceneEntityCfg("success_marker"),
+                    "object_cfg": SceneEntityCfg("object"),
+                    "primary_threshold_rad": self.pour_angle_rad,
+                    "primary_axis_local": self.pour_axis_local,
+                    "primary_world_axis": self.pour_world_axis,
+                    "primary_tilt_ge": self.pour_tilt_ge,
+                    "plane_threshold_rad": self.pour_plane_angle_threshold_rad,
+                    "plane_axis_local": self.pour_plane_axis_local,
+                    "plane_normal": self.pour_plane_normal,
+                    "radius": self.pour_progress_marker_radius,
+                    "opacity": self.pour_progress_marker_opacity,
+                    "num_color_steps": self.pour_progress_marker_num_color_steps,
+                    "prim_path_prefix": "/Visuals/PourProgressMarker",
+                },
+            )
+
+
+@configclass
+class FunctionalGraspingEnvFloatingDexHandRightCfg(FunctionalGraspingEnvCfg):
+    """Functional-grasping config for floating dexterous hands (Shadow / Leap)."""
+
+    robot_type: str = "floating_shadow_right"
+    xr: XrCfg = DEFAULT_FLOATING_SHADOW_XR_CFG
+
+    def __post_init__(self):
+        super().__post_init__()
+        setup_floating_teleop(self)
+
+
+@configclass
+class FunctionalPourEnvFloatingDexHandRightCfg(FunctionalPourEnvCfg, FunctionalGraspingEnvFloatingDexHandRightCfg):
+    """Functional pouring with a floating right dexterous hand."""
+
+    # Repeat these fields here because IsaacLab's configclass field collection
+    # does not reliably include fields that only come from the second base in
+    # this multiple-inheritance mixin.
+    robot_type: str = "floating_shadow_right"
+    xr: XrCfg = DEFAULT_FLOATING_SHADOW_XR_CFG

--- a/source/dexverse/dexverse/baseline_v1/config/functional/grasp_bleach_cfg.py
+++ b/source/dexverse/dexverse/baseline_v1/config/functional/grasp_bleach_cfg.py
@@ -1,0 +1,124 @@
+# Copyright (c) 2025-2026, The DexVerse Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Functional grasping: bleach bottle."""
+
+import math
+
+from isaaclab.managers import EventTermCfg as EventTerm
+from isaaclab.managers import SceneEntityCfg
+from isaaclab.utils import configclass
+from scipy.spatial.transform import Rotation as R
+
+from ... import mdp
+from .base_cfg import (
+    POUR_ANGLE_RAD,
+    SYNTHESIS_DIR,
+    ForbiddenZone,
+    FunctionalPourEnvFloatingDexHandRightCfg,
+)
+
+BLEACH_USD_PATH = str(SYNTHESIS_DIR / "Bleach_1" / "model_Bleach_1_69323.usd")
+BLEACH_ROT_INIT = tuple((R.from_euler("z", -90, degrees=True)).as_quat().tolist())
+
+
+@configclass
+class GraspBleachEnvFloatingDexHandRightCfg(FunctionalPourEnvFloatingDexHandRightCfg):
+    """Functional manipulation of a bleach bottle with pour-style success.
+
+    Forbidden zone is a placeholder around the trigger / nozzle area at the
+    top of the bottle in the object's local frame. Tune ``center`` / ``radius``
+    once you can preview the spawned asset.
+    """
+
+    usd_path: str = BLEACH_USD_PATH
+    object_mass: float = 1.0
+    object_scale: tuple[float, float, float] = (1.7, 1.7, 1.7)
+    object_half_height: float = 0.002  # reset audit (Aug 2026): seated ~3 mm above rest instead of dropping
+    object_static_friction: float | None = 2.5
+    object_dynamic_friction: float | None = 2.5
+    object_friction_combine_mode: str = "average"
+    table_clearance: float = 0.0
+    object_init_x_offset: float = 0.0
+    object_init_y_offset: float = 0.0
+    # 180 degrees around y-axis, then -90 degrees around z-axis, w,x,y,z.
+    object_init_rot: tuple[float, float, float, float] = BLEACH_ROT_INIT
+    object_reset_x_range: tuple[float, float] = (0.1, 0.3)
+    object_reset_y_range: tuple[float, float] = (-0.4, 0.0)
+    # NOTE: with BLEACH_ROT_INIT the reset delta is applied in the bottle's
+    # body frame, so this ``pitch`` entry is the lying bottle's in-plane
+    # heading on the table (a ``yaw`` entry would tilt it instead).
+    # Reset audit (Aug 2026): uniform heading (was +-0.3 rad) -- the bottle can
+    # point anywhere; pre-grasp reorientation may be needed.
+    object_reset_pitch_range: tuple[float, float] = (math.radians(150) - math.pi, math.radians(150) + math.pi)
+    pour_lift_height: float = 0.3
+    pour_angle_rad: float = POUR_ANGLE_RAD
+    pour_axis_local: tuple[float, float, float] = (0.0, -1.0, 0.0)
+    pour_tilt_ge: bool = True
+    pour_goal_xy_threshold: float | None = 0.02
+
+    # Tilt success uses only the directional primary gate (``pour_angle_rad``
+    # about ``pour_axis_local`` vs world +Z). The secondary plane-angle gate is
+    # left disabled (base default ``None``): it's undirected (can't tell a
+    # tipped-down pour from an upright lift) and at a 90° threshold never fired.
+
+    # Pour-goal randomization: xy offsets from the table centre. Defaults bias
+    # the goal toward the front-left of the table so it doesn't sit on top of
+    # the bottle's reset zone (x in [0.1, 0.3]).
+    goal_reset_x_range: tuple[float, float] = (0.0, 0.4)
+    goal_reset_y_range: tuple[float, float] = (0.0, 0.4)
+    # Minimum xy distance (m) between the pour goal and the bottle's reset
+    # xy. The bottle box (y <= 0) and the goal box (y >= 0) touch at y = 0,
+    # so without this the goal could be sampled right next to the bottle
+    # (reset audit, Aug 2026: min 2 cm over 500 resets). Enforced via
+    # rejection sampling like pour_can / pour_mug.
+    min_object_goal_xy_distance: float = 0.15
+
+    # The xy gate measures distance from this point on the bottle (in its
+    # local frame) to the success marker, instead of from the bottle's
+    # mass centre. The placeholder matches the existing forbidden-zone
+    # centre at the trigger/nozzle area; tune to the actual spout location.
+    pour_goal_object_local_offset: tuple[float, float, float] = (0.0, -0.4, -0.03)
+
+    # Goal indicator: hide the cuboid pole and show a sphere at the goal that
+    # tracks the success marker and animates red -> green as the bottle tilts
+    # toward the threshold (turns green when the tilt criterion is met). Purely
+    # visual; does not affect the success criterion. Disable for headless /
+    # faster rendering.
+
+    forbidden_zones: tuple[ForbiddenZone, ...] = (
+        ForbiddenZone(kind="sphere", center=(0.0, -0.4, -0.03), radius=0.035),
+    )
+    object_collision_enabled: bool = False
+
+    def __post_init__(self):
+        super().__post_init__()
+
+        # The base FunctionalPourEnvCfg syncs the success marker to the
+        # object's reset pose (so the goal always floats directly above the
+        # bottle). Replace it with uniform xy randomization in the table
+        # frame; the marker's init z (set by the base) keeps the goal at
+        # ``pour_lift_height`` above the tabletop.
+        # The marker is a kinematic body, so use the pose-only reset
+        # (``reset_root_pose_uniform``); ``reset_root_state_uniform`` also writes
+        # velocity, which PhysX rejects on a kinematic body ("Body must be
+        # non-kinematic!").
+        self.events.reset_success_marker = EventTerm(
+            func=mdp.reset_root_pose_uniform_excluding,
+            mode="reset",
+            params={
+                "pose_range": {
+                    "x": list(self.goal_reset_x_range),
+                    "y": list(self.goal_reset_y_range),
+                    "z": [0.0, 0.0],
+                    "roll": [0.0, 0.0],
+                    "pitch": [0.0, 0.0],
+                    "yaw": [0.0, 0.0],
+                },
+                "asset_cfg": SceneEntityCfg("success_marker"),
+                "reference_asset_cfg": SceneEntityCfg("object"),
+                "min_xy_distance": self.min_object_goal_xy_distance,
+            },
+        )

--- a/source/dexverse/dexverse/baseline_v1/config/functional/grasp_cup_cfg.py
+++ b/source/dexverse/dexverse/baseline_v1/config/functional/grasp_cup_cfg.py
@@ -1,0 +1,105 @@
+# Copyright (c) 2025-2026, The DexVerse Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Functional grasping: cup (rim avoidance)."""
+
+from isaaclab.managers import EventTermCfg as EventTerm
+from isaaclab.managers import SceneEntityCfg
+from isaaclab.utils import configclass
+
+from ... import mdp
+from .base_cfg import (
+    POUR_ANGLE_RAD,
+    SYNTHESIS_DIR,
+    ForbiddenZone,
+    FunctionalPourEnvFloatingDexHandRightCfg,
+)
+
+CUP_USD_PATH = str(SYNTHESIS_DIR / "Cup_B0CMD4LX4D_ForestGreen" / "model_Cup_B0CMD4LX4D_ForestGreen_69323.usd")
+CUP_ROT_INIT = (1, 0, 0, 0)
+
+
+@configclass
+class GraspCupEnvFloatingDexHandRightCfg(FunctionalPourEnvFloatingDexHandRightCfg):
+    """Functional cup task: avoid the rim, then lift and pour.
+
+    Forbidden zone is a placeholder around the rim / drinking edge in the
+    object's local frame. Tune ``center`` / ``radius`` once you can preview
+    the spawned asset.
+    """
+
+    usd_path: str = CUP_USD_PATH
+    object_mass: float = 0.2
+    object_scale: tuple[float, float, float] = (0.9, 0.9, 0.9)
+    object_half_height: float = 0.002  # reset audit (Aug 2026): seated ~3 mm above rest instead of dropping (was 0.025)
+    object_static_friction: float | None = 2.5
+    object_dynamic_friction: float | None = 2.5
+    object_friction_combine_mode: str = "average"
+    table_clearance: float = 0.0
+    object_init_x_offset: float = 0.0
+    object_init_y_offset: float = 0.0
+    object_init_rot: tuple[float, float, float, float] = CUP_ROT_INIT
+    object_reset_x_range: tuple[float, float] = (-0.15, 0.15)
+    object_reset_y_range: tuple[float, float] = (-0.15, 0.15)
+    object_reset_yaw_range: tuple[float, float] = (0.0, 0.0)
+    target_height_range: tuple[float, float] = (0.10, 0.20)
+
+    pour_lift_height: float = 0.3
+    pour_angle_rad: float = POUR_ANGLE_RAD
+    pour_axis_local: tuple[float, float, float] = (0.0, 0.0, 1.0)
+    pour_tilt_ge: bool = True
+
+    # Tilt success uses only the directional primary gate (``pour_angle_rad``
+    # about ``pour_axis_local`` vs world +Z). The secondary plane-angle gate is
+    # left disabled (base default ``None``): being undirected it can't tell a
+    # tipped-down pour from an upright lift, so the previous 80° threshold let
+    # a near-upright cup pass the tilt check.
+
+    # Shifts the xy gate measurement point from the object's mass centre
+    # to ``object.root_pos + R(object.root_quat) * pour_goal_object_local_offset``
+    # (object-local coordinates). Useful when the relevant point is the
+    # spout / lip rather than the bounding-box centre.
+    pour_goal_object_local_offset: tuple[float, float, float] = (0.0, 0.0, 0.1)  # TODO: tune to the cup's rim
+
+    # Pour-goal randomization: xy offsets from the table centre. Defaults
+    # bias the goal toward the front-right of the table so it doesn't sit
+    # inside the cup's reset zone (x ∈ (-0.15, 0.15)). Tune as needed.
+    goal_reset_x_range: tuple[float, float] = (0.0, 0.35)
+    goal_reset_y_range: tuple[float, float] = (-0.25, 0.25)
+
+    # Goal indicator: sphere at the goal that animates red -> green as the
+    # object tilts toward the threshold (green = tilt criterion met). Visual
+    # only; disable for headless / faster rendering.
+
+    forbidden_zones: tuple[ForbiddenZone, ...] = (
+        ForbiddenZone(kind="cylinder", center=(0.0, 0.0, 0.11), radius=0.035, half_height=0.005),
+    )
+
+    def __post_init__(self):
+        super().__post_init__()
+
+        # The base FunctionalPourEnvCfg syncs the success marker to the
+        # cup's reset pose (so the goal floats directly above the cup).
+        # Replace it with uniform xy randomization so the goal lives
+        # somewhere on the table independent of the cup -- matches the
+        # grasp_bleach / pour_can / pour_mug pattern. The marker's init z
+        # (set by the base) keeps the goal at ``pour_lift_height`` above
+        # the tabletop.
+        self.events.reset_success_marker = EventTerm(
+            func=mdp.reset_root_state_uniform,
+            mode="reset",
+            params={
+                "pose_range": {
+                    "x": list(self.goal_reset_x_range),
+                    "y": list(self.goal_reset_y_range),
+                    "z": [0.0, 0.0],
+                    "roll": [0.0, 0.0],
+                    "pitch": [0.0, 0.0],
+                    "yaw": [0.0, 0.0],
+                },
+                "velocity_range": {"x": [0.0, 0.0], "y": [0.0, 0.0], "z": [0.0, 0.0]},
+                "asset_cfg": SceneEntityCfg("success_marker"),
+            },
+        )

--- a/source/dexverse/dexverse/baseline_v1/config/functional/grasp_kettle_cfg.py
+++ b/source/dexverse/dexverse/baseline_v1/config/functional/grasp_kettle_cfg.py
@@ -1,0 +1,200 @@
+# Copyright (c) 2025-2026, The DexVerse Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Functional grasping: kettle (handle grasp) and pour over a mug."""
+
+from __future__ import annotations
+
+import math
+
+import isaaclab.sim as sim_utils
+from isaaclab.assets import RigidObjectCfg
+from isaaclab.managers import EventTermCfg as EventTerm
+from isaaclab.managers import SceneEntityCfg
+from isaaclab.utils import configclass
+
+from ... import dexverse_base_env_cfg as dexverse_base_env
+from ... import mdp
+from .base_cfg import (
+    SYNTHESIS_DIR,
+    ForbiddenZone,
+    FunctionalPourEnvFloatingDexHandRightCfg,
+)
+
+KETTLE_USD_PATH = str(SYNTHESIS_DIR / "teapot" / "model_Teapot_B09T313HT9_WhiteColorfulFloral_TU_69323.usd")
+KETTLE_ROT_INIT = (1.0, 0.0, 0.0, 0.0)
+
+MUG_USD_PATH = str(SYNTHESIS_DIR / "tea_cup" / "model_Cup_B0CYL5PSR3_Orange_69323.usd")
+MUG_SCALE = (1.0, 1.0, 1.0)
+# Approximate distance from the cup's base to the table-resting plane; tune
+# after eyeballing the spawned asset.
+MUG_HALF_HEIGHT_EST = 0.0
+MUG_INIT_ROT = (1.0, 0.0, 0.0, 0.0)
+
+
+def _build_mug_cfg(
+    *,
+    scale: tuple[float, float, float],
+    init_rot: tuple[float, float, float, float],
+    init_pos: tuple[float, float, float],
+) -> RigidObjectCfg:
+    """Kinematic mug prop. Re-synced under the pour goal each reset."""
+    return RigidObjectCfg(
+        prim_path="{ENV_REGEX_NS}/Mug",
+        spawn=sim_utils.UsdFileCfg(
+            func=dexverse_base_env.spawn_usd_with_rigid_properties,
+            usd_path=MUG_USD_PATH,
+            scale=scale,
+            rigid_props=sim_utils.RigidBodyPropertiesCfg(
+                rigid_body_enabled=True,
+                kinematic_enabled=True,
+                disable_gravity=True,
+                solver_position_iteration_count=16,
+                solver_velocity_iteration_count=0,
+            ),
+            collision_props=None,
+            mass_props=sim_utils.MassPropertiesCfg(mass=1.0),
+        ),
+        init_state=RigidObjectCfg.InitialStateCfg(pos=init_pos, rot=init_rot),
+    )
+
+
+@configclass
+class GraspKettleEnvFloatingDexHandRightCfg(FunctionalPourEnvFloatingDexHandRightCfg):
+    """Functional kettle task: grasp by the handle, then lift and pour over a mug.
+
+    Success requires the kettle's xy to match the mug's xy (via the
+    ``success_marker`` and ``pour_goal_xy_threshold``), the kettle to be
+    lifted by ``pour_lift_height``, and the kettle to be tilted past
+    ``pour_angle_rad`` about ``pour_axis_local``.
+    """
+
+    usd_path: str = KETTLE_USD_PATH
+    object_mass: float = 0.5
+    object_scale: tuple[float, float, float] = (1.0, 1.0, 1.0)
+    object_half_height: float = 0.003  # reset audit (Aug 2026): seated ~3 mm above rest instead of dropping (was 0.04)
+    object_static_friction: float | None = 2.0
+    object_dynamic_friction: float | None = 2.0
+    object_friction_combine_mode: str = "average"
+    table_clearance: float = 0.0
+    object_init_x_offset: float = 0.0
+    object_init_y_offset: float = 0.0
+    object_init_rot: tuple[float, float, float, float] = KETTLE_ROT_INIT
+    object_reset_x_range: tuple[float, float] = (-0.05, 0.15)
+    object_reset_y_range: tuple[float, float] = (-0.3, -0.1)
+    # Reset audit (Aug 2026): uniform yaw -- the handle can point anywhere, so
+    # the episode may need a pre-grasp reorientation before the functional
+    # grasp.
+    object_reset_yaw_range: tuple[float, float] = (3.14 - 3.14, 3.14 + 3.14)
+
+    pour_lift_height: float = 0.15
+    pour_angle_rad: float = math.radians(45)
+    pour_axis_local: tuple[float, float, float] = (1.0, 0.0, 0.0)
+    pour_tilt_ge: bool = True
+    # Max horizontal distance (m) between the kettle and the mug for the
+    # pour to count. Inherited default from FunctionalPourEnvCfg is 0.10.
+    pour_goal_xy_threshold: float | None = 0.05
+
+    # Tilt success uses only the directional primary gate (``pour_angle_rad``
+    # about ``pour_axis_local`` = local +X vs world +Z). The secondary
+    # plane-angle gate is left disabled (base default ``None``): being
+    # undirected, its 45° threshold accepted the upright kettle (local +Z near
+    # world +Z), letting a lift-without-pour pass. Pouring is now required.
+
+    # Shifts the xy gate measurement point from the object's mass centre
+    # to ``object.root_pos + R(object.root_quat) * pour_goal_object_local_offset``
+    # (object-local coordinates). Useful when the relevant point is the
+    # spout / lip rather than the bounding-box centre.
+    pour_goal_object_local_offset: tuple[float, float, float] = (0.0, -0.13, 0.12)  # TODO: tune to the kettle's spout
+
+    # Goal indicator: sphere at the goal that animates red -> green as the
+    # object tilts toward the threshold (green = tilt criterion met). Visual
+    # only; disable for headless / faster rendering.
+
+    forbidden_zones: tuple[ForbiddenZone, ...] = (ForbiddenZone(kind="sphere", center=(0.0, -0.13, 0.12), radius=0.03),)
+
+    mug_usd_path: str = MUG_USD_PATH
+    mug_scale: tuple[float, float, float] = MUG_SCALE
+    mug_half_height: float = MUG_HALF_HEIGHT_EST
+    mug_init_rot: tuple[float, float, float, float] = MUG_INIT_ROT
+    # Pour-goal randomization range (offsets from the table center). Defaults
+    # place the goal in front of the kettle's reset zone so it does not
+    # overlap the kettle on spawn.
+    mug_reset_x_range: tuple[float, float] = (-0.15, 0.15)
+    mug_reset_y_range: tuple[float, float] = (0.05, 0.3)
+
+    # Minimum xy distance (m) the pour goal/mug must keep from the kettle
+    # spawn. Enforced via rejection sampling at reset time.
+    min_object_goal_xy_distance: float = 0.10
+
+    def __post_init__(self):
+        super().__post_init__()
+
+        # Re-tilt the goal marker rod to match this cfg's pour_angle_rad. The
+        # base SUCCESS_MARKER_QUAT is computed from the module-level
+        # POUR_ANGLE_RAD constant (100°) at import time, so any subclass that
+        # overrides pour_angle_rad must rebuild the visual rotation here.
+        # Convention matches base_cfg.SUCCESS_MARKER_QUAT: rotation about -x.
+        half = self.pour_angle_rad * 0.5
+        self.scene.success_marker.init_state.rot = (
+            math.cos(half),
+            -math.sin(half),
+            0.0,
+            0.0,
+        )
+        self.scene.success_marker.spawn.visible = False
+
+        obj_pos = self.scene.object.init_state.pos
+        table_top_z = dexverse_base_env.DEFAULT_TABLE_TOP_HEIGHT
+
+        # Spawn the mug with a placeholder pose; reset events below relocate
+        # it under the randomized pour goal each episode.
+        mug_cfg = _build_mug_cfg(
+            scale=self.mug_scale,
+            init_rot=self.mug_init_rot,
+            init_pos=(obj_pos[0], obj_pos[1], table_top_z + self.mug_half_height),
+        )
+        self.scene.mug = mug_cfg
+
+        # Replace the base sync (marker tied to the kettle) with a uniform xy
+        # randomization for the pour goal indicator. roll/pitch/yaw deltas
+        # default to zero so the marker keeps its tilted SUCCESS_MARKER_QUAT.
+        # The excluding variant rejection-samples xy so the marker (and the
+        # mug it drives via reset_mug) stays at least
+        # ``min_object_goal_xy_distance`` away from the kettle spawn.
+        self.events.reset_success_marker = EventTerm(
+            func=mdp.reset_root_pose_uniform_excluding,
+            mode="reset",
+            params={
+                "pose_range": {
+                    "x": list(self.mug_reset_x_range),
+                    "y": list(self.mug_reset_y_range),
+                    "z": [0.0, 0.0],
+                    "roll": [0.0, 0.0],
+                    "pitch": [0.0, 0.0],
+                    "yaw": [0.0, 0.0],
+                },
+                "velocity_range": {"x": [0.0, 0.0], "y": [0.0, 0.0], "z": [0.0, 0.0]},
+                "asset_cfg": SceneEntityCfg("success_marker"),
+                "reference_asset_cfg": SceneEntityCfg("object"),
+                "min_xy_distance": self.min_object_goal_xy_distance,
+            },
+        )
+
+        # Slave the mug to the randomized marker xy and drop it onto the
+        # tabletop. This event is appended after reset_success_marker, so it
+        # runs after the marker has been resampled.
+        marker_z = self.scene.success_marker.init_state.pos[2]
+        mug_z_offset = table_top_z + self.mug_half_height - marker_z
+        self.events.reset_mug = EventTerm(
+            func=mdp.sync_object,
+            mode="reset",
+            params={
+                "target_cfg": SceneEntityCfg("mug"),
+                "source_cfg": SceneEntityCfg("success_marker"),
+                "z_offset": mug_z_offset,
+                "quat": self.mug_init_rot,
+            },
+        )

--- a/source/dexverse/dexverse/baseline_v1/config/functional/grasp_pan_cfg.py
+++ b/source/dexverse/dexverse/baseline_v1/config/functional/grasp_pan_cfg.py
@@ -1,0 +1,234 @@
+# Copyright (c) 2025-2026, The DexVerse Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Functional grasping: pan (handle grasp) and place flat on a stove top."""
+
+from __future__ import annotations
+
+import math
+
+import isaaclab.sim as sim_utils
+from dexverse.assets import SYNTHESIS_DIR
+from dexverse.baseline_v1.config.floating_teleop import DEFAULT_FLOATING_SHADOW_XR_CFG
+from dexverse.baseline_v1.config.robot_init import (
+    align_retargeter_wrist_origin_to_init,
+    set_robot_wrist_init_world_pos,
+)
+from isaaclab.assets import ArticulationCfg
+from isaaclab.devices.openxr import XrCfg
+from isaaclab.managers import EventTermCfg as EventTerm
+from isaaclab.managers import SceneEntityCfg
+from isaaclab.utils import configclass
+from scipy.spatial.transform import Rotation as R
+
+from ... import dexverse_base_env_cfg as dexverse_base_env
+from ... import mdp
+from ..articulation.articulation_base.usd_helpers import ensure_single_articulation_root
+from .base_cfg import ForbiddenZone, FunctionalPourEnvFloatingDexHandRightCfg
+
+PAN_USD_PATH = str(SYNTHESIS_DIR / "FryingPan" / "model_FryingPan_69323.usd")
+PAN_ROT_INIT = (1.0, 0.0, 0.0, 0.0)
+
+STOVE_USD_PATH = str(SYNTHESIS_DIR / "cooker007" / "model_cooker_007.usd")
+STOVE_SCALE = (1.0, 1.0, 1.0)
+# Placement of the stove relative to the table centre (x, y, z). The z entry
+# is the clearance above the tabletop where the stove base rests. Tune.
+STOVE_INIT_OFFSET = (0.0, 0.0, 0.0)
+# 90 degrees around z-axis
+STOVE_INIT_ROT = tuple((R.from_euler("X", -90, degrees=True)).as_quat().tolist())
+# Offset (in the stove's local frame) from the stove origin to the place-goal,
+# i.e. the burner centre. Tune so the goal sits over the cooking surface.
+GOAL_OFFSET_FROM_STOVE = (0.21, 0.025, 0.12)
+
+
+def _build_stove_cfg(
+    *,
+    scale: tuple[float, float, float],
+    init_rot: tuple[float, float, float, float],
+    init_pos: tuple[float, float, float],
+) -> ArticulationCfg:
+    """Articulated stove prop, anchored to the world.
+
+    The cooker USD is an articulation: its body is the articulation root and
+    the knobs are sibling rigid bodies linked by revolute joints. Wrapping it
+    as a single RigidObjectCfg triggers ``Rigid Body of <knob> missing
+    xformstack reset when child of another enabled rigid body`` errors in
+    PhysX. Spawning it as an ArticulationCfg with ``fix_root_link=True``
+    handles the hierarchy correctly and keeps the stove anchored on the
+    table.
+    """
+    cleaned_usd = ensure_single_articulation_root(STOVE_USD_PATH)
+    return ArticulationCfg(
+        prim_path="{ENV_REGEX_NS}/Stove",
+        spawn=sim_utils.UsdFileCfg(
+            usd_path=cleaned_usd,
+            scale=scale,
+            rigid_props=sim_utils.RigidBodyPropertiesCfg(disable_gravity=False),
+            joint_drive_props=sim_utils.JointDrivePropertiesCfg(
+                max_effort=0.0,
+                stiffness=0.0,
+                damping=0.0,
+            ),
+            articulation_props=sim_utils.ArticulationRootPropertiesCfg(
+                fix_root_link=True,
+                enabled_self_collisions=False,
+                solver_position_iteration_count=16,
+                solver_velocity_iteration_count=1,
+            ),
+        ),
+        init_state=ArticulationCfg.InitialStateCfg(pos=init_pos, rot=init_rot),
+        actuators={},
+    )
+
+
+@configclass
+class GraspPanEnvFloatingDexHandRightCfg(FunctionalPourEnvFloatingDexHandRightCfg):
+    """Grasp the pan and place it flat onto the stove burner.
+
+    Uses the same ``lift_and_tilt_with_contact_zones`` success template as
+    the pour tasks but inverted: success requires the pan to be near
+    horizontal (tilt ≤ a small threshold) AND the pan's xy to land within
+    a small radius of the success-marker xy. The success marker is
+    synced each reset to ``stove.root_pos + R(stove.root_quat) *
+    goal_offset_from_stove`` so the goal automatically follows the
+    randomized stove pose.
+    """
+
+    usd_path: str = PAN_USD_PATH
+    object_mass: float = 0.5
+    object_scale: tuple[float, float, float] = (1.0, 1.0, 1.0)
+    object_half_height: float = 0.003  # reset audit (Aug 2026): seated ~3 mm above rest instead of dropping (was 0.025)
+    object_static_friction: float | None = 2.0
+    object_dynamic_friction: float | None = 2.0
+    object_friction_combine_mode: str = "average"
+    table_clearance: float = 0.0
+    object_init_x_offset: float = 0.0
+    object_init_y_offset: float = 0.0
+    object_init_rot: tuple[float, float, float, float] = PAN_ROT_INIT
+    object_collision_enabled: bool = False
+    object_reset_x_range: tuple[float, float] = (-0.15, -0.05)
+    object_reset_y_range: tuple[float, float] = (-0.3, 0.3)
+    # Reset audit (Aug 2026): uniform yaw -- the handle can point anywhere, so
+    # the episode may need a pre-grasp reorientation before the functional
+    # grasp.
+    object_reset_yaw_range: tuple[float, float] = (3.14 - 3.14, 3.14 + 3.14)
+
+    forbidden_zones: tuple[ForbiddenZone, ...] = (
+        ForbiddenZone(
+            kind="cylinder",
+            center=(0.0, 0.0, 0.015),
+            radius=0.15,
+            half_height=0.01,
+        ),
+    )
+
+    # ---- Pour-style success criterion (inverted: pan should stay flat) ----
+    # Lift gate: 0.0 = "pan hasn't fallen below spawn z" (always true while
+    # held above the table). The pan can rest *on* the stove top, so no
+    # actual lift is required.
+    pour_lift_height: float = 0.0
+    # Primary tilt gate: angle between pan local +Z and world +Z must be
+    # ≤ 20° (with ``pour_tilt_ge=False``). Pan local +Z is the cooking-
+    # surface normal at rest; tighten the threshold for a stricter "flat"
+    # requirement.
+    pour_angle_rad: float = math.radians(10)
+    pour_axis_local: tuple[float, float, float] = (0.0, 0.0, 1.0)
+    pour_world_axis: tuple[float, float, float] = (0.0, 0.0, 1.0)
+    pour_tilt_ge: bool = False
+    # xy gate: pan centre within 5 cm of the success marker (= burner xy).
+    pour_goal_xy_threshold: float | None = 0.025
+    # Measure xy from the pan's mass centre. Set to e.g. ``(0.1, 0, 0)``
+    # if you want to anchor on the cooking-surface centre instead.
+    pour_goal_object_local_offset: tuple[float, float, float] = (0.0, 0.0, 0.0)
+    # Disable the secondary plane-angle gate: it's redundant with the
+    # primary "axis vs +Z" gate for a flat-placement task. Re-enable by
+    # setting both fields if you want an OR fallback.
+    pour_plane_axis_local: tuple[float, float, float] | None = None
+    pour_plane_angle_threshold_rad: float | None = None
+
+    # Goal indicator: sphere at the goal that animates red -> green as the
+    # pan approaches flat (green = within the tilt threshold). Visual only;
+    # disable for headless / faster rendering.
+
+    # ---- Stove prop ----
+    stove_usd_path: str = STOVE_USD_PATH
+    stove_scale: tuple[float, float, float] = STOVE_SCALE
+    stove_init_offset: tuple[float, float, float] = STOVE_INIT_OFFSET
+    stove_init_rot: tuple[float, float, float, float] = STOVE_INIT_ROT
+    # Goal-position offset from the stove origin in the stove's local frame.
+    goal_offset_from_stove: tuple[float, float, float] = GOAL_OFFSET_FROM_STOVE
+
+    # Per-reset stove randomization, expressed as offsets from its spawn pose.
+    stove_reset_x_range: tuple[float, float] = (0.2, 0.4)
+    stove_reset_y_range: tuple[float, float] = (-0.3, 0.3)
+    stove_reset_yaw_range: tuple[float, float] = (0.0, 0.0)
+
+    def __post_init__(self):
+        super().__post_init__()
+
+        table_top_z = dexverse_base_env.DEFAULT_TABLE_TOP_HEIGHT
+        table_pos = self.scene.table.init_state.pos
+
+        stove_pos = (
+            table_pos[0] + self.stove_init_offset[0],
+            table_pos[1] + self.stove_init_offset[1],
+            table_top_z + self.stove_init_offset[2],
+        )
+        self.scene.stove = _build_stove_cfg(
+            scale=self.stove_scale,
+            init_rot=self.stove_init_rot,
+            init_pos=stove_pos,
+        )
+
+        # Reorder reset events so ``reset_stove`` runs *before*
+        # ``reset_success_marker`` (the marker is sync'd to the stove's
+        # randomized pose, so it has to read the post-randomization pose).
+        # The event manager iterates ``cfg.__dict__.items()`` in insertion
+        # order, and re-assignment doesn't change position, so we
+        # explicitly delete the inherited entry and add the new one after
+        # ``reset_stove``.
+        if "reset_success_marker" in self.events.__dict__:
+            del self.events.reset_success_marker
+        self.events.reset_stove = EventTerm(
+            func=mdp.reset_root_pose_uniform,
+            mode="reset",
+            params={
+                "pose_range": {
+                    "x": list(self.stove_reset_x_range),
+                    "y": list(self.stove_reset_y_range),
+                    "z": [0.0, 0.0],
+                    "roll": [0.0, 0.0],
+                    "pitch": [0.0, 0.0],
+                    "yaw": list(self.stove_reset_yaw_range),
+                },
+                "asset_cfg": SceneEntityCfg("stove"),
+            },
+        )
+        # Sync the success marker to ``stove.root_pos + R(stove.root_quat)
+        # * goal_offset_from_stove``. The pour base hides the marker's
+        # cuboid pole (opacity 0) and the colored progress sphere becomes
+        # the visible goal indicator.
+        self.events.reset_success_marker = EventTerm(
+            func=mdp.sync_object,
+            mode="reset",
+            params={
+                "target_cfg": SceneEntityCfg("success_marker"),
+                "source_cfg": SceneEntityCfg("stove"),
+                "source_local_offset": tuple(self.goal_offset_from_stove),
+                "z_offset": -0.05,
+                "quat": (1.0, 0.0, 0.0, 0.0),
+            },
+        )
+
+        # Pull the wrist ~15 cm further from the table and shift the XR
+        # anchor to match. World coords so the same intent works for armed
+        # robots (UR10e re-IKs the arm to land the palm at the same world pose).
+        # x = floating_shadow base x (-0.75) + 0.35.
+        set_robot_wrist_init_world_pos(self, x=-0.40)
+        self.xr = XrCfg(
+            anchor_pos=[-0.65, 0.0, 0.1],
+            anchor_rot=DEFAULT_FLOATING_SHADOW_XR_CFG.anchor_rot,
+        )
+        align_retargeter_wrist_origin_to_init(self)

--- a/source/dexverse/dexverse/baseline_v1/config/functional/hammer_strike_cfg.py
+++ b/source/dexverse/dexverse/baseline_v1/config/functional/hammer_strike_cfg.py
@@ -1,0 +1,560 @@
+# Copyright (c) 2025-2026, The DexVerse Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Functional manipulation: hammer strike.
+
+The robot must grasp the hammer by its handle and drive a nail into a board.
+The target is a nail-on-a-board articulation (a single prismatic joint along
+``-Z`` so positive joint values mean the nail is being pushed *into* the
+board) authored at ``DEXVERSE_AUTHORED_ARTICULATIONS_DIR/nail_board``.
+
+Success requires:
+
+- Forbidden-zone clearance on the hammer (fingertips off the hammer head).
+- Affinity-zone overlap between the hammer head and the nail.
+- Compression of the nail's prismatic joint past a tunable threshold.
+
+Nail dynamics:
+    Gravity is disabled for the nail and the prismatic joint has zero
+    stiffness, only a small damping term. A strike imparts a velocity
+    impulse along the joint axis; damping bleeds the velocity off and the
+    nail settles at whatever displacement was reached. Tune
+    ``nail_board_damping`` if the nail moves too easily (raise) or strikes
+    barely register (lower). The previous high-stiffness +
+    ``velocity_limit_sim`` "break-through" mechanic has been removed.
+
+Hammer stand (small table):
+    Like the retrieve-tray rack, the hammer starts on furniture rather than
+    a solid block: a procedural small table (top + four legs,
+    :mod:`dexverse.assets.small_table_builder`) so the episode begins with
+    an affordance (hammer on a stand) before the strike. The table is
+    kinematic; ``table_clearance`` is set to its top-face height so the
+    hammer rests on the board. At each reset the table is snapped under the
+    hammer via ``mdp.sync_object`` (world-aligned, with a per-env xy jitter),
+    so the hammer — whose world xy and yaw are randomized by ``reset_object``
+    — starts flat at a random position and heading on the stand top.
+"""
+
+from __future__ import annotations
+
+import isaaclab.sim as sim_utils
+from dexverse.assets import DEXVERSE_AUTHORED_ARTICULATIONS_DIR
+from dexverse.assets.small_table_builder import ensure_small_table_asset
+from isaaclab.actuators.actuator_cfg import ImplicitActuatorCfg
+from isaaclab.assets import ArticulationCfg, RigidObjectCfg
+from isaaclab.managers import EventTermCfg as EventTerm
+from isaaclab.managers import ObservationGroupCfg as ObsGroup
+from isaaclab.managers import ObservationTermCfg as ObsTerm
+from isaaclab.managers import SceneEntityCfg
+from isaaclab.managers import TerminationTermCfg as DoneTerm
+from isaaclab.utils import configclass
+from isaaclab.utils.assets import NVIDIA_NUCLEUS_DIR
+from isaaclab.utils.noise import UniformNoiseCfg as Unoise
+
+from ... import dexverse_base_env_cfg as dexverse_base_env
+from ... import mdp
+from ..grasping.forbidden_zones import ForbiddenZone, split_zones
+from .base_cfg import (
+    YCB_DIR,
+    FunctionalGraspingEnvCfg,
+    FunctionalGraspingEnvFloatingDexHandRightCfg,
+    FunctionalGraspingObservationsCfg,
+)
+from .rewards import DenseHammerStrikeRewardsCfg
+
+HAMMER_USD_PATH = str(YCB_DIR / "048_hammer_usd" / "048_hammer.usd")
+
+# Head-down vertical pose: -90° about world +y rotates the asset's local +x
+# (handle axis) onto world -z, putting the head face flat on the tabletop and
+# the handle pointing straight up. Quaternion is (w, x, y, z).
+
+HAMMER_ROT_INIT = (1, 0, 0, 0)
+HAMMER_MASS = 0.6
+
+NAIL_BOARD_USD_PATH = str(DEXVERSE_AUTHORED_ARTICULATIONS_DIR / "nail_board" / "nail_board.usd")
+NAIL_BOARD_DEFAULT_SCALE = (1.0, 1.0, 1.0)
+# Half thickness of the board in metres at unit scale (URDF box is 0.10 m
+# tall, frame at centre); apply the asset scale to recover the actual
+# half-height. The URDF was scaled 2x at source rather than via USD
+# scale because USD scaling did not also scale the prismatic joint range.
+NAIL_BOARD_UNIT_HALF_HEIGHT = 0.05
+NAIL_BOARD_HALF_HEIGHT = NAIL_BOARD_UNIT_HALF_HEIGHT * NAIL_BOARD_DEFAULT_SCALE[2]
+NAIL_PRISMATIC_JOINT = "nail_prismatic"
+# Nail head centre, at q=0, expressed in the (unscaled) board root frame
+# (URDF: board top at z=+0.05, nail head visual centred at +0.084 above
+# the nail link origin which sits on the board top).
+NAIL_HEAD_UNIT_Z = 0.05 + 0.084
+# Default forbidden-zone sphere radius around the nail head (in metres,
+# applied in the *scaled* board frame). Tuned so a fingertip touching the
+# head is rejected but the hammer head can still strike from above.
+NAIL_HEAD_FORBIDDEN_RADIUS = 0.025
+
+# Scene field name for the nail-on-a-board target.
+TARGET_KEY = "hammer_target"
+
+# Procedural small table the hammer rests on (retrieve-tray-style affordance).
+# Large square top so the downscaled hammer sits fully on it with fixed yaw.
+# Offset (0, 0) centres the table under the hammer root. Oak MDL matches the
+# main table legs / drill workpiece.
+HAMMER_STAND_TABLE_PARAMS = dict(
+    depth=0.40,
+    width=0.40,
+    height=0.06,
+    top_thickness=0.012,
+    leg_size=0.022,
+)
+HAMMER_STAND_USD_PATH, HAMMER_STAND_MANIFEST = ensure_small_table_asset(
+    "hammer_stand_table",
+    **HAMMER_STAND_TABLE_PARAMS,
+)
+HAMMER_STAND_TOP_HEIGHT = float(HAMMER_STAND_MANIFEST["z_top"])
+HAMMER_STAND_DEFAULT_XY_OFFSET = (0.0, 0.0)
+HAMMER_STAND_MATERIAL_PATH = f"{NVIDIA_NUCLEUS_DIR}/Materials/Base/Wood/Oak.mdl"
+
+
+def _make_hammer_stand_spawner(
+    *,
+    static_friction: float,
+    dynamic_friction: float,
+    friction_combine_mode: str,
+):
+    """UsdFileCfg cannot take ``physics_material`` (shape spawners only).
+
+    Wrap the usual USD spawn and bind a PhysX material onto the stand's
+    collision prims so friction / combine-mode actually take effect.
+    """
+    from isaaclab.sim.spawners.from_files import spawn_from_usd
+    from isaaclab.sim.utils import bind_physics_material, clone
+    from isaaclab.sim import schemas
+
+    material_cfg = sim_utils.RigidBodyMaterialCfg(
+        static_friction=static_friction,
+        dynamic_friction=dynamic_friction,
+        restitution=0.0,
+        friction_combine_mode=friction_combine_mode,
+    )
+
+    @clone
+    def spawn(prim_path, cfg, *args, **kwargs):
+        prim = spawn_from_usd(prim_path, cfg, *args, **kwargs)
+        path = prim.GetPath().pathString
+        if cfg.rigid_props is not None:
+            schemas.define_rigid_body_properties(path, cfg.rigid_props)
+        if cfg.collision_props is not None:
+            schemas.define_collision_properties(path, cfg.collision_props)
+        if cfg.mass_props is not None:
+            schemas.define_mass_properties(path, cfg.mass_props)
+        mat_path = f"{path}/Looks/PhysicsMaterial"
+        material_cfg.func(mat_path, material_cfg)
+        bind_physics_material(path, mat_path)
+        return prim
+
+    return spawn
+
+
+def _make_nail_board_articulation_cfg(
+    *,
+    init_pos: tuple[float, float, float],
+    scale: tuple[float, float, float],
+    stiffness: float,
+    damping: float,
+    effort_limit_sim: float,
+    velocity_limit_sim: float,
+) -> ArticulationCfg:
+    return ArticulationCfg(
+        prim_path="{ENV_REGEX_NS}/HammerTarget",
+        spawn=sim_utils.UsdFileCfg(
+            usd_path=NAIL_BOARD_USD_PATH,
+            scale=scale,
+            rigid_props=sim_utils.RigidBodyPropertiesCfg(disable_gravity=True),
+            articulation_props=sim_utils.ArticulationRootPropertiesCfg(
+                fix_root_link=True,
+                enabled_self_collisions=False,
+                solver_position_iteration_count=16,
+                solver_velocity_iteration_count=1,
+            ),
+        ),
+        init_state=ArticulationCfg.InitialStateCfg(
+            pos=init_pos,
+            rot=(1.0, 0.0, 0.0, 0.0),
+            joint_pos={NAIL_PRISMATIC_JOINT: 0.0},
+        ),
+        actuators={
+            "nail_spring": ImplicitActuatorCfg(
+                joint_names_expr=[NAIL_PRISMATIC_JOINT],
+                stiffness=stiffness,
+                damping=damping,
+                effort_limit_sim=effort_limit_sim,
+                velocity_limit_sim=velocity_limit_sim,
+            ),
+        },
+    )
+
+
+@configclass
+class HammerStrikeSceneCfg(FunctionalGraspingEnvCfg.FunctionalGraspingSceneCfg):
+    """Scene with the hammer ``object``, the nail-on-a-board target, and a
+    small table stand lifting the hammer off the tabletop."""
+
+    # Placeholder; the actual init pose / actuator gains are written in
+    # ``HammerStrikeEnvCfg.__post_init__`` so subclasses can tweak them.
+    hammer_target: ArticulationCfg = _make_nail_board_articulation_cfg(
+        init_pos=(0.0, 0.0, 0.0),
+        scale=NAIL_BOARD_DEFAULT_SCALE,
+        stiffness=0.0,
+        damping=0.1,
+        effort_limit_sim=1.0,
+        velocity_limit_sim=1000.0,
+    )
+
+
+@configclass
+class HammerStrikeObservationsCfg(FunctionalGraspingObservationsCfg):
+    """Observation layout for hammer strike without an ``object_pose`` command."""
+
+    @configclass
+    class StateObsCfg(FunctionalGraspingObservationsCfg.StateObsCfg):
+        # Current nail press depth (a joint position) — observable state.
+        nail_press = ObsTerm(
+            func=mdp.max_joint_pos_signed,
+            noise=Unoise(n_min=-0.0, n_max=0.0),
+            params={
+                "asset_cfg": SceneEntityCfg(TARGET_KEY, joint_names=[NAIL_PRISMATIC_JOINT]),
+            },
+        )
+
+    @configclass
+    class GoalObsCfg(ObsGroup):
+        goal_pos_b = ObsTerm(
+            func=mdp.asset_pos_b,
+            noise=Unoise(n_min=-0.0, n_max=0.0),
+            params={"asset_cfg": SceneEntityCfg(TARGET_KEY)},
+        )
+        required_press_distance = ObsTerm(func=mdp.scalar_obs, params={"value": 0.0})
+
+        def __post_init__(self):
+            self.enable_corruption = True
+            self.concatenate_terms = True
+            self.history_length = 0
+
+    state: StateObsCfg = StateObsCfg()
+    goal: GoalObsCfg = GoalObsCfg()
+
+
+@configclass
+class HammerStrikeEnvFloatingDexHandRightCfg(FunctionalGraspingEnvFloatingDexHandRightCfg):
+    """Hammer strike: grasp + affinity overlap + nail compression success."""
+
+    usd_path: str = HAMMER_USD_PATH
+    object_mass: float = HAMMER_MASS
+    # Slightly under unit scale so the full hammer fits on the stand top.
+    object_scale: tuple[float, float, float] = (0.95, 0.95, 0.95)
+    # Vertical (head-down) pose: distance from the asset origin to the head's
+    # bottom face is roughly half the hammer's total length. Tune in the
+    # viewer if the hammer floats above or sinks into the table.
+    object_half_height: float = 0.0  # reset audit (Aug 2026): seated ~3 mm above rest instead of dropping (was 0.02, dropped 2.5 cm)
+    object_static_friction: float | None = 2.0
+    object_dynamic_friction: float | None = 2.0
+    object_friction_combine_mode: str = "average"
+    object_init_rot: tuple[float, float, float, float] = HAMMER_ROT_INIT
+    object_collision_enabled: bool = False
+
+    # Spawn a bit toward -x of the table centre (near the hand side, but not
+    # so close that the stand crowds the palm). Both the hammer's world xy and
+    # its yaw are randomized; the stand stays world-aligned with the main
+    # table, so the yaw jitter also randomizes the hammer's heading *on* the
+    # stand top. ``hammer_on_stand_xy_range`` below adds the translational
+    # randomization relative to the stand.
+    object_init_x_offset: float = -0.05
+    object_init_y_offset: float = -0.15
+    object_reset_x_range: tuple[float, float] = (-0.15, 0.05)
+    object_reset_y_range: tuple[float, float] = (-0.25, -0.05)
+    # Full-circle yaw: the handle may point in any direction on the stand.
+    object_reset_yaw_range: tuple[float, float] = (-3.14, 3.14)
+    # object_reset_roll_range: tuple[float, float] = (-1.57,-1.57)
+    # object_reset_pitch_range: tuple[float, float] = (0.3,0.3)
+    # Nail-on-a-board target placement (offsets from the table centre).
+    nail_board_init_x_offset: float = 0.0
+    nail_board_init_y_offset: float = 0.2
+    nail_board_reset_x_range: tuple[float, float] = (-0.05, 0.2)
+    nail_board_reset_y_range: tuple[float, float] = (0.0, 0.1)
+    nail_board_scale: tuple[float, float, float] = NAIL_BOARD_DEFAULT_SCALE
+    nail_board_half_height: float = NAIL_BOARD_HALF_HEIGHT
+
+    # Damping-only actuator: zero stiffness (no restoring spring), small
+    # damping bleeds off post-strike velocity, no velocity cap so a strike
+    # can actually move the nail. See module docstring.
+    nail_board_stiffness: float = 0.0
+    nail_board_damping: float = 0.3
+    nail_board_effort_limit_sim: float = 1.0
+    nail_board_velocity_limit_sim: float = 10.0
+
+    # (Hammer-frame) forbidden zones intentionally empty: success is gated on
+    # the nail-prismatic joint compression plus the target-frame forbidden
+    # zone below. Re-populate ``forbidden_zones`` to add a
+    # hand-stay-off-the-hammer-head requirement.
+    forbidden_zones: tuple[ForbiddenZone, ...] = ()
+
+    # Forbidden zones in the *target asset* (nail+board) local frame. Kept for the
+    # debug visualiser only: since Aug 2026 the "do not touch the nail" rule is a
+    # *termination* (``nail_touched`` below, attached to the moving nail body)
+    # rather than a success gate -- gating success only meant "press it with a
+    # finger, retract, still succeed".
+    target_forbidden_zones: tuple[ForbiddenZone, ...] = (
+        ForbiddenZone(
+            kind="sphere",
+            center=(0.0, 0.0, NAIL_HEAD_UNIT_Z * NAIL_BOARD_DEFAULT_SCALE[2]),
+            radius=NAIL_HEAD_FORBIDDEN_RADIUS,
+        ),
+    )
+    # Failure termination: any robot body within ``nail_touch_radius`` of the nail
+    # head centre (nail link frame, ``nail_head_local_offset``) ends the episode.
+    # 3.5 cm ~ nail head radius + fingertip radius; the hammer is a separate rigid
+    # body, so striking with it never trips this.
+    nail_touch_radius: float = 0.035
+    nail_head_local_offset: tuple[float, float, float] = (0.0, 0.0, 0.084 * NAIL_BOARD_DEFAULT_SCALE[2])
+    nail_body_name: str = "nail"
+
+    # Failure termination: the hammer *handle* touched the nail (a handle strike
+    # instead of a head strike). The nail head centre is tested against a capsule
+    # around the handle's centre line in the hammer's local frame. Geometry from
+    # the scaled (0.95) mesh: the handle runs diagonally from (+0.032, -0.175) at
+    # its end to (-0.046, +0.035) where the head begins (head spans y in
+    # [0.04, 0.14], striking face at x = -0.122), z-centre 0.015, radius ~0.017.
+    # The capsule stops 1.5 cm short of the head; radius = handle r (0.017) +
+    # nail head r (0.025) + margin. Validated on the 0821 demos: a proper head
+    # strike never brings the nail head closer than 0.074 m to this segment.
+    handle_touch_radius: float = 0.05
+    handle_segment_local_start: tuple[float, float, float] = (0.032, -0.175, 0.015)
+    handle_segment_local_end: tuple[float, float, float] = (-0.042, 0.020, 0.015)
+
+    # Small table (top + legs) the hammer rests on. Top height is the
+    # procedural asset's ``z_top`` (also used as ``table_clearance``).
+    # ``hammer_stand_xy_offset`` is in the hammer's local frame; the table
+    # inherits hammer yaw via ``quat_local``.
+    hammer_stand_height: float = HAMMER_STAND_TOP_HEIGHT
+    hammer_stand_xy_offset: tuple[float, float] = HAMMER_STAND_DEFAULT_XY_OFFSET
+    # Per-axis uniform xy jitter (m, world frame) applied to the stand when it
+    # snaps under the already-reset hammer. Shifting the stand under the
+    # hammer is equivalent to spawning the hammer at a random spot on the
+    # stand top. At +/-0.07 with full yaw the slim end of the hammer can
+    # overhang the 0.40 m top by a few cm at extreme draws, but the centre
+    # of mass stays far inside the top face, so the hammer never tips.
+    hammer_on_stand_xy_range: tuple[float, float] = (-0.07, 0.07)
+    # Low stand friction so the hammer can slide on the top. Use ``min``
+    # combine so these values win against the hammer's higher friction (2.0);
+    # with ``average`` the contact would still feel sticky.
+    hammer_stand_static_friction: float = 0.3
+    hammer_stand_dynamic_friction: float = 0.3
+    hammer_stand_friction_combine_mode: str = "min"
+
+    # Press distance (m) the nail must travel relative to its init pose.
+    press_distance_m: float = 0.06
+    # ``displacement`` measures abs(q - q_init); ``ratio`` uses joint range.
+    press_mode: str = "displacement"
+
+    # Hammer-head centre in the hammer's local frame (metres, scaled asset).
+    # Handle along local +x, head toward -x. Tuned for ``object_scale`` ~0.95.
+    hammer_head_local_offset: tuple[float, float, float] = (-0.095, 0.0, 0.0)
+
+    # Minimum xy distance (m) the nail-board target must keep from the
+    # hammer spawn. Enforced via rejection sampling at reset time.
+    min_object_goal_xy_distance: float = 0.10
+
+    # Override the scene to include the nail-board target articulation.
+    scene: HammerStrikeSceneCfg = HammerStrikeSceneCfg(
+        num_envs=4096,
+        env_spacing=3,
+        replicate_physics=False,
+    )
+    observations: HammerStrikeObservationsCfg = HammerStrikeObservationsCfg()
+    rewards: DenseHammerStrikeRewardsCfg = DenseHammerStrikeRewardsCfg()
+
+    def __post_init__(self):
+        # Lift the hammer onto the small-table top (read by the base
+        # ``__post_init__``). Asset frame origin is the footprint bottom.
+        self.table_clearance = self.hammer_stand_height
+        super().__post_init__()
+
+        # Position the nail-board on top of the table at the configured offset.
+        # Board frame is at the *centre* of the board, so add half the board
+        # thickness to land its bottom face on the table top.
+        table_top_z = dexverse_base_env.DEFAULT_TABLE_TOP_HEIGHT
+        table_pos = self.scene.table.init_state.pos
+
+        # Spawn the kinematic small table under the hammer (same role as the
+        # retrieve-tray rack: furniture that creates a pre-grasp affordance).
+        # Initial xy is nominal; ``reset_hammer_stand`` snaps it to the
+        # post-reset hammer pose. Root z = main-table top (bottom-origin USD).
+        stand_x = table_pos[0] + self.object_init_x_offset + self.hammer_stand_xy_offset[0]
+        stand_y = table_pos[1] + self.object_init_y_offset + self.hammer_stand_xy_offset[1]
+        self.scene.hammer_stand = RigidObjectCfg(
+            prim_path="{ENV_REGEX_NS}/HammerStand",
+            spawn=sim_utils.UsdFileCfg(
+                func=_make_hammer_stand_spawner(
+                    static_friction=self.hammer_stand_static_friction,
+                    dynamic_friction=self.hammer_stand_dynamic_friction,
+                    friction_combine_mode=self.hammer_stand_friction_combine_mode,
+                ),
+                usd_path=str(HAMMER_STAND_USD_PATH),
+                rigid_props=sim_utils.RigidBodyPropertiesCfg(
+                    rigid_body_enabled=True,
+                    kinematic_enabled=True,
+                    disable_gravity=True,
+                ),
+                # Collision is authored per box prim in the generated USD.
+                collision_props=None,
+                mass_props=None,
+                # Same Oak wood as the main table legs / drill workpiece.
+                visual_material=sim_utils.MdlFileCfg(
+                    mdl_path=HAMMER_STAND_MATERIAL_PATH,
+                    project_uvw=True,
+                    texture_scale=(0.5, 0.5),
+                ),
+            ),
+            init_state=RigidObjectCfg.InitialStateCfg(
+                pos=(stand_x, stand_y, table_top_z),
+                rot=(1.0, 0.0, 0.0, 0.0),
+            ),
+        )
+        self.scene.hammer_target = _make_nail_board_articulation_cfg(
+            init_pos=(
+                table_pos[0] + self.nail_board_init_x_offset,
+                table_pos[1] + self.nail_board_init_y_offset,
+                table_top_z + self.nail_board_half_height,
+            ),
+            scale=self.nail_board_scale,
+            stiffness=self.nail_board_stiffness,
+            damping=self.nail_board_damping,
+            effort_limit_sim=self.nail_board_effort_limit_sim,
+            velocity_limit_sim=self.nail_board_velocity_limit_sim,
+        )
+
+        # Attach reset events for the nail-board (root pose + prismatic joint).
+        # The excluding variant rejection-samples the nail-board xy so it
+        # stays at least ``min_object_goal_xy_distance`` from the hammer's
+        # already-reset xy.
+        self.events.reset_hammer_target = EventTerm(
+            func=mdp.reset_root_pose_uniform_excluding,
+            mode="reset",
+            params={
+                "pose_range": {
+                    "x": list(self.nail_board_reset_x_range),
+                    "y": list(self.nail_board_reset_y_range),
+                    "z": [0.0, 0.0],
+                    "roll": [0.0, 0.0],
+                    "pitch": [0.0, 0.0],
+                    "yaw": [0.0, 0.0],
+                },
+                "asset_cfg": SceneEntityCfg(TARGET_KEY),
+                "reference_asset_cfg": SceneEntityCfg("object"),
+                "min_xy_distance": self.min_object_goal_xy_distance,
+            },
+        )
+        self.events.reset_hammer_target_joints = EventTerm(
+            func=mdp.reset_joints_to_init,
+            mode="reset",
+            params={
+                "asset_cfg": SceneEntityCfg(TARGET_KEY, joint_names=[NAIL_PRISMATIC_JOINT]),
+            },
+        )
+
+        # Snap the small table under the hammer. Use a *world* identity quat
+        # (not quat_local) so the stand stays axis-aligned with the main
+        # table -- two nested squares, not a diamond on a square. xy tracks
+        # the hammer plus a per-env jitter (``hammer_on_stand_xy_range``) so
+        # the hammer lands at a random spot on the stand top; bottom-origin
+        # USD sits on the main tabletop.
+        stand_z_offset = -(self.object_half_height + self.hammer_stand_height)
+        self.events.reset_hammer_stand = EventTerm(
+            func=mdp.sync_object,
+            mode="reset",
+            params={
+                "target_cfg": SceneEntityCfg("hammer_stand"),
+                "source_cfg": SceneEntityCfg("object"),
+                "source_local_offset": (
+                    self.hammer_stand_xy_offset[0],
+                    self.hammer_stand_xy_offset[1],
+                    0.0,
+                ),
+                "xy_jitter_range": {
+                    "x": list(self.hammer_on_stand_xy_range),
+                    "y": list(self.hammer_on_stand_xy_range),
+                },
+                "z_offset": stand_z_offset,
+                "quat": (1.0, 0.0, 0.0, 0.0),
+            },
+        )
+
+        # No object-pose goal command: the goal is encoded by affinity overlap
+        # and nail compression instead (the goal-tracking reward terms are
+        # ``None`` at the class level on ``DenseHammerStrikeRewardsCfg``).
+        self.commands.object_pose = None
+        # Wire the dense strike terms: nail-head point in the scaled board
+        # frame, hammer-head point from the leaf-tunable offset, and nail
+        # compression graded toward the success press distance.
+        self.rewards.head_to_nail.params.update({
+            "source_local_offset": self.hammer_head_local_offset,
+            "target_local_offset": (0.0, 0.0, NAIL_HEAD_UNIT_Z * self.nail_board_scale[2]),
+        })
+        self.rewards.nail_press.params.update({
+            "threshold_m": self.press_distance_m,
+            "asset_cfg": SceneEntityCfg(TARGET_KEY, joint_names=[NAIL_PRISMATIC_JOINT]),
+        })
+        # ``goal_pos_b.asset_cfg`` and ``nail_press.asset_cfg`` are fixed to
+        # ``TARGET_KEY`` at the class level (see ``HammerStrikeObservationsCfg``).
+        # Only the leaf-tunable ``press_distance_m`` needs propagation.
+        self.observations.goal.required_press_distance.params["value"] = self.press_distance_m
+
+        # Replace success termination with the hammer-strike-specific success.
+        # Success is instantaneous -- the nail is pressed past the threshold -- so
+        # no contact/zone conditions are attached to it (Aug 2026; the target
+        # zones now feed the ``nail_touched`` failure termination instead).
+        sphere_zones, box_zones, cylinder_zones = split_zones(self.forbidden_zones)
+        self.terminations.success = DoneTerm(
+            func=mdp.hammer_strike_success,
+            params={
+                "press_threshold_m": self.press_distance_m,
+                "press_mode": self.press_mode,
+                "sphere_zones": sphere_zones,
+                "box_zones": box_zones,
+                "cylinder_zones": cylinder_zones,
+                "target_sphere_zones": [],
+                "target_box_zones": [],
+                "target_cylinder_zones": [],
+                "asset_cfg": self.forbidden_zone_asset_cfg(),  # every robot body (cross-embodiment)
+                "object_cfg": SceneEntityCfg("object"),
+                "target_asset_cfg": SceneEntityCfg(TARGET_KEY),
+                "target_joint_cfg": SceneEntityCfg(TARGET_KEY, joint_names=[NAIL_PRISMATIC_JOINT]),
+            },
+        )
+        # Operator cues (forbidden / contact zones from the functional base).
+        # The nail-head no-touch sphere visual was removed; ``nail_touched``
+        # below still enforces the rule without drawing a red marker.
+        self.configure_debug_vis()
+
+        # Failure: the hand touched the nail head (any robot body inside the sphere).
+        self.terminations.nail_touched = DoneTerm(
+            func=mdp.hand_near_body_point,
+            params={
+                "robot_cfg": self.forbidden_zone_asset_cfg(),  # every robot body unless the robot cfg narrows it
+                "target_cfg": SceneEntityCfg(TARGET_KEY, body_names=[self.nail_body_name]),
+                "local_offset": tuple(self.nail_head_local_offset),
+                "radius": self.nail_touch_radius,
+            },
+        )
+
+        # Failure: the hammer handle touched the nail head (handle strike).
+        self.terminations.handle_touched_nail = DoneTerm(
+            func=mdp.body_point_near_object_segment,
+            params={
+                "object_cfg": SceneEntityCfg("object"),
+                "target_cfg": SceneEntityCfg(TARGET_KEY, body_names=[self.nail_body_name]),
+                "target_local_offset": tuple(self.nail_head_local_offset),
+                "segment_start": tuple(self.handle_segment_local_start),
+                "segment_end": tuple(self.handle_segment_local_end),
+                "radius": self.handle_touch_radius,
+            },
+        )

--- a/source/dexverse/dexverse/baseline_v1/config/functional/place_cup_under_dispenser_cfg.py
+++ b/source/dexverse/dexverse/baseline_v1/config/functional/place_cup_under_dispenser_cfg.py
@@ -1,0 +1,303 @@
+# Copyright (c) 2025-2026, The DexVerse Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Grasp a knocked-over cup, stand it upright and set it under the dispenser.
+
+The pour tasks (``PourCan`` / ``GraspCup``) are all grasp-lift-tilt; this one
+exercises **reorientation and precise upright placement** instead. The green
+cup of :mod:`grasp_cup_cfg` spawns *lying on its side* (or upside down) at a
+random pose on the table; the robot has to pick it up, turn it upright and
+stand it on the drip tray of a counter-top **dispenser**, exactly under the
+nozzle, then let go.
+
+* Dispenser (:func:`dexverse.assets.desk_props_builder.build_dispenser`): a
+  kinematic prop -- drip tray, back column, arm and a nozzle whose bottom sits
+  ``spout_height`` = 16 cm above the tray (the cup is 9.6 cm tall), with a
+  green target disk on the tray under the nozzle (the vision landmark). It
+  spawns at the far side of the table facing the robot, with xy / yaw jitter;
+  the cup spawns clear of it.
+* Cup spawn (:func:`mdp.reset_root_pose_uniform_orientations`): rest orientation
+  drawn from ``cup_spawn_weights`` (side / upside-down / upright), random xy and
+  yaw; the draw is kept in ``env.cup_spawn_orientation`` (recorded with the
+  episode task state).
+* Success (stage graph ``cup_upright -> cup_placed``,
+  :func:`mdp.object_placed_at_spot`): the cup's base within ``spot_xy_tol`` of
+  the tray centre and ``spot_z_tol`` of the tray top, upright within
+  ``upright_tol_deg``, at rest, **and released** (every robot body farther than
+  the cup radius + ``release_clearance`` from the cup's axis), for
+  ``placed_hold_steps`` consecutive steps.
+* Failure: the cup-scaled rim forbidden zone (fingers in the drink) becomes an
+  immediate failure (``rim_touch_is_failure``); cup off the table.
+"""
+
+from __future__ import annotations
+
+import math
+
+import isaaclab.sim as sim_utils
+from dexverse.assets.desk_props_builder import ensure_dispenser_asset
+from isaaclab.assets import RigidObjectCfg
+from isaaclab.managers import EventTermCfg as EventTerm
+from isaaclab.managers import ObservationGroupCfg as ObsGroup
+from isaaclab.managers import ObservationTermCfg as ObsTerm
+from isaaclab.managers import RewardTermCfg as RewTerm
+from isaaclab.managers import SceneEntityCfg
+from isaaclab.managers import TerminationTermCfg as DoneTerm
+from isaaclab.utils import configclass
+from isaaclab.utils.noise import UniformNoiseCfg as Unoise
+
+from ... import dexverse_base_env_cfg as dexverse_base_env
+from ... import mdp
+from ..grasping.forbidden_zones import ForbiddenZone, split_zones
+from .grasp_cup_cfg import GraspCupEnvFloatingDexHandRightCfg
+
+STAGE_KEY = "place_cup_under_dispenser"
+CUP_SPAWN_BUFFER = "cup_spawn_orientation"
+# Green cup (Cup_B0CMD4LX4D), root at the base centre. Task-local scale is
+# 10% smaller than the previous dispenser cup (0.9); leave GraspCup v0 alone.
+CUP_SCALE = 0.81
+CUP_RADIUS = 0.0425 * CUP_SCALE
+CUP_HEIGHT = 0.118 * CUP_SCALE
+CUP_UP_AXIS_LOCAL = (0.0, 0.0, 1.0)
+_S45 = math.sqrt(0.5)
+# rest orientations: (quat wxyz, height of the cup root above the table top)
+CUP_REST_ORIENTATIONS = {
+    "side": ((_S45, _S45, 0.0, 0.0), CUP_RADIUS + 0.003),
+    "upside_down": ((0.0, 1.0, 0.0, 0.0), CUP_HEIGHT + 0.003),
+    "upright": ((1.0, 0.0, 0.0, 0.0), 0.003),
+}
+CUP_REST_ORDER = tuple(CUP_REST_ORIENTATIONS)
+
+DISPENSER_NAME = "dispenser"
+# Tray long enough in x that the column's front face stays 5 cm behind the spot
+# (cup radius now 3.4 cm): a cup on the spot must not touch the column.
+DISPENSER_PARAMS = dict(
+    spout_height=0.16,
+    tray_size=(0.22, 0.16, 0.012),
+    column_size=(0.06, 0.06, 0.26),
+    body_color=(0.55, 0.55, 0.55),
+    nozzle_color=(0.35, 0.35, 0.35),
+    # Keep the placement target green and distinct from the grey hardware.
+    target_color=(0.15, 0.75, 0.25),
+)
+DISPENSER_USD_PATH, DISPENSER_MANIFEST = ensure_dispenser_asset(DISPENSER_NAME, **DISPENSER_PARAMS)
+SPOT_LOCAL: tuple[float, float, float] = tuple(float(v) for v in DISPENSER_MANIFEST["spot_local"])
+
+
+def make_dispenser_cfg(usd_path: str, init_pos: tuple[float, float, float]) -> RigidObjectCfg:
+    return RigidObjectCfg(
+        prim_path="{ENV_REGEX_NS}/Dispenser",
+        spawn=sim_utils.UsdFileCfg(
+            func=dexverse_base_env.spawn_usd_with_rigid_properties,
+            usd_path=usd_path,
+            rigid_props=sim_utils.RigidBodyPropertiesCfg(
+                rigid_body_enabled=True, kinematic_enabled=True, disable_gravity=True
+            ),
+            collision_props=None,  # authored per prim (the target disk has none)
+            mass_props=None,
+        ),
+        init_state=RigidObjectCfg.InitialStateCfg(pos=init_pos, rot=(1.0, 0.0, 0.0, 0.0)),
+    )
+
+
+@configclass
+class PlaceCupUnderDispenserEnvFloatingDexHandRightCfg(GraspCupEnvFloatingDexHandRightCfg):
+    """Right the knocked-over cup and stand it on the dispenser tray under the nozzle."""
+
+    # Scale both the rendered mesh and its authored convex colliders. Root-frame
+    # zones/observation offsets are metric, so they must be scaled explicitly.
+    object_scale: tuple[float, float, float] = (CUP_SCALE, CUP_SCALE, CUP_SCALE)
+    forbidden_zones: tuple[ForbiddenZone, ...] = (
+        ForbiddenZone(
+            kind="cylinder", center=(0.0, 0.0, 0.11 * CUP_SCALE),
+            radius=0.035 * CUP_SCALE, half_height=0.005 * CUP_SCALE,
+        ),
+    )
+    pour_goal_object_local_offset: tuple[float, float, float] = (0.0, 0.0, 0.1 * CUP_SCALE)
+
+    # ---- cup spawn ---------------------------------------------------------------
+    cup_spawn_weights: dict[str, float] = {"side": 0.8, "upside_down": 0.2, "upright": 0.0}
+    # x starts at -0.08: the hand rests at x=-0.25 with fingertips reaching ~-0.13,
+    # so a tall inverted cup dropped further back would land on them.
+    object_reset_x_range: tuple[float, float] = (-0.08, 0.12)
+    object_reset_y_range: tuple[float, float] = (-0.20, 0.20)
+    object_reset_yaw_range: tuple[float, float] = (-math.pi, math.pi)
+    min_cup_dispenser_xy_distance: float = 0.22
+
+    # ---- dispenser spawn: far side, open side toward the robot -------------------
+    dispenser_init_xy: tuple[float, float] = (0.30, 0.0)
+    dispenser_pose_range: dict[str, list[float]] = {"x": [-0.04, 0.04], "y": [-0.15, 0.15], "yaw": [-0.25, 0.25]}
+
+    # ---- success ----------------------------------------------------------------
+    upright_stage_tol_deg: float = 15.0  # stage 1: cup standing up (anywhere)
+    spot_xy_tol: float = 0.03
+    spot_z_tol: float = 0.02
+    upright_tol_deg: float = 10.0
+    placed_max_lin_speed: float = 0.05
+    placed_hold_steps: int = 30
+    release_clearance: float = 0.02
+    rim_touch_is_failure: bool = True
+    episode_length_s_override: float = 25.0
+
+    # no pour goal sphere / progress sphere: the dispenser's disk is the target
+    pour_show_progress_marker: bool = False
+    pour_goal_marker_camera_visible: bool = False
+
+    def __post_init__(self):
+        table_top_z = dexverse_base_env.DEFAULT_TABLE_TOP_HEIGHT
+        self.scene.dispenser = make_dispenser_cfg(
+            str(DISPENSER_USD_PATH), (self.dispenser_init_xy[0], self.dispenser_init_xy[1], table_top_z)
+        )
+        super().__post_init__()
+        self.episode_length_s = self.episode_length_s_override
+
+        # --- resets: dispenser first, then the cup clear of it, then the marker ----
+        self.events.reset_object = None
+        self.events.reset_dispenser = EventTerm(
+            func=mdp.reset_root_pose_uniform,
+            mode="reset",
+            params={
+                "asset_cfg": SceneEntityCfg("dispenser"),
+                "pose_range": {
+                    "x": list(self.dispenser_pose_range["x"]),
+                    "y": list(self.dispenser_pose_range["y"]),
+                    "z": [0.0, 0.0],
+                    "roll": [0.0, 0.0],
+                    "pitch": [0.0, 0.0],
+                    "yaw": list(self.dispenser_pose_range["yaw"]),
+                },
+            },
+        )
+        self.events.reset_cup = EventTerm(
+            func=mdp.reset_root_pose_uniform_orientations,
+            mode="reset",
+            params={
+                "asset_cfg": SceneEntityCfg("object"),
+                "pose_range": {
+                    "x": list(self.object_reset_x_range),
+                    "y": list(self.object_reset_y_range),
+                    "yaw": list(self.object_reset_yaw_range),
+                },
+                "orientations": [CUP_REST_ORIENTATIONS[name] for name in CUP_REST_ORDER],
+                "weights": [float(self.cup_spawn_weights.get(name, 0.0)) for name in CUP_REST_ORDER],
+                "table_top_z": table_top_z,
+                "buffer_name": CUP_SPAWN_BUFFER,
+                "reference_asset_cfg": SceneEntityCfg("dispenser"),
+                "min_xy_distance": self.min_cup_dispenser_xy_distance,
+                "max_attempts": 40,
+            },
+        )
+        # the (hidden) pour goal marker just tracks the spot (re-added here so it
+        # runs after the dispenser reset; the inherited slot ran before it)
+        self.scene.success_marker.spawn.visible = False
+        self.events.reset_success_marker = None
+        self.events.sync_marker_to_spot = EventTerm(
+            func=mdp.sync_object,
+            mode="reset",
+            params={
+                "target_cfg": SceneEntityCfg("success_marker"),
+                "source_cfg": SceneEntityCfg("dispenser"),
+                "source_local_offset": SPOT_LOCAL,
+                "quat": (1.0, 0.0, 0.0, 0.0),
+            },
+        )
+        # clear latched stages every reset (the cup's init pose is upright, which
+        # would otherwise latch ``cup_upright`` from the construction-time eval)
+        self.events.reset_stage_state = EventTerm(
+            func=mdp.reset_stage_graph_state, mode="reset", params={"task_key": STAGE_KEY}
+        )
+
+        # --- stage graph: upright, then placed under the nozzle and released -------
+        mdp.register_stage_graph(
+            STAGE_KEY,
+            mdp.StageGraphSpec(
+                stages=(
+                    mdp.StageSpec(
+                        name="cup_upright",
+                        func=mdp.object_axis_upright,
+                        params={
+                            "object_cfg": SceneEntityCfg("object"),
+                            "axis_local": CUP_UP_AXIS_LOCAL,
+                            "min_cos": math.cos(math.radians(self.upright_stage_tol_deg)),
+                        },
+                    ),
+                    mdp.StageSpec(
+                        name="cup_placed",
+                        func=mdp.object_placed_at_spot,
+                        params={
+                            "cache_key": STAGE_KEY,
+                            "spot_cfg": SceneEntityCfg("dispenser"),
+                            "spot_local": SPOT_LOCAL,
+                            "object_cfg": SceneEntityCfg("object"),
+                            "xy_tol": self.spot_xy_tol,
+                            "z_tol": self.spot_z_tol,
+                            "axis_local": CUP_UP_AXIS_LOCAL,
+                            "upright_cos": math.cos(math.radians(self.upright_tol_deg)),
+                            "max_lin_speed": self.placed_max_lin_speed,
+                            "hold_steps": self.placed_hold_steps,
+                            "robot_cfg": self.forbidden_zone_asset_cfg(),
+                            "object_radius": CUP_RADIUS,
+                            "object_axis_length": CUP_HEIGHT,
+                            "release_clearance": self.release_clearance,
+                        },
+                        deps=("cup_upright",),
+                    ),
+                ),
+                terminal_stage="cup_placed",
+                ordering_mode="strict",
+                success_mode="substage",
+            ),
+            override=True,
+        )
+        self.terminations.success = DoneTerm(func=mdp.stage_success, params={"task_key": STAGE_KEY, "persistent": True})
+        if self.rim_touch_is_failure:
+            sphere_zones, box_zones, cylinder_zones = split_zones(self.forbidden_zones)
+            self.terminations.rim_touched = DoneTerm(
+                func=mdp.robot_in_forbidden_zones,
+                params={
+                    "asset_cfg": self.forbidden_zone_asset_cfg(),
+                    "object_cfg": SceneEntityCfg("object"),
+                    "sphere_zones": sphere_zones,
+                    "box_zones": box_zones,
+                    "cylinder_zones": cylinder_zones,
+                },
+            )
+
+        # --- rewards: no tilt shaping here; stage bonus ------------------------------
+        self.rewards.tilt_reward = None
+        if getattr(self.rewards, "lift_progress", None) is not None:
+            self.rewards.lift_progress = None
+        self.rewards.stage_bonus = RewTerm(
+            func=mdp.stage_success_reward, weight=5.0, params={"task_key": STAGE_KEY, "persistent": True}
+        )
+
+        # --- observations: spot in ``goal``; dispenser pose + stage signals in state
+        @configclass
+        class GoalObsCfg(ObsGroup):
+            spot_pos_b = ObsTerm(
+                func=mdp.object_local_point_pos_b,
+                params={"object_cfg": SceneEntityCfg("dispenser"), "local_offset": SPOT_LOCAL},
+                noise=Unoise(n_min=-0.0, n_max=0.0),
+            )
+
+            def __post_init__(self):
+                self.enable_corruption = True
+                self.concatenate_terms = True
+                self.history_length = 0
+
+        self.observations.goal = GoalObsCfg()
+        state = self.observations.state
+        if state is not None:
+            state.dispenser_pos_b = ObsTerm(
+                func=mdp.asset_pos_b,
+                params={"asset_cfg": SceneEntityCfg("dispenser")},
+                noise=Unoise(n_min=-0.0, n_max=0.0),
+            )
+            state.dispenser_quat_b = ObsTerm(
+                func=mdp.object_quat_b,
+                params={"object_cfg": SceneEntityCfg("dispenser")},
+                noise=Unoise(n_min=-0.0, n_max=0.0),
+            )
+            state.stage_signals = ObsTerm(func=mdp.stage_signals, params={"task_key": STAGE_KEY, "persistent": True})

--- a/source/dexverse/dexverse/baseline_v1/config/functional/pour_can_cfg.py
+++ b/source/dexverse/dexverse/baseline_v1/config/functional/pour_can_cfg.py
@@ -1,0 +1,232 @@
+# Copyright (c) 2025-2026, The DexVerse Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Functional grasping: pour can into a bowl."""
+
+from __future__ import annotations
+
+import math
+
+import isaaclab.sim as sim_utils
+from dexverse.assets import SYNTHESIS_DIR, YCB_DIR
+from isaaclab.assets import RigidObjectCfg
+from isaaclab.managers import EventTermCfg as EventTerm
+from isaaclab.managers import SceneEntityCfg
+from isaaclab.utils import configclass
+
+from ... import dexverse_base_env_cfg as dexverse_base_env
+from ... import mdp
+from ..robot_init import (
+    align_retargeter_wrist_origin_to_init,
+    set_robot_wrist_init_world_pos,
+)
+from .base_cfg import (
+    POUR_ANGLE_RAD,
+    ForbiddenZone,
+    FunctionalPourEnvFloatingDexHandRightCfg,
+    FunctionalPourObservationsCfg,
+    build_object_cfg_from_usd,
+)
+
+CAN_USD_PATH = str(YCB_DIR / "005_tomato_soup_can" / "tomato_soup_can.usd")
+CAN_SCALE = (1.0, 1.0, 1.0)
+CAN_MASS = 0.3
+CAN_HALF_HEIGHT_EST = 0.062  # reset audit (Aug 2026): 0.05 sat 9 mm inside the table and popped up; +12 mm
+CAN_ROT_INIT = (0.707107, -0.707107, 0.0, 0.0)
+CAN_FORBIDDEN_ZONE_ROT_OFFSET = (
+    math.cos(math.pi / 4.0),
+    math.sin(math.pi / 4.0),
+    0.0,
+    0.0,
+)
+CENTER_SQUARE_SIZE = 0.45
+
+BOWL_USD_PATH = str(
+    SYNTHESIS_DIR / "Bowl_B0888F8FR2_SpiralCenter_1_TU" / "model_Bowl_B0888F8FR2_SpiralCenter_1_TU_69323.usd"
+)
+BOWL_SCALE = (1.5, 1.5, 1.5)
+BOWL_HALF_HEIGHT_EST = 0.001
+
+CAN_CFG = build_object_cfg_from_usd(
+    CAN_USD_PATH,
+    mass=CAN_MASS,
+    scale=CAN_SCALE,
+    init_rot=CAN_ROT_INIT,
+    collision_enabled=True,
+)
+PickUpCanObservationsCfg = FunctionalPourObservationsCfg
+
+
+def _build_bowl_cfg(
+    *,
+    scale: tuple[float, float, float],
+    init_rot: tuple[float, float, float, float],
+    init_pos: tuple[float, float, float],
+) -> RigidObjectCfg:
+    """Kinematic bowl prop. Re-synced under the pour goal each reset."""
+    return RigidObjectCfg(
+        prim_path="{ENV_REGEX_NS}/Bowl",
+        spawn=sim_utils.UsdFileCfg(
+            func=dexverse_base_env.spawn_usd_with_rigid_properties,
+            usd_path=BOWL_USD_PATH,
+            scale=scale,
+            rigid_props=sim_utils.RigidBodyPropertiesCfg(
+                rigid_body_enabled=True,
+                kinematic_enabled=True,
+                disable_gravity=True,
+                solver_position_iteration_count=16,
+                solver_velocity_iteration_count=0,
+            ),
+            collision_props=None,
+            mass_props=sim_utils.MassPropertiesCfg(mass=1.0),
+        ),
+        init_state=RigidObjectCfg.InitialStateCfg(pos=init_pos, rot=init_rot),
+    )
+
+
+@configclass
+class PourCanEnvFloatingDexHandRightCfg(FunctionalPourEnvFloatingDexHandRightCfg):
+    """Lift and tilt the tomato soup can over a bowl prop."""
+
+    usd_path: str = CAN_USD_PATH
+    object_mass: float = CAN_MASS
+    object_scale: tuple[float, float, float] = CAN_SCALE
+    object_half_height: float = CAN_HALF_HEIGHT_EST
+    object_static_friction: float | None = 2.5
+    object_dynamic_friction: float | None = 2.5
+    object_friction_combine_mode: str = "average"
+    table_clearance: float = 0.0
+    object_init_x_offset: float = 0.0
+    object_init_y_offset: float = 0.0
+    object_init_rot: tuple[float, float, float, float] = CAN_ROT_INIT
+    object_collision_enabled: bool = False
+
+    # Reset audit (Aug 2026): the can used to spawn at x in [-0.15, 0], i.e.
+    # directly under the floating hand's fingertips (palm x=-0.25, tips at
+    # x~-0.06, 10 cm above the can). Shifted 15 cm forward, out from under
+    # the hand; the goal/bowl band below is shifted by the same amount.
+    object_reset_x_range: tuple[float, float] = (0.0, 0.15)
+    object_reset_y_range: tuple[float, float] = (-0.15, 0.15)
+    object_reset_yaw_range: tuple[float, float] = (0.0, 0.0)
+
+    pour_lift_height: float = 0.2
+    pour_angle_rad: float = POUR_ANGLE_RAD
+    pour_axis_local: tuple[float, float, float] = (0.0, -1.0, 0.0)
+    pour_tilt_ge: bool = True
+
+    # Tilt success uses only the directional primary gate (``pour_angle_rad``
+    # about ``pour_axis_local`` vs world +Z). The secondary plane-angle gate is
+    # left disabled (base default ``None``): it's undirected (can't tell a
+    # tipped-down pour from an upright lift) and at a 90° threshold never fired.
+
+    # Shifts the xy gate measurement point from the object's mass centre
+    # to ``object.root_pos + R(object.root_quat) * pour_goal_object_local_offset``
+    # (object-local coordinates). Useful when the relevant point is the
+    # spout / lip rather than the bounding-box centre.
+    pour_goal_object_local_offset: tuple[float, float, float] = (0.0, -0.0475, 0.0)  # TODO: tune to the can's lip
+
+    # Goal indicator: sphere at the goal that animates red -> green as the
+    # object tilts toward the threshold (green = tilt criterion met). Visual
+    # only; disable for headless / faster rendering.
+
+    forbidden_zones: tuple[ForbiddenZone, ...] = (
+        ForbiddenZone(
+            kind="cylinder",
+            center=(0.0, -0.048, 0.0),
+            radius=0.03,
+            half_height=0.005,
+            rotation_offset=CAN_FORBIDDEN_ZONE_ROT_OFFSET,
+        ),
+    )
+
+    bowl_usd_path: str = BOWL_USD_PATH
+    bowl_scale: tuple[float, float, float] = BOWL_SCALE
+    bowl_half_height: float = BOWL_HALF_HEIGHT_EST
+    bowl_init_rot: tuple[float, float, float, float] = (1.0, 0.0, 0.0, 0.0)
+    # Pour-goal randomization (offsets from the table centre). The bowl is
+    # slaved to this same xy via ``reset_bowl`` below, so the goal
+    # indicator and the bowl prop always share their location. Defaults
+    # place the goal in front of the can's reset zone (x ∈ [0.0, 0.15]).
+    goal_reset_x_range: tuple[float, float] = (0.15, 0.30)
+    goal_reset_y_range: tuple[float, float] = (-0.15, 0.15)
+
+    # Minimum xy distance (m) the pour goal/bowl must keep from the can
+    # spawn. Enforced via rejection sampling at reset time. The bowl rim is
+    # r~8.7 cm (scale 1.5) and the can r~3.4 cm, so 0.20 leaves ~8 cm of clear
+    # table between them (at 0.10 the can could spawn inside the bowl rim;
+    # 0.15 left only ~3 cm).
+    min_object_goal_xy_distance: float = 0.20
+
+    def __post_init__(self):
+        super().__post_init__()
+
+        # Leap default palm world-z is base (0.6) + z_translation (0.3) = 0.9.
+        # Raise 5 cm for this task so the hand clears the can/bowl more cleanly.
+        if self.robot_type == "floating_leap_right":
+            init_state = self.scene.robot.init_state
+            base_z = float(init_state.pos[2])
+            z_joint = float(init_state.joint_pos.get("z_translation_joint", 0.0))
+            set_robot_wrist_init_world_pos(self, z=base_z + z_joint + 0.05)
+            align_retargeter_wrist_origin_to_init(self)
+
+        table_top_z = dexverse_base_env.DEFAULT_TABLE_TOP_HEIGHT
+        marker_pos = self.scene.success_marker.init_state.pos
+
+        # Spawn the bowl directly under the success marker so the goal
+        # indicator and the bowl prop are visually paired even at frame 0
+        # (before the first reset event runs). Both x/y/z come from the
+        # marker pose so they can never disagree by accident; only z is
+        # dropped to the tabletop.
+        bowl_cfg = _build_bowl_cfg(
+            scale=self.bowl_scale,
+            init_rot=self.bowl_init_rot,
+            init_pos=(marker_pos[0], marker_pos[1], table_top_z + self.bowl_half_height),
+        )
+        self.scene.bowl = bowl_cfg
+
+        # Replace the base sync (marker tied to can) with a uniform xy
+        # randomization for the pour goal indicator. roll/pitch/yaw deltas
+        # default to zero so the marker keeps its tilted SUCCESS_MARKER_QUAT.
+        # The excluding variant rejection-samples xy so the marker (and the
+        # bowl it drives via reset_bowl) stays at least
+        # ``min_object_goal_xy_distance`` away from the can spawn.
+        self.events.reset_success_marker = EventTerm(
+            func=mdp.reset_root_pose_uniform_excluding,
+            mode="reset",
+            params={
+                "pose_range": {
+                    "x": list(self.goal_reset_x_range),
+                    "y": list(self.goal_reset_y_range),
+                    "z": [0.0, 0.0],
+                    "roll": [0.0, 0.0],
+                    "pitch": [0.0, 0.0],
+                    "yaw": [0.0, 0.0],
+                },
+                "velocity_range": {"x": [0.0, 0.0], "y": [0.0, 0.0], "z": [0.0, 0.0]},
+                "asset_cfg": SceneEntityCfg("success_marker"),
+                "reference_asset_cfg": SceneEntityCfg("object"),
+                "min_xy_distance": self.min_object_goal_xy_distance,
+                "max_attempts": 40,
+            },
+        )
+
+        # Slave the bowl to the (now-randomized) marker xy and drop it
+        # onto the tabletop. This event is appended after
+        # ``reset_success_marker``, so on every reset the marker pose is
+        # resampled first and the bowl then snaps under it. The
+        # marker-driven xy is the single source of truth -- bowl and goal
+        # cannot diverge.
+        marker_z = self.scene.success_marker.init_state.pos[2]
+        bowl_z_offset = table_top_z + self.bowl_half_height - marker_z
+        self.events.reset_bowl = EventTerm(
+            func=mdp.sync_object,
+            mode="reset",
+            params={
+                "target_cfg": SceneEntityCfg("bowl"),
+                "source_cfg": SceneEntityCfg("success_marker"),
+                "z_offset": bowl_z_offset,
+                "quat": self.bowl_init_rot,
+            },
+        )

--- a/source/dexverse/dexverse/baseline_v1/config/functional/pour_mug_cfg.py
+++ b/source/dexverse/dexverse/baseline_v1/config/functional/pour_mug_cfg.py
@@ -1,0 +1,145 @@
+# Copyright (c) 2025-2026, The DexVerse Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Functional grasping: pour mug."""
+
+from __future__ import annotations
+
+import numpy as np
+from dexverse.assets import DEXVERSE_AUTHORED_ASSETS_DIR
+from isaaclab.devices.openxr import XrCfg
+from isaaclab.managers import EventTermCfg as EventTerm
+from isaaclab.managers import SceneEntityCfg
+from isaaclab.utils import configclass
+from scipy.spatial.transform import Rotation as R
+
+from ... import mdp
+from .base_cfg import (
+    DEFAULT_FLOATING_SHADOW_XR_CFG,
+    POUR_ANGLE_RAD,
+    ForbiddenZone,
+    FunctionalPourEnvCfg,
+    FunctionalPourEnvFloatingDexHandRightCfg,
+    FunctionalPourObservationsCfg,
+    build_object_cfg_from_usd,
+)
+
+MUG_USD_PATH = str(DEXVERSE_AUTHORED_ASSETS_DIR / "mug" / "SM_Mug_A2.usd")
+MUG_SCALE = (0.015, 0.015, 0.015)
+MUG_MASS = 0.3
+MUG_Z_OFFSET = 0.003  # reset audit (Aug 2026): seated ~3 mm above rest instead of dropping (was 0.05, dropped 5 cm)
+
+# rotate 90 degrees around z axis
+rot_quat = R.from_euler("x", np.pi / 2).as_quat()
+
+MUG_INIT_QUAT = tuple(rot_quat.tolist())
+CENTER_SQUARE_SIZE = 0.45
+
+MUG_CFG = build_object_cfg_from_usd(
+    MUG_USD_PATH,
+    mass=MUG_MASS,
+    scale=MUG_SCALE,
+    init_rot=MUG_INIT_QUAT,
+    collision_enabled=False,
+)
+PourMugObservationsCfg = FunctionalPourObservationsCfg
+
+
+@configclass
+class PourMugEnvCfg(FunctionalPourEnvCfg):
+    """Lift and tilt a mug into a pouring pose."""
+
+    usd_path: str = MUG_USD_PATH
+    object_mass: float = MUG_MASS
+    object_scale: tuple[float, float, float] = MUG_SCALE
+    object_half_height: float = MUG_Z_OFFSET
+    object_static_friction: float | None = 2.0
+    object_dynamic_friction: float | None = 2.0
+    object_friction_combine_mode: str = "average"
+    table_clearance: float = 0.0
+    object_init_x_offset: float = 0.0
+    object_init_y_offset: float = 0.0
+    object_init_rot: tuple[float, float, float, float] = MUG_INIT_QUAT
+    object_collision_enabled: bool = False
+
+    object_reset_x_range: tuple[float, float] = (-0.1, 0.2)
+    object_reset_y_range: tuple[float, float] = (-0.35, 0.35)
+    # Reset audit (Aug 2026): uniform yaw -- the handle can point anywhere, so
+    # the episode may need a pre-grasp reorientation before the functional
+    # grasp.
+    object_reset_yaw_range: tuple[float, float] = (-3.14, 3.14)
+
+    pour_lift_height: float = 0.2
+    pour_angle_rad: float = POUR_ANGLE_RAD
+    pour_axis_local: tuple[float, float, float] = (0.0, 0.0, 1.0)
+    pour_tilt_ge: bool = True
+
+    # Tilt success uses only the directional primary gate (``pour_angle_rad``
+    # about ``pour_axis_local`` vs world +Z). The secondary plane-angle gate is
+    # left disabled (base default ``None``): it's undirected (can't tell a
+    # tipped-down pour from an upright lift) and at a 90° threshold never fired.
+
+    # Shifts the xy gate measurement point from the object's mass centre
+    # to ``object.root_pos + R(object.root_quat) * pour_goal_object_local_offset``
+    # (object-local coordinates). Useful when the relevant point is the
+    # spout / lip rather than the bounding-box centre.
+    pour_goal_object_local_offset: tuple[float, float, float] = (0.0, 0.0, 0.14)  # TODO: tune to the mug's rim
+
+    # Pour-goal randomization: xy offsets from the table centre. Defaults
+    # bias the goal away from the mug's reset zone (x ∈ (-0.1, 0.2)) so the
+    # pour target rarely overlaps the spawn region. Tune as needed.
+    goal_reset_x_range: tuple[float, float] = (0.2, 0.35)
+    goal_reset_y_range: tuple[float, float] = (-0.25, 0.25)
+
+    # Minimum xy distance (m) the pour goal must keep from the mug spawn.
+    # Enforced via rejection sampling at reset time.
+    min_object_goal_xy_distance: float = 0.10
+
+    # Goal indicator: sphere at the goal that animates red -> green as the
+    # object tilts toward the threshold (green = tilt criterion met). Visual
+    # only; disable for headless / faster rendering.
+
+    forbidden_zones: tuple[ForbiddenZone, ...] = (
+        ForbiddenZone(kind="cylinder", center=(0.0, 0.0, 0.14), radius=0.065, half_height=0.02),
+    )
+
+    def __post_init__(self):
+        super().__post_init__()
+
+        # The base FunctionalPourEnvCfg syncs the success marker to the
+        # mug's reset pose (so the pour goal floats directly above the
+        # mug). Replace that with uniform xy randomization so the goal
+        # actually moves to a different location each episode -- matches
+        # the grasp_bleach / pour_can pattern. The marker's init z (set
+        # by the base) keeps the goal at ``pour_lift_height`` above the
+        # tabletop.
+        # Rejection-sample the goal xy so it keeps
+        # ``min_object_goal_xy_distance`` from the mug's reset xy.
+        self.events.reset_success_marker = EventTerm(
+            func=mdp.reset_root_pose_uniform_excluding,
+            mode="reset",
+            params={
+                "pose_range": {
+                    "x": list(self.goal_reset_x_range),
+                    "y": list(self.goal_reset_y_range),
+                    "z": [0.0, 0.0],
+                    "roll": [0.0, 0.0],
+                    "pitch": [0.0, 0.0],
+                    "yaw": [0.0, 0.0],
+                },
+                "velocity_range": {"x": [0.0, 0.0], "y": [0.0, 0.0], "z": [0.0, 0.0]},
+                "asset_cfg": SceneEntityCfg("success_marker"),
+                "reference_asset_cfg": SceneEntityCfg("object"),
+                "min_xy_distance": self.min_object_goal_xy_distance,
+            },
+        )
+
+
+@configclass
+class PourMugEnvFloatingDexHandRightCfg(PourMugEnvCfg, FunctionalPourEnvFloatingDexHandRightCfg):
+    """Floating-hand version of the functional pour-mug task."""
+
+    robot_type: str = "floating_shadow_right"
+    xr: XrCfg = DEFAULT_FLOATING_SHADOW_XR_CFG

--- a/source/dexverse/dexverse/baseline_v1/config/functional/remove_cup_from_rack_cfg.py
+++ b/source/dexverse/dexverse/baseline_v1/config/functional/remove_cup_from_rack_cfg.py
@@ -1,0 +1,320 @@
+# Copyright (c) 2025-2026, The DexVerse Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Remove-cup-from-rack task.
+
+A cup starts seated on a wooden cup holder (rack); the hand must lift it off
+the rack and set it down *upright* on a small raised destination table.
+
+Scene layout
+~~~~~~~~~~~~
+  - ``table``: the original 1.5 x 1.5 m main tabletop.
+  - ``cup_destination_table``: a 15 x 15 cm top, raised 15 cm above the
+    main tabletop, allowing the hand to approach the destination sideways.
+  - ``cup_holder``: a kinematic prop (the wooden stand). It is seated on the
+    table and re-randomized each reset (``reset_cup_holder``). Its authored
+    convex colliders are kept so the cup physically rests on it.
+    Yaw is sampled uniformly from -115 to +115 degrees relative to the
+    cup-facing side pointing toward the hand's initial wrist position.
+  - ``object`` (the cup): uniformly scaled to 0.9 (10% smaller than baseline),
+    re-seated *relative to the holder* every reset via
+    ``mdp.sync_object`` (``reset_cup_on_holder``), so wherever the holder lands
+    *and however it is yawed* the cup tracks it in both position and
+    orientation. The relative placement is fully tunable through
+    :attr:`cup_offset_from_holder` (holder-local x, y, z) and
+    :attr:`cup_rot_on_holder` (the cup's world-frame quat when the holder is at
+    its init rotation; upright by default). The sync converts that to a
+    holder-local quat and recomposes it with the holder's randomized rotation.
+  - ``object_pose`` command: a position-only goal near the small table's centre.
+
+Success (``object_upright_at_goal``): the cup is within
+:attr:`success_position_threshold` of the goal AND upright (its local +Z within
+:attr:`success_max_tilt_rad` of world +Z, yaw-agnostic).
+
+Reset ordering note: the cup-on-holder sync and holder randomization are added
+in ``__post_init__`` *after* ``super().__post_init__()``, so they run after the
+base ``reset_object`` (which zeroes the cup's velocity). The event manager fires
+reset terms in insertion order, and we add the holder randomization before the
+cup sync so the cup reads the holder's *post-randomization* pose.
+"""
+
+from __future__ import annotations
+
+import math
+
+import isaaclab.sim as sim_utils
+from dexverse.assets import SYNTHESIS_DIR
+from dexverse.assets.small_table_builder import ensure_small_table_asset
+from dexverse.baseline_v1.config.bimanual.usd_helpers import ensure_single_rigid_body
+from dexverse.robot_agents.shadow.floating import FLOATING_SHADOW_RIGHT_WRIST_POSITION_OFFSET
+from isaaclab.assets import RigidObjectCfg
+from isaaclab.managers import EventTermCfg as EventTerm
+from isaaclab.managers import SceneEntityCfg
+from isaaclab.managers import TerminationTermCfg as DoneTerm
+from isaaclab.markers import VisualizationMarkersCfg
+from isaaclab.utils import configclass
+from scipy.spatial.transform import Rotation as R
+
+from ... import dexverse_base_env_cfg as dexverse_base_env
+from ... import mdp
+from .base_cfg import FunctionalGraspingEnvFloatingDexHandRightCfg
+
+CUP_USD_PATH = str(SYNTHESIS_DIR / "Cup_B0CMD4LX4D_ForestGreen" / "model_Cup_B0CMD4LX4D_ForestGreen_69323.usd")
+CUP_HOLDER_USD_PATH = str(SYNTHESIS_DIR / "cup_holder" / "model_woodenstand3.usd")
+
+# Identity quaternion = the cup spawns upright (matches the cup used by the
+# existing GraspCup task, whose "up" axis is local +Z at identity rotation).
+CUP_UPRIGHT_ROT = (1.0, 0.0, 0.0, 0.0)
+CUP_INIT_ROT = tuple(R.from_euler("x", -105, degrees=True).as_quat(scalar_first=True))
+
+
+def _build_cup_holder_cfg(
+    *,
+    scale: tuple[float, float, float],
+    init_rot: tuple[float, float, float, float],
+    init_pos: tuple[float, float, float],
+) -> RigidObjectCfg:
+    """Static (kinematic) cup-holder prop.
+
+    The holder USD authors its own (nested) ``RigidBodyAPI`` on a child link,
+    which would collide with the top-level rigid body that
+    ``spawn_usd_with_rigid_properties`` applies ("Failed to find a single rigid
+    body ... Found multiple"). ``ensure_single_rigid_body`` strips the authored
+    nested rigid/articulation/joint schemas (keeping the mesh colliders) so the
+    spawn-applied kinematic body is the only one, and the ``reset_cup_holder``
+    event can re-randomize it each reset. The asset's authored convex colliders
+    are kept (``collision_props=None``) so the cup rests on it.
+    """
+    # The source USD authors its own (dynamic) ``RigidBodyAPI`` on a child link;
+    # left in place it coexists with the spawn-applied top-level body, so the
+    # holder is not purely kinematic (and the RigidObject resolver may abort on
+    # multiple bodies). Collapse to a single body here so the only rigid body is
+    # the kinematic one applied below.
+    holder_usd_path = ensure_single_rigid_body(CUP_HOLDER_USD_PATH)
+    return RigidObjectCfg(
+        prim_path="{ENV_REGEX_NS}/CupHolder",
+        spawn=sim_utils.UsdFileCfg(
+            func=dexverse_base_env.spawn_usd_with_rigid_properties,
+            usd_path=holder_usd_path,
+            scale=scale,
+            rigid_props=sim_utils.RigidBodyPropertiesCfg(
+                rigid_body_enabled=True,
+                kinematic_enabled=True,
+                disable_gravity=True,
+                solver_position_iteration_count=16,
+                solver_velocity_iteration_count=0,
+            ),
+            collision_props=None,
+            mass_props=sim_utils.MassPropertiesCfg(mass=1.0),
+        ),
+        init_state=RigidObjectCfg.InitialStateCfg(pos=init_pos, rot=init_rot),
+    )
+
+
+@configclass
+class RemoveCupFromRackEnvFloatingDexHandRightCfg(FunctionalGraspingEnvFloatingDexHandRightCfg):
+    """Lift a cup off a wooden rack and place it upright on a small raised table."""
+
+    # ---- Cup (the manipulated object) ------------------------------------
+    usd_path: str = CUP_USD_PATH
+    object_mass: float = 0.2
+    # Uniform scaling applies to both the visual mesh and its authored convex
+    # colliders. Keep rack dimensions, seating root pose, mass and friction.
+    object_scale: tuple[float, float, float] = (0.9, 0.9, 0.9)
+    object_half_height: float = 0.025
+    object_static_friction: float | None = 2.0
+    object_dynamic_friction: float | None = 2.0
+    object_friction_combine_mode: str = "average"
+    object_init_rot: tuple[float, float, float, float] = CUP_UPRIGHT_ROT
+
+    # The cup does not randomize on its own — it is placed relative to the
+    # holder by ``reset_cup_on_holder``. Zero every per-axis range so the base
+    # ``reset_object`` only re-seats it at its init pose (and zeroes velocity).
+    object_reset_x_range: tuple[float, float] = (0.0, 0.0)
+    object_reset_y_range: tuple[float, float] = (0.0, 0.0)
+    object_reset_yaw_range: tuple[float, float] = (0.0, 0.0)
+
+    # ---- Cup holder (the rack) -------------------------------------------
+    cup_holder_usd_path: str = CUP_HOLDER_USD_PATH
+    cup_holder_scale: tuple[float, float, float] = (1.5, 1.5, 1.5)  # TODO: tune to cup size
+    cup_holder_init_rot: tuple[float, float, float, float] = tuple(
+        R.from_euler("z", -90, degrees=True).as_quat(scalar_first=True)
+    )
+    # Half-height used to seat the holder flush on the tabletop. TODO: tune so
+    # the holder's base rests on the table (depends on the asset's origin).
+    cup_holder_half_height: float = 0.0125
+    # Where the holder is centred on the table (offsets from the table centre).
+    cup_holder_init_x_offset: float = 0.0
+    cup_holder_init_y_offset: float = 0.2
+    # Position offsets from the seated init pose; unchanged by the yaw upgrade.
+    cup_holder_reset_x_range: tuple[float, float] = (0.05, 0.15)
+    cup_holder_reset_y_range: tuple[float, float] = (-0.1, 0.15)
+    # Zero yaw means the cup-facing side points at the initial wrist position
+    # in the env frame (not the robot's dummy articulation root or live hand).
+    # Recompute that heading at each sampled rack position, then add a uniform
+    # signed yaw offset. Positive angles are counterclockwise viewed from +Z.
+    cup_holder_face_point: tuple[float, float] = FLOATING_SHADOW_RIGHT_WRIST_POSITION_OFFSET[:2]
+    cup_holder_reset_yaw_range: tuple[float, float] = (math.radians(-115.0), math.radians(115.0))
+
+    # ---- Cup placement relative to the holder (tunable) ------------------
+    # ``cup_offset_from_holder`` is in the holder's local frame; its z lifts the
+    # cup up into the holder's seat. ``cup_rot_on_holder`` is the cup's absolute
+    # (world-frame) orientation when seated — upright by default. Both are
+    # applied every reset by ``mdp.sync_object``.
+    # TODO: tune both after previewing the spawned holder + cup.
+    cup_offset_from_holder: tuple[float, float, float] = (0.16, -0.01, 0.255)
+    cup_rot_on_holder: tuple[float, float, float, float] = CUP_INIT_ROT
+
+    # ---- Goal: place the cup upright on the small destination table -------
+    destination_table_size: tuple[float, float, float] = (0.15, 0.15, 0.15)
+    # Keep the original goal-region centre, but sample within its central
+    # 2 x 2 cm so the smaller destination can support the upright cup.
+    # The cup USD root is at its base, not halfway up the cup: retain the
+    # existing 2.5 cm root-goal allowance rather than deriving it from height.
+    target_x_range: tuple[float, float] = (0.09, 0.11)
+    target_y_range: tuple[float, float] = (-0.335, -0.315)
+    place_clearance: float = 0.0
+
+    # ---- Success: at goal position AND upright ---------------------------
+    success_position_threshold: float = 0.04
+    success_max_tilt_rad: float = 0.2617993878  # 15 degrees
+
+    def __post_init__(self):
+        super().__post_init__()
+
+        table_top_z = dexverse_base_env.DEFAULT_TABLE_TOP_HEIGHT
+        table_pos = self.scene.table.init_state.pos
+
+        # --- Cup holder: seat on the table, then randomize each reset. -----
+        holder_z = table_top_z + self.cup_holder_half_height
+        holder_pos = (
+            table_pos[0] + self.cup_holder_init_x_offset,
+            table_pos[1] + self.cup_holder_init_y_offset,
+            holder_z,
+        )
+        self.scene.cup_holder = _build_cup_holder_cfg(
+            scale=self.cup_holder_scale,
+            init_rot=self.cup_holder_init_rot,
+            init_pos=holder_pos,
+        )
+        # The horizontal direction from the rack origin toward the seated cup
+        # defines its cup-facing side. Aim it at the fixed hand start, then yaw
+        # by the sampled offset. This reset also skips kinematic velocity writes.
+        self.events.reset_cup_holder = EventTerm(
+            func=mdp.reset_root_pose_uniform_facing,
+            mode="reset",
+            params={
+                "asset_cfg": SceneEntityCfg("cup_holder"),
+                "pose_range": {
+                    "x": list(self.cup_holder_reset_x_range),
+                    "y": list(self.cup_holder_reset_y_range),
+                    "z": [0.0, 0.0],
+                },
+                "face_asset_cfg": None,
+                "face_point": tuple(self.cup_holder_face_point),
+                "open_dir_local": tuple(self.cup_offset_from_holder[:2]),
+                "yaw_jitter": tuple(self.cup_holder_reset_yaw_range),
+            },
+        )
+
+        # --- Cup seated on the holder (cosmetic init + authoritative reset).
+        ox, oy, oz = self.cup_offset_from_holder
+        self.scene.object.init_state.pos = (
+            holder_pos[0] + ox,
+            holder_pos[1] + oy,
+            holder_pos[2] + oz,
+        )
+        self.scene.object.init_state.rot = self.cup_rot_on_holder
+        # The cup is rigidly seated on the holder, so it must follow the
+        # holder's re-randomized yaw — not just in position but in orientation.
+        # ``cup_rot_on_holder`` is the cup's *world* orientation when the holder
+        # sits at its init rotation; express it in the holder's local frame
+        # (``inv(holder_init) * cup_world``) so ``sync_object`` recomposes it
+        # with the holder's post-reset rotation (``R(holder) * quat_local``).
+        holder_init_R = R.from_quat(self.cup_holder_init_rot, scalar_first=True)
+        cup_world_R = R.from_quat(self.cup_rot_on_holder, scalar_first=True)
+        cup_rot_local_on_holder = tuple(
+            float(v) for v in (holder_init_R.inv() * cup_world_R).as_quat(scalar_first=True)
+        )
+        # Re-seat the cup relative to the (post-randomization) holder. Added
+        # after reset_cup_holder so it reads the holder's new pose; the
+        # local-frame offset and ``quat_local`` make both position and
+        # orientation track the holder's randomized yaw.
+        self.events.reset_cup_on_holder = EventTerm(
+            func=mdp.sync_object,
+            mode="reset",
+            params={
+                "target_cfg": SceneEntityCfg("object"),
+                "source_cfg": SceneEntityCfg("cup_holder"),
+                "source_local_offset": (ox, oy, oz),
+                "z_offset": 0.0,
+                "quat_local": cup_rot_local_on_holder,
+            },
+        )
+
+        # --- Goal: place upright on the small raised destination. ----------
+        self._configure_destination_table(table_pos=table_pos, table_top_z=table_top_z)
+
+        # Goal marker: always on and camera-visible (task information for vision policies too).
+        self.commands.object_pose.debug_vis = True
+
+        # ``debug_vis`` also draws the command's *current-pose* visualizer at the
+        # cup every step. Its default (``ALIGN_MARKER_CFG``) renders a
+        # coordinate-frame triad (``frame_prim.usd``), which clutters the scene.
+        # The debug callback always draws marker index 0, so swap that marker for
+        # a fully transparent sphere: no triad is drawn, while the goal sphere
+        # (a separate visualizer) is untouched.
+        self.commands.object_pose.curr_pose_visualizer_cfg = VisualizationMarkersCfg(
+            prim_path="/Visuals/Command/body_pose",
+            markers={
+                "hidden": sim_utils.SphereCfg(
+                    radius=1e-4,
+                    visual_material=sim_utils.PreviewSurfaceCfg(diffuse_color=(0.0, 0.0, 0.0), opacity=0.0),
+                )
+            },
+        )
+
+        # --- Success: at goal position AND upright (yaw-agnostic). --------
+        # Replaces the base lift-to-goal success (position-only / zone-gated).
+        self.terminations.success = DoneTerm(
+            func=mdp.object_upright_at_goal,
+            params={
+                "command_name": "object_pose",
+                "position_threshold": self.success_position_threshold,
+                "max_tilt_rad": self.success_max_tilt_rad,
+                "object_cfg": SceneEntityCfg("object"),
+            },
+        )
+
+    def _configure_destination_table(self, *, table_pos, table_top_z):
+        depth, width, height = self.destination_table_size
+        usd_path, manifest = ensure_small_table_asset(
+            "cup_rack_destination_table_15cm",
+            depth=depth,
+            width=width,
+            height=height,
+            top_thickness=0.012,
+            leg_size=0.022,
+        )
+        # Centre the stand beneath the sampled goal region. Its asset origin
+        # is on the bottom face, so its legs rest on the main tabletop.
+        self.scene.cup_destination_table = RigidObjectCfg(
+            prim_path="{ENV_REGEX_NS}/CupDestinationTable",
+            spawn=sim_utils.UsdFileCfg(
+                func=dexverse_base_env.spawn_usd_with_rigid_properties,
+                usd_path=str(usd_path),
+                rigid_props=sim_utils.RigidBodyPropertiesCfg(
+                    kinematic_enabled=True, disable_gravity=True,
+                ),
+                collision_props=None,  # Preserve the top and four leg box colliders.
+            ),
+            init_state=RigidObjectCfg.InitialStateCfg(pos=(
+                table_pos[0] + sum(self.target_x_range) * 0.5,
+                table_pos[1] + sum(self.target_y_range) * 0.5,
+                table_top_z,
+            )),
+        )
+        place_z = table_top_z + float(manifest["z_top"]) + self.object_half_height + self.place_clearance
+        self.commands.object_pose.ranges.pos_z = (place_z, place_z)

--- a/source/dexverse/dexverse/baseline_v1/config/functional/rewards.py
+++ b/source/dexverse/dexverse/baseline_v1/config/functional/rewards.py
@@ -1,0 +1,241 @@
+# Copyright (c) 2025-2026, The DexVerse Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Reward configurations for the functional task family.
+
+Holds the reward-term presets for functional grasping / pouring / tool-use
+tasks so per-task reward shaping lives next to the task configs rather than in
+the shared ``tasks/mdp/rewards.py`` (which only hosts generic primitives).
+
+The ``Dense*`` presets are the PPO-ready variants: they keep the legacy term
+names (so ``__post_init__`` wiring keeps working) but use mean-reduced reach
+and name-scoped grasp conditions that are correct for five-fingertip hands.
+"""
+
+from __future__ import annotations
+
+import math
+
+from isaaclab.managers import RewardTermCfg as RewTerm
+from isaaclab.managers import SceneEntityCfg
+from isaaclab.utils import configclass
+
+from ... import dexverse_base_env_cfg as dexverse_base_env
+from ... import mdp
+
+POUR_ANGLE_RAD = math.radians(100.0)
+
+# Substrings identifying the thumb fingertip across supported hands
+# (Shadow: ``thtip`` / ``rh_thtip`` / ``lh_thtip``; DexHand: ``thumb_fingertip``).
+_THUMB_NAME_HINTS = ("thtip", "thumb")
+
+
+def split_thumb_fingertip_names(fingertip_body_names: list[str]) -> tuple[list[str], list[str]]:
+    """Split fingertip body names into (thumb names, non-thumb names)."""
+    thumbs = [name for name in fingertip_body_names if any(hint in name.lower() for hint in _THUMB_NAME_HINTS)]
+    others = [name for name in fingertip_body_names if name not in thumbs]
+    return thumbs, others
+
+
+def wire_fingertip_reward_bodies(rewards, fingertip_body_names: list[str]) -> None:
+    """Point the reach/grasp reward terms at the active robot's fingertip bodies.
+
+    Handles both grasp-term shapes: the legacy ``lift_when_grasping_reward``
+    (positional ``asset_cfg``) and ``grasp_lift_action_reward`` (name-scoped
+    ``fingers_cfg`` / ``thumb_cfg``).
+    """
+    fingers_to_object = getattr(rewards, "fingers_to_object", None)
+    if fingers_to_object is not None:
+        fingers_to_object.params["asset_cfg"].body_names = fingertip_body_names
+    term = getattr(rewards, "lift_when_grasping", None)
+    if term is None:
+        return
+    if "asset_cfg" in term.params:
+        term.params["asset_cfg"].body_names = fingertip_body_names
+    else:
+        thumbs, others = split_thumb_fingertip_names(fingertip_body_names)
+        term.params["thumb_cfg"] = SceneEntityCfg("robot", body_names=thumbs) if thumbs else None
+        term.params["fingers_cfg"] = SceneEntityCfg("robot", body_names=others or fingertip_body_names)
+
+
+@configclass
+class FunctionalGraspingRewardsCfg(dexverse_base_env.RewardsCfg):
+    """Pickup-style shaping + goal tracking and success bonus."""
+
+    fingers_to_object = RewTerm(
+        func=mdp.object_ee_distance,
+        params={
+            "std": 0.4,
+            "distance_gain": 10.0,
+            "asset_cfg": SceneEntityCfg("robot", body_names=None),
+        },
+        weight=2.0,
+    )
+
+    lift_when_grasping = RewTerm(
+        func=mdp.lift_when_grasping_reward,
+        weight=0.3,
+        params={
+            "asset_cfg": SceneEntityCfg("robot", body_names=None),
+            "object_cfg": SceneEntityCfg("object"),
+            "threshold": 0.08,
+        },
+    )
+
+    position_tracking = RewTerm(
+        func=mdp.position_command_error,
+        weight=2.0,
+        params={"std": 0.15, "command_name": "object_pose"},
+    )
+
+    success = RewTerm(
+        func=mdp.success_reward,
+        weight=8.0,
+        params={"pos_std": 0.05, "rot_std": None, "command_name": "object_pose"},
+    )
+
+
+@configclass
+class DenseFunctionalGraspingRewardsCfg(FunctionalGraspingRewardsCfg):
+    """PPO-ready dense preset: mean-reduced reach + name-scoped grasp-lift."""
+
+    fingers_to_object = RewTerm(
+        func=mdp.object_ee_distance,
+        params={
+            "std": 0.4,
+            "distance_gain": 10.0,
+            "asset_cfg": SceneEntityCfg("robot", body_names=None),
+            "reduce": "mean",
+        },
+        weight=2.0,
+    )
+
+    lift_when_grasping = RewTerm(
+        func=mdp.grasp_lift_action_reward,
+        weight=0.5,
+        params={
+            "object_cfg": SceneEntityCfg("object"),
+            # fingers_cfg / thumb_cfg body names are wired from the active
+            # robot's fingertips by wire_fingertip_reward_bodies().
+            "fingers_cfg": SceneEntityCfg("robot", body_names=None),
+            "thumb_cfg": None,
+            "threshold": 0.08,
+        },
+    )
+
+
+@configclass
+class DenseHammerStrikeRewardsCfg(DenseFunctionalGraspingRewardsCfg):
+    """PPO-ready dense preset for hammer strike.
+
+    The goal command does not exist on this task, so the goal-tracking terms
+    are disabled at the class level. The strike itself is shaped by driving
+    the hammer head toward the nail head and by graded nail compression.
+    """
+
+    position_tracking = None
+    success = None
+
+    # Hammer-head point -> nail-head point. Local offsets are wired in
+    # ``HammerStrikeEnvFloatingDexHandRightCfg.__post_init__`` (the nail-head
+    # offset depends on the board scale; the hammer-head offset is a
+    # leaf-tunable attribute).
+    head_to_nail = RewTerm(
+        func=mdp.point_to_point_distance_exp,
+        weight=3.0,
+        params={
+            "source_cfg": SceneEntityCfg("object"),
+            "target_cfg": SceneEntityCfg("hammer_target"),
+            "source_local_offset": (0.0, 0.0, 0.0),
+            "target_local_offset": (0.0, 0.0, 0.0),
+            "distance_gain": 8.0,
+        },
+    )
+
+    # Graded nail compression toward the success press distance. Joint names
+    # and the threshold are wired in the leaf ``__post_init__``.
+    nail_press = RewTerm(
+        func=mdp.joint_displacement_reward,
+        weight=8.0,
+        params={
+            "threshold_m": 0.06,
+            "asset_cfg": SceneEntityCfg("hammer_target"),
+        },
+    )
+
+
+@configclass
+class FunctionalPourRewardsCfg(dexverse_base_env.RewardsCfg):
+    """Reach, grasp, and tilt shaping for pouring."""
+
+    fingers_to_object = RewTerm(
+        func=mdp.object_ee_distance,
+        params={
+            "std": 0.4,
+            "distance_gain": 10.0,
+            "asset_cfg": SceneEntityCfg("robot", body_names=None),
+        },
+        weight=2.0,
+    )
+
+    lift_when_grasping = RewTerm(
+        func=mdp.lift_when_grasping_reward,
+        weight=0.3,
+        params={
+            "asset_cfg": SceneEntityCfg("robot", body_names=None),
+            "object_cfg": SceneEntityCfg("object"),
+            "threshold": 0.08,
+        },
+    )
+
+    tilt_reward = RewTerm(
+        func=mdp.tilt_angle_reward,
+        weight=5.0,
+        params={
+            "threshold_rad": POUR_ANGLE_RAD,
+            "axis_local": (0.0, 0.0, 1.0),
+            "world_axis": (0.0, 0.0, 1.0),
+            "tilt_ge": True,
+            "object_cfg": SceneEntityCfg("object"),
+        },
+    )
+
+
+@configclass
+class DenseFunctionalPourRewardsCfg(FunctionalPourRewardsCfg):
+    """PPO-ready dense preset: pour shaping plus graded lift progress.
+
+    ``lift_progress`` grades 0 -> 1 up to the pour lift height (``min_height``
+    is wired from ``pour_lift_height`` in ``FunctionalPourEnvCfg.__post_init__``)
+    so the tilt term is reachable through a learnable lift stage.
+    """
+
+    fingers_to_object = RewTerm(
+        func=mdp.object_ee_distance,
+        params={
+            "std": 0.4,
+            "distance_gain": 10.0,
+            "asset_cfg": SceneEntityCfg("robot", body_names=None),
+            "reduce": "mean",
+        },
+        weight=2.0,
+    )
+
+    lift_when_grasping = RewTerm(
+        func=mdp.grasp_lift_action_reward,
+        weight=0.5,
+        params={
+            "object_cfg": SceneEntityCfg("object"),
+            "fingers_cfg": SceneEntityCfg("robot", body_names=None),
+            "thumb_cfg": None,
+            "threshold": 0.08,
+        },
+    )
+
+    lift_progress = RewTerm(
+        func=mdp.object_lift_height,
+        weight=2.0,
+        params={"asset_cfg": SceneEntityCfg("object"), "min_height": 0.2},
+    )

--- a/source/dexverse/dexverse/baseline_v1/config/grasping/__init__.py
+++ b/source/dexverse/dexverse/baseline_v1/config/grasping/__init__.py
@@ -1,0 +1,1 @@
+"""Version-one baseline task implementation package."""

--- a/source/dexverse/dexverse/baseline_v1/config/grasping/forbidden_zones.py
+++ b/source/dexverse/dexverse/baseline_v1/config/grasping/forbidden_zones.py
@@ -1,0 +1,82 @@
+# Copyright (c) 2025-2026, The DexVerse Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Shared contact-region declarations used across grasping task families.
+
+Zones are no-touch regions defined in an object's local frame. Each task
+family translates them into the flat parameter lists consumed by the
+``mdp.success_no_forbidden_contact`` /
+``mdp.lifted_no_forbidden_contact`` terminations and the
+``mdp.forbidden_zones_vis`` observation.
+
+Designated contact zones are the positive counterpart: success can require
+configured robot/tool bodies to occupy these object-local regions.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+IDENTITY_QUAT: tuple[float, float, float, float] = (1.0, 0.0, 0.0, 0.0)
+
+
+@dataclass
+class ForbiddenZone:
+    """A no-touch region attached to the object's local frame.
+
+    - ``kind="sphere"``: ``center`` + ``radius``.
+    - ``kind="box"``: ``center`` + ``half_size`` (axis-aligned in obj frame).
+    - ``kind="cylinder"``: ``center`` + ``radius`` + ``half_height``. Cylinders
+      are aligned with the zone's local z-axis.
+
+    Coordinates are in the object's root frame (i.e. the frame whose pose
+    is ``object.data.root_pos_w`` / ``root_quat_w``). ``rotation_offset`` is
+    a local quaternion ``(w, x, y, z)`` applied to cylinder zones relative to
+    that object frame.
+    """
+
+    kind: Literal["sphere", "box", "cylinder"]
+    center: tuple[float, float, float] = (0.0, 0.0, 0.0)
+    radius: float = 0.0
+    half_size: tuple[float, float, float] = (0.0, 0.0, 0.0)
+    half_height: float = 0.0
+    rotation_offset: tuple[float, float, float, float] = IDENTITY_QUAT
+
+
+@dataclass
+class DesignatedContactZone:
+    """A required-contact region attached to an object's local frame.
+
+    Each zone is satisfied when at least one configured robot/tool body lies
+    inside the region. Multiple zones are conjunctive: every declared zone
+    must be satisfied for success.
+    """
+
+    kind: Literal["sphere", "box", "cylinder"]
+    center: tuple[float, float, float] = (0.0, 0.0, 0.0)
+    radius: float = 0.0
+    half_size: tuple[float, float, float] = (0.0, 0.0, 0.0)
+    half_height: float = 0.0
+    rotation_offset: tuple[float, float, float, float] = IDENTITY_QUAT
+
+
+def split_zones(
+    zones: tuple[ForbiddenZone | DesignatedContactZone, ...] | list[ForbiddenZone | DesignatedContactZone],
+) -> tuple[list[list[float]], list[list[float]], list[list[float]]]:
+    """Split mixed zones into flat sphere/box/cylinder parameter lists for mdp params."""
+    sphere_zones: list[list[float]] = []
+    box_zones: list[list[float]] = []
+    cylinder_zones: list[list[float]] = []
+    for z in zones:
+        if z.kind == "sphere":
+            sphere_zones.append([*z.center, float(z.radius)])
+        elif z.kind == "box":
+            box_zones.append([*z.center, *z.half_size])
+        elif z.kind == "cylinder":
+            cylinder_zones.append([*z.center, float(z.radius), float(z.half_height), *z.rotation_offset])
+        else:
+            raise ValueError(f"Unsupported zone kind: {z.kind!r}")
+    return sphere_zones, box_zones, cylinder_zones

--- a/source/dexverse/dexverse/baseline_v1/config/non_prehensile/__init__.py
+++ b/source/dexverse/dexverse/baseline_v1/config/non_prehensile/__init__.py
@@ -1,0 +1,1 @@
+"""Version-one baseline task implementation package."""

--- a/source/dexverse/dexverse/baseline_v1/config/non_prehensile/push_small_sphere_obstacle_slope_cfg.py
+++ b/source/dexverse/dexverse/baseline_v1/config/non_prehensile/push_small_sphere_obstacle_slope_cfg.py
@@ -1,0 +1,591 @@
+# Copyright (c) 2025-2026, The DexVerse Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Task configuration for pushing a small sphere uphill while avoiding obstacles.
+
+Ten thin vertical rods are sampled uniformly over the full usable slope.
+``mdp.reset_rod_obstacles_sequential`` keeps every new rod at least one sphere
+diameter plus margin away from the surfaces of all earlier rods. No strata,
+corridor, or other deliberately safe path is reserved.
+"""
+
+import math
+
+import isaaclab.sim as sim_utils
+import torch
+from isaaclab.assets import RigidObjectCfg
+from isaaclab.devices.openxr import XrCfg
+from isaaclab.managers import EventTermCfg as EventTerm
+from isaaclab.managers import ObservationGroupCfg as ObsGroup
+from isaaclab.managers import ObservationTermCfg as ObsTerm
+from isaaclab.managers import RewardTermCfg as RewTerm
+from isaaclab.managers import SceneEntityCfg
+from isaaclab.managers import TerminationTermCfg as DoneTerm
+from isaaclab.markers import VisualizationMarkersCfg
+from isaaclab.utils import configclass
+from isaaclab.utils.noise import UniformNoiseCfg as Unoise
+
+from ... import dexverse_base_env_cfg as dexverse_base_env
+from ... import mdp
+from ..floating_teleop import DEFAULT_FLOATING_SHADOW_XR_CFG, setup_floating_teleop
+from ..robot_init import set_robot_wrist_init_world_pos
+
+SMALL_SPHERE_RADIUS = 0.08
+SMALL_SPHERE_MASS_KG = 0.50
+SMALL_SPHERE_STATIC_FRICTION = 0.3
+SMALL_SPHERE_DYNAMIC_FRICTION = 0.2
+TARGET_OPACITY = 0.30
+# Sphere start / goal lateral randomization (m). Reset audit (Aug 2026): both
+# used to be (almost) fixed on the centerline (start y +-0.04, goal fixed);
+# they now slide along y independently. Side guards sit at |y| = 0.47 and
+# the sphere radius is 0.08, so +-0.30 keeps a >= 9 cm margin to the guards.
+RESET_Y_RANGE = 0.30
+GOAL_Y_RANGE = 0.30
+# Success needs the ball past the goal's x/z line AND within this lateral
+# band of the goal's y (None -> y-agnostic, the pre-audit behaviour).
+GOAL_Y_TOLERANCE_M: float | None = 0.15
+SUCCESS_THRESHOLD_M = 0.08
+TARGET_LINE_TOLERANCE_M = 0.0
+BOUND_Z_MIN = -0.2
+BOUND_Z_MAX = 1.6
+# Initial palm world position in m. Drives a joint translation on floating
+# Shadow/Leap and an arm IK target on UR10e (= floating_shadow base + 0.12).
+ROBOT_INIT_PALM_WORLD_X = -0.63
+
+SLOPE_LENGTH = 0.80
+SLOPE_WIDTH = 0.90
+SLOPE_THICKNESS = 0.04
+SLOPE_ANGLE_DEG = 15.0
+SLOPE_ANGLE_RAD = math.radians(SLOPE_ANGLE_DEG)
+SLOPE_CENTER_X = 0.18
+SLOPE_CENTER_Y = 0.0
+SLOPE_HEIGHT_OFFSET = -0.04
+GOAL_OFFSET_FROM_TOP_M = 0.12
+START_OFFSET_FROM_SLOPE_M = 0.10
+SIDE_GUARD_THICKNESS = 0.04
+SIDE_GUARD_HEIGHT = 0.16
+SIDE_GUARD_COLOR = (0.30, 0.30, 0.35)
+
+MAX_NUM_OBSTACLES = 10
+OBSTACLE_RADIUS = 0.020
+# Keep enough height to block the sphere reliably; "smaller" refers to the
+# rod footprint, which is what allows more non-clustered samples.
+OBSTACLE_HEIGHT = 0.10
+GOAL_TANGENT = 0.5 * SLOPE_LENGTH - GOAL_OFFSET_FROM_TOP_M
+OBSTACLE_TANGENT_RANGE = (-0.30, GOAL_TANGENT - OBSTACLE_RADIUS - 0.08)
+# Keep a sphere-sized *free gap* between rod surfaces, plus a small margin.
+# Centre spacing therefore includes the diameter of both rods as well as the
+# sphere. The margin avoids marginal contacts from wedging the sphere.
+OBSTACLE_GAP_MARGIN = 0.015
+OBSTACLE_MIN_CENTER_SPACING = 2.0 * SMALL_SPHERE_RADIUS + 2.0 * OBSTACLE_RADIUS + OBSTACLE_GAP_MARGIN
+OBSTACLE_CLEARANCE_M = 0.02
+OBSTACLE_LATERAL_LIMIT = 0.5 * SLOPE_WIDTH - OBSTACLE_CLEARANCE_M - OBSTACLE_RADIUS
+if OBSTACLE_LATERAL_LIMIT <= 0.0:
+    raise ValueError("Slope is too narrow to keep obstacle clearance from the side guards.")
+OBSTACLE_COLOR = (0.25, 0.25, 0.30)
+
+SLOPE_TANGENT = (math.cos(SLOPE_ANGLE_RAD), 0.0, math.sin(SLOPE_ANGLE_RAD))
+SLOPE_NORMAL = (-math.sin(SLOPE_ANGLE_RAD), 0.0, math.cos(SLOPE_ANGLE_RAD))
+SLOPE_QUAT = (math.cos(SLOPE_ANGLE_RAD / 2.0), 0.0, -math.sin(SLOPE_ANGLE_RAD / 2.0), 0.0)
+
+
+def _surface_centerline_point(
+    slope_center: tuple[float, float, float],
+    tangent_scale: float,
+    normal_scale: float,
+) -> tuple[float, float, float]:
+    """Return a point on the slope centerline using tangent/normal offsets."""
+    return (
+        slope_center[0] + tangent_scale * SLOPE_TANGENT[0] + normal_scale * SLOPE_NORMAL[0],
+        slope_center[1] + tangent_scale * SLOPE_TANGENT[1] + normal_scale * SLOPE_NORMAL[1],
+        slope_center[2] + tangent_scale * SLOPE_TANGENT[2] + normal_scale * SLOPE_NORMAL[2],
+    )
+
+
+def _make_obstacle_cfg(name: str) -> RigidObjectCfg:
+    return RigidObjectCfg(
+        prim_path=f"{{ENV_REGEX_NS}}/{name}",
+        spawn=sim_utils.CylinderCfg(
+            radius=OBSTACLE_RADIUS,
+            height=OBSTACLE_HEIGHT,
+            rigid_props=sim_utils.RigidBodyPropertiesCfg(
+                rigid_body_enabled=True,
+                kinematic_enabled=True,
+                disable_gravity=True,
+            ),
+            collision_props=sim_utils.CollisionPropertiesCfg(collision_enabled=True),
+            visual_material=sim_utils.PreviewSurfaceCfg(diffuse_color=OBSTACLE_COLOR, roughness=0.9),
+            visible=True,
+        ),
+        init_state=RigidObjectCfg.InitialStateCfg(pos=(0.0, 0.0, 0.0), rot=SLOPE_QUAT),
+    )
+
+
+def _make_side_guard_cfg(name: str) -> RigidObjectCfg:
+    return RigidObjectCfg(
+        prim_path=f"{{ENV_REGEX_NS}}/{name}",
+        spawn=sim_utils.CuboidCfg(
+            size=(SLOPE_LENGTH, SIDE_GUARD_THICKNESS, SIDE_GUARD_HEIGHT),
+            rigid_props=sim_utils.RigidBodyPropertiesCfg(
+                rigid_body_enabled=True,
+                kinematic_enabled=True,
+                disable_gravity=True,
+            ),
+            collision_props=sim_utils.CollisionPropertiesCfg(collision_enabled=True),
+            visual_material=sim_utils.PreviewSurfaceCfg(diffuse_color=SIDE_GUARD_COLOR, roughness=0.9),
+            visible=True,
+        ),
+        init_state=RigidObjectCfg.InitialStateCfg(pos=(0.0, 0.0, 0.0), rot=SLOPE_QUAT),
+    )
+
+
+SMALL_OBJECT_CFG = RigidObjectCfg(
+    prim_path="{ENV_REGEX_NS}/Object",
+    spawn=sim_utils.SphereCfg(
+        radius=SMALL_SPHERE_RADIUS,
+        rigid_props=sim_utils.RigidBodyPropertiesCfg(
+            rigid_body_enabled=True,
+            solver_position_iteration_count=16,
+            solver_velocity_iteration_count=0,
+            disable_gravity=False,
+        ),
+        collision_props=sim_utils.CollisionPropertiesCfg(),
+        # Low-friction surface so the sphere slides readily across the hand.
+        # ``min`` ensures a grippy fingertip material cannot dominate the pair.
+        physics_material=sim_utils.RigidBodyMaterialCfg(
+            static_friction=SMALL_SPHERE_STATIC_FRICTION,
+            dynamic_friction=SMALL_SPHERE_DYNAMIC_FRICTION,
+            restitution=0.0,
+            friction_combine_mode="min",
+        ),
+        mass_props=sim_utils.MassPropertiesCfg(mass=SMALL_SPHERE_MASS_KG),
+        visual_material=sim_utils.PreviewSurfaceCfg(diffuse_color=(0.90, 0.55, 0.18)),
+    ),
+    init_state=RigidObjectCfg.InitialStateCfg(pos=(0.0, 0.0, 0.0)),
+)
+
+SLOPE_CFG = RigidObjectCfg(
+    prim_path="{ENV_REGEX_NS}/Slope",
+    spawn=sim_utils.CuboidCfg(
+        size=(SLOPE_LENGTH, SLOPE_WIDTH, SLOPE_THICKNESS),
+        rigid_props=sim_utils.RigidBodyPropertiesCfg(
+            rigid_body_enabled=True,
+            kinematic_enabled=True,
+            disable_gravity=True,
+        ),
+        collision_props=sim_utils.CollisionPropertiesCfg(),
+        visual_material=sim_utils.PreviewSurfaceCfg(diffuse_color=(0.45, 0.35, 0.25), roughness=0.9),
+        visible=True,
+    ),
+    init_state=RigidObjectCfg.InitialStateCfg(pos=(0.0, 0.0, 0.0), rot=SLOPE_QUAT),
+)
+
+SIDE_GUARD_LEFT_CFG = _make_side_guard_cfg("SideGuardLeft")
+SIDE_GUARD_RIGHT_CFG = _make_side_guard_cfg("SideGuardRight")
+OBSTACLE_CFGS = tuple(_make_obstacle_cfg(f"Obstacle{obstacle_idx}") for obstacle_idx in range(MAX_NUM_OBSTACLES))
+
+
+def object_passed_target_xz_line(
+    env,
+    command_name: str,
+    object_cfg: SceneEntityCfg = SceneEntityCfg("object"),
+    tolerance: float = TARGET_LINE_TOLERANCE_M,
+    y_tolerance: float | None = GOAL_Y_TOLERANCE_M,
+) -> torch.Tensor:
+    """Success once the ball has crossed the target's x and z coordinates and,
+    when ``y_tolerance`` is set, is within that lateral distance of the target's y."""
+    obj = env.scene[object_cfg.name]
+    target_pos = env.command_manager.get_command(command_name)[:, :3]
+    obj_pos = obj.data.root_pos_w
+    passed = (obj_pos[:, 0] >= target_pos[:, 0] - tolerance) & (obj_pos[:, 2] >= target_pos[:, 2] - tolerance)
+    if y_tolerance is not None:
+        passed &= (obj_pos[:, 1] - target_pos[:, 1]).abs() <= float(y_tolerance)
+    return passed
+
+
+@configclass
+class PushSmallSphereObstacleSlopeCommandsCfg(dexverse_base_env.CommandsCfg):
+    """Command terms for the obstacle-slope pushing task."""
+
+    object_pose = mdp.ObjectUniformPoseCommandCfg(
+        asset_name="robot",
+        object_name="object",
+        resampling_time_range=(8.0, 8.0),
+        debug_vis=True,  # goal marker: always on, camera-visible
+        use_world_frame=True,
+        ranges=mdp.ObjectUniformPoseCommandCfg.Ranges(
+            pos_x=(0.0, 0.0),
+            pos_y=(0.0, 0.0),
+            pos_z=(0.0, 0.0),
+            roll=(0.0, 0.0),
+            pitch=(0.0, 0.0),
+            yaw=(0.0, 0.0),
+        ),
+        success_vis_asset_name="object",
+        position_only=True,
+    )
+
+
+@configclass
+class PushSmallSphereObstacleSlopeObservationsCfg(dexverse_base_env.ObservationsCfg):
+    """Observation layout for push-sphere-with-obstacles on a slope.
+
+    Sphere position / orientation and the (kinematic) obstacle states in
+    ``proprio``; sphere velocities in ``privileged``. Commanded goal pose
+    lives in ``goal``.
+    """
+
+    @configclass
+    class PrivilegedObsCfg(dexverse_base_env.ObservationsCfg.PrivilegedObsCfg):
+        object_pos_b = ObsTerm(func=mdp.object_pos_b, noise=Unoise(n_min=-0.0, n_max=0.0))
+        object_quat_b = ObsTerm(func=mdp.object_quat_b, noise=Unoise(n_min=-0.0, n_max=0.0))
+        # Obstacle states are kinematic (velocities = 0) so we keep them as
+        # the original body_state_b 13-vec rather than splitting per axis.
+        obstacle_0_state_b = ObsTerm(
+            func=mdp.body_state_b,
+            noise=Unoise(n_min=-0.0, n_max=0.0),
+            params={"body_asset_cfg": SceneEntityCfg("obstacle_0"), "base_asset_cfg": SceneEntityCfg("table")},
+        )
+        obstacle_1_state_b = ObsTerm(
+            func=mdp.body_state_b,
+            noise=Unoise(n_min=-0.0, n_max=0.0),
+            params={"body_asset_cfg": SceneEntityCfg("obstacle_1"), "base_asset_cfg": SceneEntityCfg("table")},
+        )
+        obstacle_2_state_b = ObsTerm(
+            func=mdp.body_state_b,
+            noise=Unoise(n_min=-0.0, n_max=0.0),
+            params={"body_asset_cfg": SceneEntityCfg("obstacle_2"), "base_asset_cfg": SceneEntityCfg("table")},
+        )
+        obstacle_3_state_b = ObsTerm(
+            func=mdp.body_state_b,
+            noise=Unoise(n_min=-0.0, n_max=0.0),
+            params={"body_asset_cfg": SceneEntityCfg("obstacle_3"), "base_asset_cfg": SceneEntityCfg("table")},
+        )
+        obstacle_4_state_b = ObsTerm(
+            func=mdp.body_state_b,
+            noise=Unoise(n_min=-0.0, n_max=0.0),
+            params={"body_asset_cfg": SceneEntityCfg("obstacle_4"), "base_asset_cfg": SceneEntityCfg("table")},
+        )
+        obstacle_5_state_b = ObsTerm(
+            func=mdp.body_state_b,
+            noise=Unoise(n_min=-0.0, n_max=0.0),
+            params={"body_asset_cfg": SceneEntityCfg("obstacle_5"), "base_asset_cfg": SceneEntityCfg("table")},
+        )
+        obstacle_6_state_b = ObsTerm(
+            func=mdp.body_state_b,
+            noise=Unoise(n_min=-0.0, n_max=0.0),
+            params={"body_asset_cfg": SceneEntityCfg("obstacle_6"), "base_asset_cfg": SceneEntityCfg("table")},
+        )
+        obstacle_7_state_b = ObsTerm(
+            func=mdp.body_state_b,
+            noise=Unoise(n_min=-0.0, n_max=0.0),
+            params={"body_asset_cfg": SceneEntityCfg("obstacle_7"), "base_asset_cfg": SceneEntityCfg("table")},
+        )
+        obstacle_8_state_b = ObsTerm(
+            func=mdp.body_state_b,
+            noise=Unoise(n_min=-0.0, n_max=0.0),
+            params={"body_asset_cfg": SceneEntityCfg("obstacle_8"), "base_asset_cfg": SceneEntityCfg("table")},
+        )
+        obstacle_9_state_b = ObsTerm(
+            func=mdp.body_state_b,
+            noise=Unoise(n_min=-0.0, n_max=0.0),
+            params={"body_asset_cfg": SceneEntityCfg("obstacle_9"), "base_asset_cfg": SceneEntityCfg("table")},
+        )
+        object_lin_vel_b = ObsTerm(func=mdp.object_lin_vel_b, noise=Unoise(n_min=-0.0, n_max=0.0))
+        object_ang_vel_b = ObsTerm(func=mdp.object_ang_vel_b, noise=Unoise(n_min=-0.0, n_max=0.0))
+
+    @configclass
+    class GoalObsCfg(ObsGroup):
+        target_object_pose_b = ObsTerm(
+            func=mdp.generated_commands,
+            params={"command_name": "object_pose"},
+        )
+
+        def __post_init__(self):
+            self.enable_corruption = True
+            self.concatenate_terms = True
+            self.history_length = 0
+
+    privileged: PrivilegedObsCfg = PrivilegedObsCfg()
+    goal: GoalObsCfg = GoalObsCfg()
+
+
+@configclass
+class PushSmallSphereObstacleSlopeRewardsCfg(dexverse_base_env.RewardsCfg):
+    """Reward terms for the obstacle-slope pushing task."""
+
+    fingers_to_object = RewTerm(
+        func=mdp.object_ee_distance,
+        params={
+            "std": 0.4,
+            "distance_gain": 5.0,
+            "asset_cfg": SceneEntityCfg("robot", body_names=None),
+            # Mean over fingertips: the summed default saturates to ~0 with
+            # the five-fingertip Shadow hand.
+            "reduce": "mean",
+        },
+        weight=1.5,
+    )
+
+    position_tracking = RewTerm(
+        func=mdp.position_command_error,
+        weight=5.0,
+        params={
+            "std": 0.14,
+            "command_name": "object_pose",
+        },
+    )
+
+    success = RewTerm(
+        func=mdp.success_reward,
+        weight=10.0,
+        params={
+            "pos_std": SUCCESS_THRESHOLD_M,
+            "rot_std": None,
+            "command_name": "object_pose",
+        },
+    )
+
+
+@configclass
+class PushSmallSphereObstacleSlopeTerminationsCfg(dexverse_base_env.TerminationsCfg):
+    """Termination terms for the obstacle-slope pushing task."""
+
+    object_out_of_bound = DoneTerm(
+        func=mdp.out_of_bound,
+        params={
+            "in_bound_range": {"x": (-1.0, 1.0), "y": (-1.0, 1.0), "z": (BOUND_Z_MIN, BOUND_Z_MAX)},
+            "asset_cfg": SceneEntityCfg("object"),
+        },
+    )
+
+    success = DoneTerm(
+        func=object_passed_target_xz_line,
+        params={
+            "command_name": "object_pose",
+            "tolerance": TARGET_LINE_TOLERANCE_M,
+            "y_tolerance": GOAL_Y_TOLERANCE_M,
+        },
+    )
+
+
+@configclass
+class PushSmallSphereObstacleSlopeEventCfg(dexverse_base_env.EventCfg):
+    """Event configuration for the obstacle-slope task."""
+
+    reset_obstacles = EventTerm(
+        func=mdp.reset_rod_obstacles_sequential,
+        mode="reset",
+        params={
+            "obstacle_asset_cfgs": tuple(SceneEntityCfg(f"obstacle_{i}") for i in range(MAX_NUM_OBSTACLES)),
+            "slope_center": (SLOPE_CENTER_X, SLOPE_CENTER_Y, 0.0),
+            "slope_quat": SLOPE_QUAT,
+            "tangent_range": OBSTACLE_TANGENT_RANGE,
+            "lateral_limit": OBSTACLE_LATERAL_LIMIT,
+            "obstacle_radius": OBSTACLE_RADIUS,
+            "normal_offset": 0.5 * SLOPE_THICKNESS + 0.5 * OBSTACLE_HEIGHT,
+            "min_center_spacing": OBSTACLE_MIN_CENTER_SPACING,
+        },
+    )
+
+
+@configclass
+class PushSmallSphereObstacleSlopeSceneCfg(dexverse_base_env.SceneCfg):
+    object: RigidObjectCfg = SMALL_OBJECT_CFG
+    slope: RigidObjectCfg = SLOPE_CFG
+    side_guard_left: RigidObjectCfg = SIDE_GUARD_LEFT_CFG
+    side_guard_right: RigidObjectCfg = SIDE_GUARD_RIGHT_CFG
+    obstacle_0: RigidObjectCfg = OBSTACLE_CFGS[0]
+    obstacle_1: RigidObjectCfg = OBSTACLE_CFGS[1]
+    obstacle_2: RigidObjectCfg = OBSTACLE_CFGS[2]
+    obstacle_3: RigidObjectCfg = OBSTACLE_CFGS[3]
+    obstacle_4: RigidObjectCfg = OBSTACLE_CFGS[4]
+    obstacle_5: RigidObjectCfg = OBSTACLE_CFGS[5]
+    obstacle_6: RigidObjectCfg = OBSTACLE_CFGS[6]
+    obstacle_7: RigidObjectCfg = OBSTACLE_CFGS[7]
+    obstacle_8: RigidObjectCfg = OBSTACLE_CFGS[8]
+    obstacle_9: RigidObjectCfg = OBSTACLE_CFGS[9]
+
+
+@configclass
+class PushSmallSphereObstacleSlopeEnvCfg(dexverse_base_env.DexVerseBaseEnvCfg):
+    """Push a smaller sphere uphill while navigating around randomized obstacles."""
+
+    supports_object_pose_command: bool = True
+
+    commands: PushSmallSphereObstacleSlopeCommandsCfg = PushSmallSphereObstacleSlopeCommandsCfg()
+    observations: PushSmallSphereObstacleSlopeObservationsCfg = PushSmallSphereObstacleSlopeObservationsCfg()
+    rewards: PushSmallSphereObstacleSlopeRewardsCfg = PushSmallSphereObstacleSlopeRewardsCfg()
+    terminations: PushSmallSphereObstacleSlopeTerminationsCfg = PushSmallSphereObstacleSlopeTerminationsCfg()
+    events: PushSmallSphereObstacleSlopeEventCfg = PushSmallSphereObstacleSlopeEventCfg()
+    scene: PushSmallSphereObstacleSlopeSceneCfg = PushSmallSphereObstacleSlopeSceneCfg(
+        num_envs=4096,
+        env_spacing=3,
+        replicate_physics=False,
+        object=SMALL_OBJECT_CFG,
+        slope=SLOPE_CFG,
+        side_guard_left=SIDE_GUARD_LEFT_CFG,
+        side_guard_right=SIDE_GUARD_RIGHT_CFG,
+        obstacle_0=OBSTACLE_CFGS[0],
+        obstacle_1=OBSTACLE_CFGS[1],
+        obstacle_2=OBSTACLE_CFGS[2],
+        obstacle_3=OBSTACLE_CFGS[3],
+        obstacle_4=OBSTACLE_CFGS[4],
+        obstacle_5=OBSTACLE_CFGS[5],
+        obstacle_6=OBSTACLE_CFGS[6],
+        obstacle_7=OBSTACLE_CFGS[7],
+        obstacle_8=OBSTACLE_CFGS[8],
+        obstacle_9=OBSTACLE_CFGS[9],
+    )
+
+    def __post_init__(self):
+        super().__post_init__()
+
+        set_robot_wrist_init_world_pos(self, x=ROBOT_INIT_PALM_WORLD_X)
+
+        self.episode_length_s = 20.0
+        self.commands.object_pose.resampling_time_range = (self.episode_length_s + 1.0, self.episode_length_s + 1.0)
+        self.commands.object_pose.position_only = True
+        self.commands.object_pose.use_world_frame = True
+
+        table_top_z = dexverse_base_env.DEFAULT_TABLE_TOP_HEIGHT
+        slope_center_z = (
+            table_top_z
+            + 0.5 * (SLOPE_THICKNESS * math.cos(SLOPE_ANGLE_RAD) + SLOPE_LENGTH * math.sin(SLOPE_ANGLE_RAD))
+            + SLOPE_HEIGHT_OFFSET
+        )
+        slope_center = (SLOPE_CENTER_X, SLOPE_CENTER_Y, slope_center_z)
+        self.scene.slope.init_state.pos = slope_center
+        self.scene.slope.init_state.rot = SLOPE_QUAT
+        self.events.reset_obstacles.params["slope_center"] = slope_center
+        side_guard_center_y = 0.5 * SLOPE_WIDTH + 0.5 * SIDE_GUARD_THICKNESS
+        side_guard_normal_offset = 0.5 * SLOPE_THICKNESS + 0.5 * SIDE_GUARD_HEIGHT
+        for side_guard, center_y in (
+            (self.scene.side_guard_left, side_guard_center_y),
+            (self.scene.side_guard_right, -side_guard_center_y),
+        ):
+            side_guard.init_state.pos = _surface_centerline_point(
+                slope_center=slope_center,
+                tangent_scale=0.0,
+                normal_scale=side_guard_normal_offset,
+            )
+            side_guard.init_state.pos = (
+                side_guard.init_state.pos[0],
+                slope_center[1] + center_y,
+                side_guard.init_state.pos[2],
+            )
+            side_guard.init_state.rot = SLOPE_QUAT
+
+        lower_surface_point = _surface_centerline_point(
+            slope_center=slope_center,
+            tangent_scale=-0.5 * SLOPE_LENGTH,
+            normal_scale=0.5 * SLOPE_THICKNESS,
+        )
+        sphere_start = (
+            lower_surface_point[0] - START_OFFSET_FROM_SLOPE_M,
+            lower_surface_point[1],
+            table_top_z + SMALL_SPHERE_RADIUS,
+        )
+        self.scene.object.init_state.pos = sphere_start
+        self.scene.object.init_state.rot = (1.0, 0.0, 0.0, 0.0)
+
+        goal_surface_point = _surface_centerline_point(
+            slope_center=slope_center,
+            tangent_scale=0.5 * SLOPE_LENGTH - GOAL_OFFSET_FROM_TOP_M,
+            normal_scale=0.5 * SLOPE_THICKNESS,
+        )
+        goal_center = (
+            goal_surface_point[0] + SMALL_SPHERE_RADIUS * SLOPE_NORMAL[0],
+            goal_surface_point[1] + SMALL_SPHERE_RADIUS * SLOPE_NORMAL[1],
+            goal_surface_point[2] + SMALL_SPHERE_RADIUS * SLOPE_NORMAL[2],
+        )
+        self.commands.object_pose.ranges.pos_x = (goal_center[0], goal_center[0])
+        # goal slides along the slope's lateral axis (sampled once per episode)
+        self.commands.object_pose.ranges.pos_y = (goal_center[1] - GOAL_Y_RANGE, goal_center[1] + GOAL_Y_RANGE)
+        self.commands.object_pose.ranges.pos_z = (goal_center[2], goal_center[2])
+
+        self.commands.object_pose.goal_pose_visualizer_cfg = VisualizationMarkersCfg(
+            prim_path="/Visuals/Command/goal_pose",
+            markers={
+                "target": sim_utils.SphereCfg(
+                    radius=SMALL_SPHERE_RADIUS,
+                    visible=True,
+                    visual_material=sim_utils.PreviewSurfaceCfg(
+                        diffuse_color=(0.20, 0.60, 0.90),
+                        opacity=TARGET_OPACITY,
+                    ),
+                )
+            },
+        )
+        self.commands.object_pose.success_visualizer_cfg = VisualizationMarkersCfg(
+            prim_path="/Visuals/SuccessMarkers",
+            markers={
+                "failure": sim_utils.SphereCfg(
+                    radius=SMALL_SPHERE_RADIUS,
+                    visible=False,
+                    visual_material=sim_utils.PreviewSurfaceCfg(diffuse_color=(0.90, 0.55, 0.18)),
+                ),
+                "success": sim_utils.SphereCfg(
+                    radius=SMALL_SPHERE_RADIUS,
+                    visible=False,
+                    visual_material=sim_utils.PreviewSurfaceCfg(diffuse_color=(0.25, 0.80, 0.25)),
+                ),
+            },
+        )
+
+        if self.events.reset_object is not None:
+            self.events.reset_object.params["pose_range"] = {
+                "x": [0.0, 0.0],
+                "y": [-RESET_Y_RANGE, RESET_Y_RANGE],
+                "z": [0.0, 0.0],
+                "roll": [0.0, 0.0],
+                "pitch": [0.0, 0.0],
+                "yaw": [-math.pi, math.pi],
+            }
+
+        # Nominal poses are used before the first reset; subsequent resets use
+        # the sequential 2-D rod sampler above.
+        obstacle_normal_offset = 0.5 * SLOPE_THICKNESS + 0.5 * OBSTACLE_HEIGHT
+        tangent_span = OBSTACLE_TANGENT_RANGE[1] - OBSTACLE_TANGENT_RANGE[0]
+        for obstacle_idx in range(MAX_NUM_OBSTACLES):
+            tangent = OBSTACLE_TANGENT_RANGE[0] + (obstacle_idx + 0.5) * tangent_span / MAX_NUM_OBSTACLES
+            lateral = -0.25 if obstacle_idx % 2 == 0 else 0.25
+            obstacle = getattr(self.scene, f"obstacle_{obstacle_idx}")
+            obstacle.init_state.pos = _surface_centerline_point(
+                slope_center=slope_center,
+                tangent_scale=tangent,
+                normal_scale=obstacle_normal_offset,
+            )
+            obstacle.init_state.pos = (
+                obstacle.init_state.pos[0],
+                slope_center[1] + lateral,
+                obstacle.init_state.pos[2],
+            )
+            obstacle.init_state.rot = SLOPE_QUAT
+
+        if self.terminations.object_out_of_bound is not None:
+            table_size = self.scene.table.spawn.size
+            half_x = table_size[0] * 0.5
+            half_y = table_size[1] * 0.5
+            self.terminations.object_out_of_bound.params["in_bound_range"] = {
+                "x": (-half_x, half_x),
+                "y": (-half_y, half_y),
+                "z": (BOUND_Z_MIN, BOUND_Z_MAX),
+            }
+
+        mdp.setup_fingertip_contact_observation(self)
+        self.rewards.fingers_to_object.params["asset_cfg"].body_names = self.robot_config.fingertip_body_names
+
+
+@configclass
+class PushSmallSphereObstacleSlopeEnvFloatingDexHandRightCfg(PushSmallSphereObstacleSlopeEnvCfg):
+    """Obstacle-slope pushing config for floating dex hands."""
+
+    robot_type: str = "floating_shadow_right"
+    xr: XrCfg = DEFAULT_FLOATING_SHADOW_XR_CFG
+
+    def __post_init__(self):
+        super().__post_init__()
+        setup_floating_teleop(self)

--- a/source/dexverse/dexverse/baseline_v1/config/non_prehensile/pusht_cfg.py
+++ b/source/dexverse/dexverse/baseline_v1/config/non_prehensile/pusht_cfg.py
@@ -1,0 +1,337 @@
+# Copyright (c) 2025-2026, The DexVerse Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Push-T v1 with ten goal-local orange rods, 15 cm gaps and XY/yaw reachability."""
+
+import isaaclab.sim as sim_utils
+from dexverse.assets import DEXVERSE_AUTHORED_ASSETS_DIR
+from isaaclab.assets import RigidObjectCfg
+from isaaclab.devices.openxr import XrCfg
+from isaaclab.managers import EventTermCfg as EventTerm
+from isaaclab.managers import ObservationGroupCfg as ObsGroup
+from isaaclab.managers import ObservationTermCfg as ObsTerm
+from isaaclab.managers import RewardTermCfg as RewTerm
+from isaaclab.managers import SceneEntityCfg
+from isaaclab.managers import TerminationTermCfg as DoneTerm
+from isaaclab.utils import configclass
+from isaaclab.utils.noise import UniformNoiseCfg as Unoise
+
+from ... import dexverse_base_env_cfg as dexverse_base_env
+from ... import mdp
+from ...mdp.pusht_obstacles import (
+    ROD_COLOR, ROD_HEIGHT, ROD_NAMES, ROD_RADIUS,
+    reset_push_t_with_rods, rod_positions_in_table,
+)
+from ..floating_teleop import DEFAULT_FLOATING_SHADOW_XR_CFG, setup_floating_teleop
+
+PUSH_T_ASSET_DIR = DEXVERSE_AUTHORED_ASSETS_DIR / "push_t"
+TEE_USD_PATH = str((PUSH_T_ASSET_DIR / "tee.usda").resolve())
+GOAL_TEE_USD_PATH = str((PUSH_T_ASSET_DIR / "tee_goal_2d.usda").resolve())
+
+TEE_THICKNESS_M = 0.04
+TEE_HALF_THICKNESS_M = 0.5 * TEE_THICKNESS_M
+TABLE_CLEARANCE_M = 0.001
+GOAL_MARKER_Z_OFFSET_M = 0.003
+
+GOAL_OFFSET_XY = (-0.156, -0.100)
+
+SPAWN_BOX_X_OFFSET = -0.25
+SPAWN_BOX_Y_OFFSET = -0.25
+SPAWN_BOX_X_LENGTH = 0.50
+SPAWN_BOX_Y_LENGTH = 0.50
+
+OVERLAP_SUCCESS_THRESHOLD = 0.70  # Rod navigation is harder; final alignment is more forgiving.
+BOUND_Z_MIN = -0.2
+BOUND_Z_MAX = 1.5
+# Non-prehensile: the tee must stay on the table. The episode fails the moment
+# the tee root rises this far above its resting height — catches both lifting
+# and tipping onto an edge, while leaving room for contact jitter during pushes.
+LIFT_FAIL_HEIGHT_M = 0.03
+
+
+def _make_rod(index):
+    return RigidObjectCfg(
+        prim_path=f"{{ENV_REGEX_NS}}/PushTRod{index}",
+        spawn=sim_utils.CylinderCfg(
+            radius=ROD_RADIUS, height=ROD_HEIGHT,
+            rigid_props=sim_utils.RigidBodyPropertiesCfg(
+                rigid_body_enabled=True, kinematic_enabled=True, disable_gravity=True,
+            ),
+            collision_props=sim_utils.CollisionPropertiesCfg(contact_offset=0.005, rest_offset=0.0),
+            visual_material=sim_utils.PreviewSurfaceCfg(diffuse_color=ROD_COLOR, roughness=0.55),
+            visible=True,
+        ),
+        init_state=RigidObjectCfg.InitialStateCfg(pos=(0.0, 0.0, 0.62)),
+    )
+
+
+TEE_CFG = RigidObjectCfg(
+    prim_path="{ENV_REGEX_NS}/Object",
+    spawn=sim_utils.UsdFileCfg(
+        func=dexverse_base_env.spawn_usd_with_rigid_properties,
+        usd_path=TEE_USD_PATH,
+        activate_contact_sensors=True,
+        rigid_props=sim_utils.RigidBodyPropertiesCfg(
+            rigid_body_enabled=True,
+            disable_gravity=False,
+            max_depenetration_velocity=5.0,
+            linear_damping=0.0,
+            angular_damping=0.0,
+            max_linear_velocity=1000.0,
+            max_angular_velocity=3666.0,
+            enable_gyroscopic_forces=True,
+            solver_position_iteration_count=64,
+            solver_velocity_iteration_count=4,
+            max_contact_impulse=1.0e32,
+        ),
+        mass_props=sim_utils.MassPropertiesCfg(mass=0.8),
+        collision_props=sim_utils.CollisionPropertiesCfg(contact_offset=0.005, rest_offset=0.0),
+    ),
+    init_state=RigidObjectCfg.InitialStateCfg(
+        pos=(0.0, 0.0, 0.62),
+        rot=(1.0, 0.0, 0.0, 0.0),
+    ),
+)
+
+GOAL_TEE_CFG = RigidObjectCfg(
+    prim_path="{ENV_REGEX_NS}/GoalTee",
+    spawn=sim_utils.UsdFileCfg(
+        func=dexverse_base_env.spawn_usd_with_rigid_properties,
+        usd_path=GOAL_TEE_USD_PATH,
+        rigid_props=sim_utils.RigidBodyPropertiesCfg(
+            rigid_body_enabled=True,
+            kinematic_enabled=True,
+            disable_gravity=True,
+            max_depenetration_velocity=5.0,
+            linear_damping=0.0,
+            angular_damping=0.0,
+            max_linear_velocity=1000.0,
+            max_angular_velocity=3666.0,
+            enable_gyroscopic_forces=True,
+            solver_position_iteration_count=64,
+            solver_velocity_iteration_count=4,
+            max_contact_impulse=1.0e32,
+        ),
+        mass_props=sim_utils.MassPropertiesCfg(mass=0.01),
+        collision_props=sim_utils.CollisionPropertiesCfg(collision_enabled=False),
+        visible=True,
+    ),
+    init_state=RigidObjectCfg.InitialStateCfg(
+        pos=(0.0, 0.0, 0.62),
+        rot=(1.0, 0.0, 0.0, 0.0),
+    ),
+)
+
+
+@configclass
+class PushTObservationsCfg(dexverse_base_env.ObservationsCfg):
+    """Observation layout for the rigid push-T task.
+
+    The state policy sees tee/goal poses and all ten rod positions. Full
+    tee/goal body states (including velocity) remain in the privileged group.
+    """
+
+    @configclass
+    class StateObsCfg(ObsGroup):
+        tee_pose = ObsTerm(func=mdp.body_pose_b, params={
+            "body_asset_cfg": SceneEntityCfg("object"), "base_asset_cfg": SceneEntityCfg("table"),
+        })
+        goal_pose = ObsTerm(func=mdp.body_pose_b, params={
+            "body_asset_cfg": SceneEntityCfg("goal_tee"), "base_asset_cfg": SceneEntityCfg("table"),
+        })
+        rod_positions = ObsTerm(func=rod_positions_in_table)
+
+    state: StateObsCfg = StateObsCfg()
+
+    @configclass
+    class PrivilegedObsCfg(dexverse_base_env.ObservationsCfg.PrivilegedObsCfg):
+        rod_positions = ObsTerm(func=rod_positions_in_table)
+        tee_state_b = ObsTerm(
+            func=mdp.body_state_b,
+            noise=Unoise(n_min=-0.0, n_max=0.0),
+            params={"body_asset_cfg": SceneEntityCfg("object"), "base_asset_cfg": SceneEntityCfg("table")},
+        )
+        goal_tee_state_b = ObsTerm(
+            func=mdp.body_state_b,
+            noise=Unoise(n_min=-0.0, n_max=0.0),
+            params={"body_asset_cfg": SceneEntityCfg("goal_tee"), "base_asset_cfg": SceneEntityCfg("table")},
+        )
+        tee_state_rel_goal = ObsTerm(
+            func=mdp.body_state_b,
+            noise=Unoise(n_min=-0.0, n_max=0.0),
+            params={"body_asset_cfg": SceneEntityCfg("object"), "base_asset_cfg": SceneEntityCfg("goal_tee")},
+        )
+
+    privileged: PrivilegedObsCfg = PrivilegedObsCfg()
+
+
+@configclass
+class PushTRewardsCfg(dexverse_base_env.RewardsCfg):
+    """Rewards for PushT task."""
+
+    pose_dense = RewTerm(
+        func=mdp.push_t_pose_dense_reward,
+        weight=1.0,
+        params={
+            "object_cfg": SceneEntityCfg("object"),
+            "goal_cfg": SceneEntityCfg("goal_tee"),
+            "rotation_weight": 0.5,
+            "translation_weight": 0.5,
+            "translation_distance_gain": 5.0,
+            "overlap_success_threshold": OVERLAP_SUCCESS_THRESHOLD,
+            "success_bonus": 3.0,
+            "overlap_point_step": 0.005,
+        },
+    )
+
+
+@configclass
+class PushTTerminationsCfg(dexverse_base_env.TerminationsCfg):
+    """Termination terms for PushT task."""
+
+    success = DoneTerm(
+        func=mdp.push_t_success,
+        params={
+            "object_cfg": SceneEntityCfg("object"),
+            "goal_cfg": SceneEntityCfg("goal_tee"),
+            "success_threshold": OVERLAP_SUCCESS_THRESHOLD,
+            "overlap_point_step": 0.005,
+        },
+    )
+
+    object_out_of_bound = DoneTerm(
+        func=mdp.out_of_bound,
+        params={
+            "in_bound_range": {"x": (-1.0, 1.0), "y": (-1.0, 1.0), "z": (BOUND_Z_MIN, BOUND_Z_MAX)},
+            "asset_cfg": SceneEntityCfg("object"),
+        },
+    )
+
+    # Instant failure when the tee leaves the tabletop plane (lifted or tipped
+    # on an edge). x/y are left effectively unbounded — leaving the table is
+    # ``object_out_of_bound``'s job. The z cap is finalized in
+    # ``__post_init__`` from the tee's resting height.
+    object_lifted = DoneTerm(
+        func=mdp.out_of_bound,
+        params={
+            "in_bound_range": {"x": (-1e3, 1e3), "y": (-1e3, 1e3), "z": (BOUND_Z_MIN, BOUND_Z_MAX)},
+            "asset_cfg": SceneEntityCfg("object"),
+        },
+    )
+
+
+@configclass
+class PushTEventCfg(dexverse_base_env.EventCfg):
+    """Event configuration for PushT task."""
+
+    reset_object = EventTerm(
+        func=reset_push_t_with_rods,
+        mode="reset",
+        params={},
+    )
+    reset_goal_tee = None  # Joint reset above owns the goal and obstacle poses.
+
+
+@configclass
+class PushTSceneCfg(dexverse_base_env.SceneCfg):
+    object: RigidObjectCfg = TEE_CFG
+    goal_tee: RigidObjectCfg = GOAL_TEE_CFG
+    push_t_rod_0: RigidObjectCfg = _make_rod(0)
+    push_t_rod_1: RigidObjectCfg = _make_rod(1)
+    push_t_rod_2: RigidObjectCfg = _make_rod(2)
+    push_t_rod_3: RigidObjectCfg = _make_rod(3)
+    push_t_rod_4: RigidObjectCfg = _make_rod(4)
+    push_t_rod_5: RigidObjectCfg = _make_rod(5)
+    push_t_rod_6: RigidObjectCfg = _make_rod(6)
+    push_t_rod_7: RigidObjectCfg = _make_rod(7)
+    push_t_rod_8: RigidObjectCfg = _make_rod(8)
+    push_t_rod_9: RigidObjectCfg = _make_rod(9)
+
+
+@configclass
+class PushTEnvCfg(dexverse_base_env.DexVerseBaseEnvCfg):
+    """PushT task configuration (base, robot-agnostic)."""
+
+    observations: PushTObservationsCfg = PushTObservationsCfg()
+    rewards: PushTRewardsCfg = PushTRewardsCfg()
+    terminations: PushTTerminationsCfg = PushTTerminationsCfg()
+    events: PushTEventCfg = PushTEventCfg()
+    scene: PushTSceneCfg = PushTSceneCfg(
+        num_envs=4096,
+        env_spacing=3,
+        replicate_physics=False,
+        object=TEE_CFG,
+        goal_tee=GOAL_TEE_CFG,
+    )
+
+    def __post_init__(self):
+        super().__post_init__()
+
+        # ``body_state_b`` (non-vis variant) for hand tips — the live
+        # visualizer slows rendering and isn't needed here.
+        if hasattr(self.observations.privileged, "hand_tips_state_b"):
+            self.observations.privileged.hand_tips_state_b.func = mdp.body_state_b
+
+        if hasattr(self.events, "object_physics_material"):
+            self.events.object_physics_material = None
+        if hasattr(self.events, "object_scale_mass"):
+            self.events.object_scale_mass = None
+
+        table_size = self.scene.table.spawn.size
+        table_pos = self.scene.table.init_state.pos
+        table_top_z = table_pos[2] + table_size[2] * 0.5
+        tee_root_z = table_top_z + TEE_HALF_THICKNESS_M + TABLE_CLEARANCE_M
+        goal_root_z = table_top_z + GOAL_MARKER_Z_OFFSET_M
+        if self.scene.table.init_state.rot != (1.0, 0.0, 0.0, 0.0):
+            raise ValueError("Push-T clearance sampler requires an axis-aligned tabletop")
+        self.events.reset_object.params = {
+            "table_size": tuple(table_size[:2]), "table_center": tuple(table_pos[:2]),
+            "spawn_x": (GOAL_OFFSET_XY[0] + SPAWN_BOX_X_OFFSET,
+                        GOAL_OFFSET_XY[0] + SPAWN_BOX_X_OFFSET + SPAWN_BOX_X_LENGTH),
+            "spawn_y": (GOAL_OFFSET_XY[1] + SPAWN_BOX_Y_OFFSET,
+                        GOAL_OFFSET_XY[1] + SPAWN_BOX_Y_OFFSET + SPAWN_BOX_Y_LENGTH),
+        }
+        for index, name in enumerate(ROD_NAMES):
+            getattr(self.scene, name).init_state.pos = (
+                table_pos[0] + (index % 4 - 1.5) * 0.42,
+                table_pos[1] + (index // 4 - 1) * 0.42, table_top_z + ROD_HEIGHT / 2,
+            )
+
+        self.scene.object.init_state.pos = (GOAL_OFFSET_XY[0], GOAL_OFFSET_XY[1], tee_root_z)
+        self.scene.object.init_state.rot = (1.0, 0.0, 0.0, 0.0)
+        self.scene.goal_tee.init_state.pos = (GOAL_OFFSET_XY[0], GOAL_OFFSET_XY[1], goal_root_z)
+        self.scene.goal_tee.init_state.rot = (1.0, 0.0, 0.0, 0.0)
+
+        if self.terminations.object_out_of_bound is not None:
+            half_x = table_size[0] * 0.5
+            half_y = table_size[1] * 0.5
+            self.terminations.object_out_of_bound.params["in_bound_range"] = {
+                "x": (-half_x, half_x),
+                "y": (-half_y, half_y),
+                "z": (BOUND_Z_MIN, BOUND_Z_MAX),
+            }
+
+        if self.terminations.object_lifted is not None:
+            self.terminations.object_lifted.params["in_bound_range"] = {
+                "x": (-1e3, 1e3),
+                "y": (-1e3, 1e3),
+                "z": (BOUND_Z_MIN, tee_root_z + LIFT_FAIL_HEIGHT_M),
+            }
+
+        self.episode_length_s = 25  # Extra time to push around rods and realign.
+
+        mdp.setup_fingertip_contact_observation(self)
+
+
+@configclass
+class PushTEnvFloatingDexHandRightCfg(PushTEnvCfg):
+    """PushT environment configuration for floating dexterous hands."""
+
+    robot_type: str = "floating_shadow_right"
+    xr: XrCfg = DEFAULT_FLOATING_SHADOW_XR_CFG
+
+    def __post_init__(self):
+        super().__post_init__()
+        setup_floating_teleop(self)

--- a/source/dexverse/dexverse/baseline_v1/config/robot_init.py
+++ b/source/dexverse/dexverse/baseline_v1/config/robot_init.py
@@ -1,0 +1,387 @@
+# Copyright (c) 2025-2026, The DexVerse Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Robot-agnostic wrist (palm) init-pose helpers for task configs.
+
+Tasks that want the robot's wrist to spawn at a specific world location pre-
+dexverse-cross-embodiment-refactor expressed that intent by writing directly to
+``init_state.joint_pos["x_translation_joint"]`` etc. — which only works for
+single-arm floating Shadow / Leap robots. On the bimanual variants those keys
+don't exist (they're prefixed ``rh_``/``lh_``).
+
+:func:`set_robot_wrist_init_world_pos` takes the desired palm pose in
+*world* coordinates and dispatches per ``env_cfg.robot_type`` to the correct
+mechanism so the same task cfg works across embodiments.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+from scipy.spatial.transform import Rotation as R
+
+_SINGLE_ARM_FLOATING_TRANSLATION_ROBOTS = (
+    "floating_shadow_right",
+    "floating_shadow_left",
+    "floating_leap_right",
+    "floating_sharpa_right",
+    "floating_sharpa_left",
+    "floating_wuji_right",
+    "floating_wuji_left",
+)
+_FLOATING_BIMANUAL_TRANSLATION_ROBOTS = (
+    "floating_shadow_bimanual",
+    "floating_sharpa_bimanual",
+    "floating_wuji_bimanual",
+)
+
+_SINGLE_FLOATING_JOINTS: dict[str, tuple[tuple[str, str, str], tuple[str, str, str]]] = {
+    "floating_shadow_right": (
+        ("x_translation_joint", "y_translation_joint", "z_translation_joint"),
+        ("x_rotation_joint", "y_rotation_joint", "z_rotation_joint"),
+    ),
+    "floating_shadow_left": (
+        ("x_translation_joint", "y_translation_joint", "z_translation_joint"),
+        ("x_rotation_joint", "y_rotation_joint", "z_rotation_joint"),
+    ),
+    "floating_leap_right": (
+        ("x_translation_joint", "y_translation_joint", "z_translation_joint"),
+        ("x_rotation_joint", "y_rotation_joint", "z_rotation_joint"),
+    ),
+    "floating_sharpa_right": (
+        ("right_x_joint", "right_y_joint", "right_z_joint"),
+        ("right_roll_joint", "right_pitch_joint", "right_yaw_joint"),
+    ),
+    "floating_sharpa_left": (
+        ("left_x_joint", "left_y_joint", "left_z_joint"),
+        ("left_roll_joint", "left_pitch_joint", "left_yaw_joint"),
+    ),
+    "floating_wuji_right": (
+        ("right_x_joint", "right_y_joint", "right_z_joint"),
+        ("right_roll_joint", "right_pitch_joint", "right_yaw_joint"),
+    ),
+    "floating_wuji_left": (
+        ("left_x_joint", "left_y_joint", "left_z_joint"),
+        ("left_roll_joint", "left_pitch_joint", "left_yaw_joint"),
+    ),
+}
+
+_FLOATING_BIMANUAL_JOINTS: dict[str, dict[str, tuple[tuple[str, str, str], tuple[str, str, str]]]] = {
+    "floating_shadow_bimanual": {
+        "right": (
+            ("rh_x_translation_joint", "rh_y_translation_joint", "rh_z_translation_joint"),
+            ("rh_x_rotation_joint", "rh_y_rotation_joint", "rh_z_rotation_joint"),
+        ),
+        "left": (
+            ("lh_x_translation_joint", "lh_y_translation_joint", "lh_z_translation_joint"),
+            ("lh_x_rotation_joint", "lh_y_rotation_joint", "lh_z_rotation_joint"),
+        ),
+    },
+    "floating_sharpa_bimanual": {
+        "right": (
+            ("right_x_joint", "right_y_joint", "right_z_joint"),
+            ("right_roll_joint", "right_pitch_joint", "right_yaw_joint"),
+        ),
+        "left": (
+            ("left_x_joint", "left_y_joint", "left_z_joint"),
+            ("left_roll_joint", "left_pitch_joint", "left_yaw_joint"),
+        ),
+    },
+    "floating_wuji_bimanual": {
+        "right": (
+            ("right_x_joint", "right_y_joint", "right_z_joint"),
+            ("right_roll_joint", "right_pitch_joint", "right_yaw_joint"),
+        ),
+        "left": (
+            ("left_x_joint", "left_y_joint", "left_z_joint"),
+            ("left_roll_joint", "left_pitch_joint", "left_yaw_joint"),
+        ),
+    },
+}
+
+
+def _supported_robot_types_for_wrist_init() -> tuple[str, ...]:
+    return (
+        *_SINGLE_ARM_FLOATING_TRANSLATION_ROBOTS,
+        *_FLOATING_BIMANUAL_TRANSLATION_ROBOTS,
+    )
+
+
+def _single_floating_joint_names(robot_type: str) -> tuple[tuple[str, str, str], tuple[str, str, str]]:
+    try:
+        return _SINGLE_FLOATING_JOINTS[robot_type]
+    except KeyError as exc:
+        raise NotImplementedError(f"No single-floating joint map for robot_type={robot_type!r}.") from exc
+
+
+def _floating_bimanual_joint_names(
+    robot_type: str,
+) -> dict[str, tuple[tuple[str, str, str], tuple[str, str, str]]]:
+    try:
+        return _FLOATING_BIMANUAL_JOINTS[robot_type]
+    except KeyError as exc:
+        raise NotImplementedError(f"No bimanual-floating joint map for robot_type={robot_type!r}.") from exc
+
+
+def _bimanual_hand_mount_offsets(robot_type: str) -> dict[str, tuple]:
+    """Per-hand mount offsets (base frame) for a bimanual floating hand.
+
+    Imported lazily so this module stays free of a hard ``robot_agents``
+    dependency at import time.
+    """
+    if robot_type == "floating_shadow_bimanual":
+        from dexverse.robot_agents.shadow.floating import (
+            FLOATING_SHADOW_BIMANUAL_HAND_MOUNT_OFFSET,
+        )
+
+        return FLOATING_SHADOW_BIMANUAL_HAND_MOUNT_OFFSET
+
+    if robot_type == "floating_sharpa_bimanual":
+        from dexverse.robot_agents.sharpa.floating import (
+            FLOATING_SHARPA_BIMANUAL_HAND_MOUNT_OFFSET,
+        )
+
+        return FLOATING_SHARPA_BIMANUAL_HAND_MOUNT_OFFSET
+
+    if robot_type == "floating_wuji_bimanual":
+        from dexverse.robot_agents.wuji.floating import (
+            FLOATING_WUJI_BIMANUAL_HAND_MOUNT_OFFSET,
+        )
+
+        return FLOATING_WUJI_BIMANUAL_HAND_MOUNT_OFFSET
+
+    raise NotImplementedError(f"No bimanual mount-offset map for robot_type={robot_type!r}.")
+
+
+def _wxyz_to_xyzw(q) -> np.ndarray:
+    return np.array([q[1], q[2], q[3], q[0]], dtype=np.float64)
+
+
+def _xyzw_to_wxyz_tuple(q) -> tuple[float, float, float, float]:
+    return (float(q[3]), float(q[0]), float(q[1]), float(q[2]))
+
+
+def set_robot_wrist_init_world_pos(
+    env_cfg,
+    *,
+    x: float | None = None,
+    y: float | None = None,
+    z: float | None = None,
+    rot: tuple[float, float, float, float] | None = None,
+) -> None:
+    """Set the robot's wrist (palm) initial world pose.
+
+    ``x``/``y``/``z`` are absolute world-frame coords in metres; ``None`` leaves
+    that component at the robot's default. ``rot`` is a world-frame quaternion
+    ``(w, x, y, z)`` for the palm; ``None`` preserves the default orientation.
+    The conversion to joint values is robot-specific:
+
+    * Floating Shadow/Leap/Sharpa single-arm robots: writes the robot-specific
+      three translation joints so that ``base_pos + R(base_rot) @ joint`` equals
+      the requested palm world position, and writes the three rotation joints
+      (XYZ intrinsic euler) for the orientation.
+    * Bimanual floating Shadow/Sharpa/Wuji: writes the robot-specific translation
+      and rotation joints for *both* hands, accounting for each hand's fixed
+      mount offset.
+    """
+    if x is None and y is None and z is None and rot is None:
+        return
+    robot_type = getattr(env_cfg, "robot_type", None)
+    if robot_type in _SINGLE_ARM_FLOATING_TRANSLATION_ROBOTS:
+        _apply_floating_pose(env_cfg, x=x, y=y, z=z, rot=rot)
+    elif robot_type in _FLOATING_BIMANUAL_TRANSLATION_ROBOTS:
+        _apply_floating_bimanual_pose(env_cfg, x=x, y=y, z=z, rot=rot)
+    else:
+        raise NotImplementedError(
+            f"set_robot_wrist_init_world_pos: robot_type={robot_type!r} is not "
+            "supported yet. Supported: "
+            f"{_supported_robot_types_for_wrist_init()}."
+        )
+
+
+def _apply_floating_pose(env_cfg, *, x, y, z, rot) -> None:
+    """Set translation (and optionally rotation) joints on a floating hand."""
+    robot_type = getattr(env_cfg, "robot_type", None)
+    translation_joint_names, rotation_joint_names = _single_floating_joint_names(robot_type)
+    init_state = env_cfg.scene.robot.init_state
+    base_pos = np.asarray(init_state.pos, dtype=np.float64)
+    base_rot_sp = R.from_quat(_wxyz_to_xyzw(init_state.rot))
+    joint_pos = dict(init_state.joint_pos)
+
+    cur_joint_trans = np.array(
+        [float(joint_pos.get(joint_name, 0.0)) for joint_name in translation_joint_names],
+        dtype=np.float64,
+    )
+    cur_palm_w = base_pos + base_rot_sp.apply(cur_joint_trans)
+    new_palm_w = np.array(
+        [
+            float(x) if x is not None else cur_palm_w[0],
+            float(y) if y is not None else cur_palm_w[1],
+            float(z) if z is not None else cur_palm_w[2],
+        ],
+        dtype=np.float64,
+    )
+    new_joint_trans = base_rot_sp.inv().apply(new_palm_w - base_pos)
+    for joint_name, joint_value in zip(translation_joint_names, new_joint_trans):
+        joint_pos[joint_name] = float(joint_value)
+
+    if rot is not None:
+        # palm_rot_w = base_rot @ joint_rot, so joint_rot = base_rot^-1 @ palm_rot_w.
+        # The wrist chain is XYZ intrinsic; mirrors compute_wrist_joint_origin.
+        target_palm_rot_w = R.from_quat(_wxyz_to_xyzw(rot))
+        joint_rot_sp = base_rot_sp.inv() * target_palm_rot_w
+        for joint_name, joint_value in zip(rotation_joint_names, joint_rot_sp.as_euler("XYZ", degrees=False)):
+            joint_pos[joint_name] = float(joint_value)
+
+    env_cfg.scene.robot = env_cfg.scene.robot.replace(
+        init_state=init_state.replace(joint_pos=joint_pos),
+    )
+
+
+def _apply_floating_bimanual_pose(env_cfg, *, x, y, z, rot) -> None:
+    """Set wrist translation and rotation joints on both hands of a floating bimanual robot."""
+    robot_type = getattr(env_cfg, "robot_type", None)
+    init_state = env_cfg.scene.robot.init_state
+    base_pos = np.asarray(init_state.pos, dtype=np.float64)
+    base_rot_sp = R.from_quat(_wxyz_to_xyzw(init_state.rot))
+    joint_pos = dict(init_state.joint_pos)
+    mount_offsets = _bimanual_hand_mount_offsets(robot_type)
+    joint_names_by_hand = _floating_bimanual_joint_names(robot_type)
+
+    for hand_key in ("right", "left"):
+        translation_joint_names, rotation_joint_names = joint_names_by_hand[hand_key]
+        mount = np.asarray(mount_offsets[hand_key], dtype=np.float64)
+        cur_joint_trans = np.array(
+            [float(joint_pos.get(joint_name, 0.0)) for joint_name in translation_joint_names],
+            dtype=np.float64,
+        )
+        cur_palm_w = base_pos + base_rot_sp.apply(mount + cur_joint_trans)
+        new_palm_w = np.array(
+            [
+                float(x) if x is not None else cur_palm_w[0],
+                float(y) if y is not None else cur_palm_w[1],
+                float(z) if z is not None else cur_palm_w[2],
+            ],
+            dtype=np.float64,
+        )
+        new_joint_trans = base_rot_sp.inv().apply(new_palm_w - base_pos) - mount
+        for joint_name, joint_value in zip(translation_joint_names, new_joint_trans):
+            joint_pos[joint_name] = float(joint_value)
+
+        if rot is not None:
+            target_palm_rot_w = R.from_quat(_wxyz_to_xyzw(rot))
+            joint_rot_sp = base_rot_sp.inv() * target_palm_rot_w
+            for joint_name, joint_value in zip(rotation_joint_names, joint_rot_sp.as_euler("XYZ", degrees=False)):
+                joint_pos[joint_name] = float(joint_value)
+
+    env_cfg.scene.robot = env_cfg.scene.robot.replace(
+        init_state=init_state.replace(joint_pos=joint_pos),
+    )
+
+
+def align_retargeter_wrist_origin_to_init(
+    env_cfg,
+    hand_key: str = "right",
+) -> None:
+    """Stamp every retargeter's ``wrist_joint_origin`` to the current init frame.
+
+    Call this after :func:`set_robot_wrist_init_world_pos` (so the joint state
+    already reflects the desired init) AND after ``teleop_devices`` has been
+    built. Floating-hand absolute retargeting needs the world pose the wrist
+    sits at when actions are zero.
+
+    Robot dispatch matches :func:`set_robot_wrist_init_world_pos`. For bimanual
+    robots both ``"right"`` and ``"left"`` origins are stamped (``hand_key`` is
+    ignored).
+    """
+    origin_entry = _compute_retargeter_origin_entry(env_cfg, hand_key)
+    teleop_devices = getattr(env_cfg, "teleop_devices", None)
+    if teleop_devices is None:
+        return
+    devices = getattr(teleop_devices, "devices", None) or {}
+    if not devices:
+        return
+    for device_cfg in devices.values():
+        for rtg in getattr(device_cfg, "retargeters", None) or []:
+            if hasattr(rtg, "wrist_joint_origin"):
+                rtg.wrist_joint_origin = origin_entry
+
+
+def _compute_retargeter_origin_entry(env_cfg, hand_key: str) -> dict[str, dict]:
+    """Return the ``{hand_key: {"pos", "rot"}}`` map for the retargeter origin."""
+    robot_type = getattr(env_cfg, "robot_type", None)
+    if robot_type in _SINGLE_ARM_FLOATING_TRANSLATION_ROBOTS:
+        return {hand_key: _palm_world_pose_floating(env_cfg)}
+    if robot_type in _FLOATING_BIMANUAL_TRANSLATION_ROBOTS:
+        return _palm_world_pose_floating_bimanual(env_cfg)
+    raise NotImplementedError(
+        f"align_retargeter_wrist_origin_to_init: robot_type={robot_type!r} "
+        "is not supported yet. Supported: "
+        f"{_supported_robot_types_for_wrist_init()}."
+    )
+
+
+def _palm_world_pose_floating(env_cfg) -> dict[str, tuple]:
+    robot_type = getattr(env_cfg, "robot_type", None)
+    translation_joint_names, rotation_joint_names = _single_floating_joint_names(robot_type)
+    init_state = env_cfg.scene.robot.init_state
+    base_pos = np.asarray(init_state.pos, dtype=np.float64)
+    base_rot_sp = R.from_quat(_wxyz_to_xyzw(init_state.rot))
+    joint_pos = init_state.joint_pos
+
+    trans = np.array(
+        [float(joint_pos.get(joint_name, 0.0)) for joint_name in translation_joint_names],
+        dtype=np.float64,
+    )
+    palm_pos_w = base_pos + base_rot_sp.apply(trans)
+
+    # The wrist chain is base → x_rot → y_rot → z_rot → palm with XYZ intrinsic
+    # composition; matches dexverse.devices.wrist_origin.compute_wrist_joint_origin.
+    joint_rot_values = [float(joint_pos.get(joint_name, 0.0)) for joint_name in rotation_joint_names]
+    joint_rot_sp = R.from_euler("XYZ", joint_rot_values, degrees=False)
+    palm_rot_w_sp = base_rot_sp * joint_rot_sp
+    palm_quat_w_wxyz = _xyzw_to_wxyz_tuple(palm_rot_w_sp.as_quat())
+
+    return {
+        "pos": (float(palm_pos_w[0]), float(palm_pos_w[1]), float(palm_pos_w[2])),
+        "rot": palm_quat_w_wxyz,
+    }
+
+
+def _palm_world_pose_floating_bimanual(env_cfg) -> dict[str, dict]:
+    """Return per-hand palm world pose for a floating bimanual setup."""
+    robot_type = getattr(env_cfg, "robot_type", None)
+    init_state = env_cfg.scene.robot.init_state
+    base_pos = np.asarray(init_state.pos, dtype=np.float64)
+    base_rot_sp = R.from_quat(_wxyz_to_xyzw(init_state.rot))
+    joint_pos = init_state.joint_pos
+    mount_offsets = _bimanual_hand_mount_offsets(robot_type)
+    joint_names_by_hand = _floating_bimanual_joint_names(robot_type)
+
+    poses: dict[str, dict] = {}
+    for hand_key in ("right", "left"):
+        translation_joint_names, rotation_joint_names = joint_names_by_hand[hand_key]
+        mount = np.asarray(mount_offsets[hand_key], dtype=np.float64)
+        trans = np.array(
+            [float(joint_pos.get(joint_name, 0.0)) for joint_name in translation_joint_names],
+            dtype=np.float64,
+        )
+        palm_pos_w = base_pos + base_rot_sp.apply(mount + trans)
+
+        joint_rot_values = [float(joint_pos.get(joint_name, 0.0)) for joint_name in rotation_joint_names]
+        joint_rot_sp = R.from_euler("XYZ", joint_rot_values, degrees=False)
+        palm_rot_w_sp = base_rot_sp * joint_rot_sp
+        palm_quat_w_wxyz = _xyzw_to_wxyz_tuple(palm_rot_w_sp.as_quat())
+
+        poses[hand_key] = {
+            "pos": (float(palm_pos_w[0]), float(palm_pos_w[1]), float(palm_pos_w[2])),
+            "rot": palm_quat_w_wxyz,
+        }
+    return poses
+
+
+__all__ = [
+    "set_robot_wrist_init_world_pos",
+    "align_retargeter_wrist_origin_to_init",
+]

--- a/source/dexverse/dexverse/baseline_v1/control_profile.py
+++ b/source/dexverse/dexverse/baseline_v1/control_profile.py
@@ -1,0 +1,37 @@
+# Copyright (c) 2025-2026, The DexVerse Project Developers.
+# All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Baseline-v1 control overrides; robot assets and actuator definitions stay shared.
+
+These preserve the v1 collection/control setup, not v0 policy compatibility.
+Always copy nested configuration before overriding it so v0 is unaffected.
+"""
+
+from copy import deepcopy
+import math
+
+SHADOW_ROBOT_TYPES = frozenset({
+    "floating_shadow_right", "floating_shadow_left", "floating_shadow_bimanual",
+})
+SHADOW_WRIST_LIMITS = (-2.0 * math.pi, 2.0 * math.pi)
+VECTOR_LOW_PASS_ALPHA = 0.2
+VECTOR_SCALING_FACTOR = 1.125
+
+
+def action_layout(layout: dict) -> dict:
+    """Copy a shared Shadow layout and retain the v1 wrist command limits."""
+    result = deepcopy(layout)
+    for hand in result["hands"].values():
+        hand["wrist_euler_limits"] = (SHADOW_WRIST_LIMITS,) * 3
+    return result
+
+
+def retargeting_config(config: dict, scheme: str) -> dict:
+    """Copy the shared YAML settings; only vector collection settings differ."""
+    result = deepcopy(config)
+    if scheme == "vector":
+        result["retargeting"].update(
+            low_pass_alpha=VECTOR_LOW_PASS_ALPHA, scaling_factor=VECTOR_SCALING_FACTOR,
+        )
+    return result

--- a/source/dexverse/dexverse/baseline_v1/dexverse_base_env_cfg.py
+++ b/source/dexverse/dexverse/baseline_v1/dexverse_base_env_cfg.py
@@ -1,0 +1,1428 @@
+# Copyright (c) 2025-2026, The DexVerse Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# Copyright (c) 2022-2025, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+import math
+from copy import deepcopy
+from dataclasses import MISSING
+
+import isaaclab.sim as sim_utils
+from dexverse.assets import DEBUG_YCB_OBJ_DIR, POLYHAVEN_HDRI_DIR
+from dexverse.baseline_v1.control_profile import SHADOW_ROBOT_TYPES, SHADOW_WRIST_LIMITS
+from dexverse.baseline_v1.visual_purpose import set_prim_purpose_guide
+from isaaclab.assets import ArticulationCfg, AssetBaseCfg, RigidObjectCfg
+from isaaclab.envs import ManagerBasedRLEnvCfg, ViewerCfg
+from isaaclab.managers import EventTermCfg as EventTerm
+from isaaclab.managers import ObservationGroupCfg as ObsGroup
+from isaaclab.managers import ObservationTermCfg as ObsTerm
+from isaaclab.managers import RewardTermCfg as RewTerm
+from isaaclab.managers import SceneEntityCfg
+from isaaclab.managers import TerminationTermCfg as DoneTerm
+from isaaclab.scene import InteractiveSceneCfg
+from isaaclab.sensors import TiledCameraCfg
+from isaaclab.sim.utils import clone
+from isaaclab.utils import configclass
+from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR, NVIDIA_NUCLEUS_DIR
+from isaaclab.utils.noise import AdditiveUniformNoiseCfg as Unoise
+
+from . import mdp
+from .adr_curriculum import CurriculumCfg
+
+DEFAULT_TABLE_THICKNESS = 0.05
+DEFAULT_TABLE_TOP_HEIGHT = 0.6
+DEFAULT_TABLE_SIZE = (1.5, 1.5, DEFAULT_TABLE_THICKNESS)
+DEFAULT_TABLE_INIT_POS = (0.0, 0.0, DEFAULT_TABLE_TOP_HEIGHT - DEFAULT_TABLE_THICKNESS / 2)
+DEFAULT_TABLE_INIT_ROT = (1.0, 0.0, 0.0, 0.0)
+DEFAULT_TABLE_LEG_THICKNESS = 0.08
+DEFAULT_TABLE_LEG_INSET = 0.12
+DEFAULT_TABLE_LEG_MATERIAL_PATH = f"{NVIDIA_NUCLEUS_DIR}/Materials/Base/Wood/Oak.mdl"
+DEFAULT_CAMERA_POINT_CLOUD_TABLE_XY_INSET = 0.0
+DEFAULT_CAMERA_POINT_CLOUD_TABLE_Z_MIN_OFFSET = 0.01
+DEFAULT_CAMERA_POINT_CLOUD_TABLE_Z_MAX_OFFSET = 0.60
+DEFAULT_WRIST_CAMERA_OFFSET_POS = (0.0, -0.08, -0.08)
+DEFAULT_WRIST_CAMERA_OFFSET_ROT = (0.0, 0.0, 0.04997916927067833, 0.9987502603949663)
+DEFAULT_WRIST_CAMERA_BODY_SIZE = (0.09, 0.025, 0.025)
+DEFAULT_WRIST_CAMERA_BODY_COLOR = (0.25, 0.25, 0.25)
+# Extra offset added to the cube position in palm-local coordinates, on top of
+# the camera-relative placement. Tune this to bias the cube toward the hand
+# without moving the camera. Each component is a meters-offset added to the
+# cube's palm-local pose: (x, y, z).
+DEFAULT_WRIST_CAMERA_BODY_PALM_OFFSET = (0.0, 0.0, 0.0)
+
+
+def _collect_polyhaven_hdri_pool() -> list[str]:
+    """Glob the local Poly Haven HDRI dir for fully-downloaded `.hdr` files."""
+    import glob as _glob
+    import os as _os
+
+    if not _os.path.isdir(POLYHAVEN_HDRI_DIR):
+        return []
+    return sorted(str(p) for p in _glob.glob(_os.path.join(str(POLYHAVEN_HDRI_DIR), "*.hdr")))
+
+
+DEFAULT_BACKGROUND_HDRI_POOL = _collect_polyhaven_hdri_pool()
+
+# Pool of textures sampled per-episode for the tabletop. Replace these entries
+# with any local or Nucleus-accessible texture paths you want to randomize over.
+DEFAULT_TABLE_TEXTURE_POOL = [
+    f"{NVIDIA_NUCLEUS_DIR}/Materials/Base/Wood/Ash/Ash_BaseColor.png",
+    f"{NVIDIA_NUCLEUS_DIR}/Materials/Base/Wood/Bamboo_Planks/Bamboo_Planks_BaseColor.png",
+    f"{NVIDIA_NUCLEUS_DIR}/Materials/Base/Wood/Birch/Birch_BaseColor.png",
+    f"{NVIDIA_NUCLEUS_DIR}/Materials/Base/Wood/Cherry/Cherry_BaseColor.png",
+    f"{NVIDIA_NUCLEUS_DIR}/Materials/Base/Wood/Mahogany_Planks/Mahogany_Planks_BaseColor.png",
+    f"{NVIDIA_NUCLEUS_DIR}/Materials/Base/Wood/Oak/Oak_BaseColor.png",
+    f"{NVIDIA_NUCLEUS_DIR}/Materials/Base/Wood/Plywood/Plywood_BaseColor.png",
+    f"{NVIDIA_NUCLEUS_DIR}/Materials/Base/Wood/Walnut_Planks/Walnut_Planks_BaseColor.png",
+    f"{NVIDIA_NUCLEUS_DIR}/Materials/Base/Stone/Marble/Marble_BaseColor.png",
+    f"{NVIDIA_NUCLEUS_DIR}/Materials/Base/Metals/Steel_Stainless/Steel_Stainless_BaseColor.png",
+]
+
+
+def make_obj_cfg_list(usd_parent_dir, object_ids=None):
+    import glob
+    import os
+
+    from . import object_annotations
+
+    usd_files_all = []
+    for ext in ("usd", "usda", "usdc", "usdz"):
+        usd_files_all.extend(glob.glob(os.path.join(usd_parent_dir, f"**/*.{ext}"), recursive=True))
+    usd_files_all = sorted(set(usd_files_all))
+    usd_files_all = object_annotations.prefer_unpacked_usd(usd_files_all)
+    usd_files = []
+    if object_ids is not None:
+        for ids in object_ids:
+            for file in usd_files_all:
+                if ids in file:
+                    usd_files.append(file)
+    else:
+        usd_files = usd_files_all
+    if not usd_files:
+        raise ValueError(f"No USD assets found under {usd_parent_dir}")
+    return [
+        sim_utils.UsdFileCfg(
+            func=spawn_usd_with_rigid_properties,
+            usd_path=usd_file,
+        )
+        for usd_file in usd_files
+        if "instanceable_meshes" not in usd_file
+    ]
+
+
+def _obj_cfg_list_from_paths(usd_paths):
+    """Build a list of ``UsdFileCfg`` objects in the given order."""
+    return [sim_utils.UsdFileCfg(func=spawn_usd_with_rigid_properties, usd_path=p) for p in usd_paths]
+
+
+def _compute_table_leg_size_and_pos(
+    table_size: tuple[float, float, float],
+    table_pos: tuple[float, float, float],
+    x_sign: float,
+    y_sign: float,
+) -> tuple[tuple[float, float, float], tuple[float, float, float]]:
+    table_bottom_z = table_pos[2] - table_size[2] * 0.5
+    leg_height = max(table_bottom_z, DEFAULT_TABLE_LEG_THICKNESS)
+    leg_x = table_pos[0] + x_sign * max(table_size[0] * 0.5 - DEFAULT_TABLE_LEG_INSET, 0.0)
+    leg_y = table_pos[1] + y_sign * max(table_size[1] * 0.5 - DEFAULT_TABLE_LEG_INSET, 0.0)
+    return (
+        (DEFAULT_TABLE_LEG_THICKNESS, DEFAULT_TABLE_LEG_THICKNESS, leg_height),
+        (leg_x, leg_y, leg_height * 0.5),
+    )
+
+
+def make_table_leg_cfg(name: str, x_sign: float, y_sign: float) -> RigidObjectCfg:
+    leg_size, leg_pos = _compute_table_leg_size_and_pos(DEFAULT_TABLE_SIZE, DEFAULT_TABLE_INIT_POS, x_sign, y_sign)
+    return RigidObjectCfg(
+        prim_path=f"{{ENV_REGEX_NS}}/table_leg_{name}",
+        spawn=sim_utils.CuboidCfg(
+            size=leg_size,
+            rigid_props=sim_utils.RigidBodyPropertiesCfg(kinematic_enabled=True),
+            collision_props=sim_utils.CollisionPropertiesCfg(),
+            visual_material=sim_utils.MdlFileCfg(
+                mdl_path=DEFAULT_TABLE_LEG_MATERIAL_PATH,
+                project_uvw=True,
+                texture_scale=(0.4, 0.4),
+            ),
+            visible=True,
+        ),
+        init_state=RigidObjectCfg.InitialStateCfg(pos=leg_pos, rot=DEFAULT_TABLE_INIT_ROT),
+    )
+
+
+def _quat_multiply(
+    q1: tuple[float, float, float, float],
+    q2: tuple[float, float, float, float],
+) -> tuple[float, float, float, float]:
+    w1, x1, y1, z1 = q1
+    w2, x2, y2, z2 = q2
+    return (
+        w1 * w2 - x1 * x2 - y1 * y2 - z1 * z2,
+        w1 * x2 + x1 * w2 + y1 * z2 - z1 * y2,
+        w1 * y2 - x1 * z2 + y1 * w2 + z1 * x2,
+        w1 * z2 + x1 * y2 - y1 * x2 + z1 * w2,
+    )
+
+
+def _quat_normalize(q: tuple[float, float, float, float]) -> tuple[float, float, float, float]:
+    norm = math.sqrt(sum(v * v for v in q))
+    if norm == 0.0:
+        return (1.0, 0.0, 0.0, 0.0)
+    return tuple(v / norm for v in q)
+
+
+def _quat_conjugate(q: tuple[float, float, float, float]) -> tuple[float, float, float, float]:
+    w, x, y, z = q
+    return (w, -x, -y, -z)
+
+
+def _rotate_vector_by_quat(
+    q: tuple[float, float, float, float],
+    v: tuple[float, float, float],
+) -> tuple[float, float, float]:
+    q = _quat_normalize(q)
+    rotated = _quat_multiply(_quat_multiply(q, (0.0, *v)), _quat_conjugate(q))
+    return rotated[1], rotated[2], rotated[3]
+
+
+def _camera_offset_rot_to_opengl(
+    rot: tuple[float, float, float, float],
+    convention: str,
+) -> tuple[float, float, float, float]:
+    if convention == "opengl":
+        return _quat_normalize(rot)
+    if convention == "ros":
+        # USD cameras use OpenGL convention. Isaac Lab converts ROS camera
+        # offsets by composing a 180-degree rotation around the camera x-axis.
+        return _quat_normalize(_quat_multiply(rot, (0.0, 1.0, 0.0, 0.0)))
+    raise ValueError(f"Unsupported wrist camera offset convention for blocker pose: {convention!r}")
+
+
+def _wrist_camera_body_pose(
+    camera_pos: tuple[float, float, float],
+    camera_rot: tuple[float, float, float, float],
+    camera_convention: str,
+    body_size: tuple[float, float, float],
+) -> tuple[tuple[float, float, float], tuple[float, float, float, float]]:
+    body_rot = _camera_offset_rot_to_opengl(camera_rot, camera_convention)
+    # Move the cuboid behind the camera's optical origin. This keeps the
+    # visual/collider from sitting inside the rendered camera frustum.
+    local_body_offset = (0.0, 0.0, body_size[2] * 0.5)
+    body_offset = _rotate_vector_by_quat(body_rot, local_body_offset)
+    body_pos = tuple(camera_pos[i] + body_offset[i] + DEFAULT_WRIST_CAMERA_BODY_PALM_OFFSET[i] for i in range(3))
+    return body_pos, body_rot
+
+
+def make_wrist_camera_cfg(prim_path: str = "{ENV_REGEX_NS}/Robot/palm/wrist_cam") -> TiledCameraCfg:
+    return TiledCameraCfg(
+        prim_path=prim_path,
+        update_period=0.0,
+        width=256,
+        height=256,
+        data_types=["rgb", "distance_to_image_plane"],
+        spawn=sim_utils.PinholeCameraCfg(
+            focal_length=24.0,
+            focus_distance=400.0,
+            horizontal_aperture=20.955,
+            clipping_range=(0.01, 2.0),
+        ),
+        offset=TiledCameraCfg.OffsetCfg(
+            pos=DEFAULT_WRIST_CAMERA_OFFSET_POS,
+            rot=DEFAULT_WRIST_CAMERA_OFFSET_ROT,
+            convention="ros",
+        ),
+    )
+
+
+@clone
+def spawn_cuboid_as_guide(prim_path, cfg, *args, **kwargs):
+    """Spawn a cuboid and tag it as USD ``purpose=guide``.
+
+    Guide-tagged prims show in the Kit viewport but are excluded from
+    ``TiledCamera`` (RGB/depth) renders, so the teleoperator can see the
+    wrist-camera cuboid while policies / recorded videos do not.
+    """
+    from isaaclab.sim.spawners.shapes.shapes import spawn_cuboid
+
+    prim = spawn_cuboid(prim_path, cfg, *args, **kwargs)
+    set_prim_purpose_guide(prim.GetPath().pathString)
+    return prim
+
+
+def make_wrist_camera_body_cfg(
+    prim_path: str = "{ENV_REGEX_NS}/Robot/palm/wrist_camera_body",
+    collision_enabled: bool = True,
+) -> AssetBaseCfg:
+    body_pos, body_rot = _wrist_camera_body_pose(
+        DEFAULT_WRIST_CAMERA_OFFSET_POS,
+        DEFAULT_WRIST_CAMERA_OFFSET_ROT,
+        "ros",
+        DEFAULT_WRIST_CAMERA_BODY_SIZE,
+    )
+    return AssetBaseCfg(
+        prim_path=prim_path,
+        spawn=sim_utils.CuboidCfg(
+            func=spawn_cuboid_as_guide,
+            size=DEFAULT_WRIST_CAMERA_BODY_SIZE,
+            collision_props=sim_utils.CollisionPropertiesCfg(collision_enabled=collision_enabled),
+            visual_material=sim_utils.PreviewSurfaceCfg(
+                diffuse_color=DEFAULT_WRIST_CAMERA_BODY_COLOR,
+                roughness=0.5,
+            ),
+            visible=True,
+        ),
+        init_state=AssetBaseCfg.InitialStateCfg(pos=body_pos, rot=body_rot),
+    )
+
+
+def _v3_sub(a: tuple[float, float, float], b: tuple[float, float, float]) -> tuple[float, float, float]:
+    return (a[0] - b[0], a[1] - b[1], a[2] - b[2])
+
+
+def _v3_scale(a: tuple[float, float, float], s: float) -> tuple[float, float, float]:
+    return (a[0] * s, a[1] * s, a[2] * s)
+
+
+def _v3_dot(a: tuple[float, float, float], b: tuple[float, float, float]) -> float:
+    return a[0] * b[0] + a[1] * b[1] + a[2] * b[2]
+
+
+def _v3_cross(a: tuple[float, float, float], b: tuple[float, float, float]) -> tuple[float, float, float]:
+    return (
+        a[1] * b[2] - a[2] * b[1],
+        a[2] * b[0] - a[0] * b[2],
+        a[0] * b[1] - a[1] * b[0],
+    )
+
+
+def _v3_norm(a: tuple[float, float, float]) -> float:
+    return math.sqrt(_v3_dot(a, a))
+
+
+def _v3_normalize(a: tuple[float, float, float]) -> tuple[float, float, float]:
+    n = _v3_norm(a)
+    if n < 1e-9:
+        return (1.0, 0.0, 0.0)
+    return (a[0] / n, a[1] / n, a[2] / n)
+
+
+def _quat_from_rot_cols(
+    c0: tuple[float, float, float],
+    c1: tuple[float, float, float],
+    c2: tuple[float, float, float],
+) -> tuple[float, float, float, float]:
+    """Quaternion (w, x, y, z) for rotation matrix with columns c0, c1, c2 (camera axes in world)."""
+    m00, m10, m20 = c0[0], c0[1], c0[2]
+    m01, m11, m21 = c1[0], c1[1], c1[2]
+    m02, m12, m22 = c2[0], c2[1], c2[2]
+    trace = m00 + m11 + m22
+    if trace > 0.0:
+        s = 0.5 / math.sqrt(trace + 1.0)
+        w = 0.25 / s
+        x = (m21 - m12) * s
+        y = (m02 - m20) * s
+        z = (m10 - m01) * s
+    elif m00 > m11 and m00 > m22:
+        s = 2.0 * math.sqrt(1.0 + m00 - m11 - m22)
+        w = (m21 - m12) / s
+        x = 0.25 * s
+        y = (m01 + m10) / s
+        z = (m02 + m20) / s
+    elif m11 > m22:
+        s = 2.0 * math.sqrt(1.0 + m11 - m00 - m22)
+        w = (m02 - m20) / s
+        x = (m01 + m10) / s
+        y = 0.25 * s
+        z = (m12 + m21) / s
+    else:
+        s = 2.0 * math.sqrt(1.0 + m22 - m00 - m11)
+        w = (m10 - m01) / s
+        x = (m02 + m20) / s
+        y = (m12 + m21) / s
+        z = 0.25 * s
+    return _quat_normalize((w, x, y, z))
+
+
+def _world_convention_look_at_quat(
+    eye: tuple[float, float, float],
+    target: tuple[float, float, float],
+    world_up_hint: tuple[float, float, float] = (0.0, 0.0, 1.0),
+) -> tuple[float, float, float, float]:
+    """Quaternion for ``TiledCameraCfg.OffsetCfg(..., convention='world')``.
+
+    Isaac Lab world convention: camera +X is forward, +Z is up. We build columns
+    ``[forward, +Y_cam, +Z_cam]`` in world frame so the camera looks from ``eye`` toward ``target``.
+    """
+    forward = _v3_normalize(_v3_sub(target, eye))
+    up_hint = world_up_hint
+    if abs(_v3_dot(forward, up_hint)) > 0.99:
+        up_hint = (0.0, 1.0, 0.0)
+    up = _v3_sub(up_hint, _v3_scale(forward, _v3_dot(up_hint, forward)))
+    up = _v3_normalize(up)
+    side = _v3_normalize(_v3_cross(up, forward))
+    return _quat_from_rot_cols(forward, side, up)
+
+
+def _make_side_view_camera_cfg(
+    prim_path: str, pos: tuple[float, float, float], rot: tuple[float, float, float, float]
+) -> TiledCameraCfg:
+    """Side-view third-person camera factory. Placeholder pose — tune in a subclass."""
+    return TiledCameraCfg(
+        prim_path=prim_path,
+        offset=TiledCameraCfg.OffsetCfg(pos=pos, rot=rot, convention="world"),
+        data_types=["rgb", "distance_to_image_plane"],
+        spawn=sim_utils.PinholeCameraCfg(
+            focal_length=24.0,
+            focus_distance=400.0,
+            horizontal_aperture=20.955,
+            clipping_range=(0.1, 10.0),
+        ),
+        width=256,
+        height=256,
+    )
+
+
+def make_third_person_camera_left_cfg() -> TiledCameraCfg:
+    eye = (0.0, 1.5, 1.5)
+    look_at = (0.0, 0.0, DEFAULT_TABLE_TOP_HEIGHT)
+    return _make_side_view_camera_cfg(
+        prim_path="{ENV_REGEX_NS}/CameraLeft",
+        pos=eye,
+        rot=_world_convention_look_at_quat(eye, look_at),
+    )
+
+
+def make_third_person_camera_right_cfg() -> TiledCameraCfg:
+    eye = (0.0, -1.5, 1.5)
+    look_at = (0.0, 0.0, DEFAULT_TABLE_TOP_HEIGHT)
+    return _make_side_view_camera_cfg(
+        prim_path="{ENV_REGEX_NS}/CameraRight",
+        pos=eye,
+        rot=_world_convention_look_at_quat(eye, look_at),
+    )
+
+
+def _sync_table_legs_to_table(scene_cfg) -> None:
+    table_size = scene_cfg.table.spawn.size
+    table_pos = scene_cfg.table.init_state.pos
+    table_rot = scene_cfg.table.init_state.rot
+    for leg_name, x_sign, y_sign in (
+        ("front_left", 1.0, 1.0),
+        ("front_right", 1.0, -1.0),
+        ("back_left", -1.0, 1.0),
+        ("back_right", -1.0, -1.0),
+    ):
+        leg_cfg = getattr(scene_cfg, f"table_leg_{leg_name}")
+        leg_size, leg_pos = _compute_table_leg_size_and_pos(table_size, table_pos, x_sign, y_sign)
+        leg_cfg.spawn.size = leg_size
+        leg_cfg.init_state.pos = leg_pos
+        leg_cfg.init_state.rot = table_rot
+
+
+def _sync_wrist_camera_attachment(scene_cfg, camera_attr: str, body_attr: str, palm_body_name: str | None) -> None:
+    if palm_body_name is None:
+        return
+
+    camera_cfg = getattr(scene_cfg, camera_attr, None)
+    body_cfg = getattr(scene_cfg, body_attr, None)
+    if camera_cfg is None:
+        camera_cfg = make_wrist_camera_cfg()
+        setattr(scene_cfg, camera_attr, camera_cfg)
+    if body_cfg is None:
+        body_cfg = make_wrist_camera_body_cfg()
+        setattr(scene_cfg, body_attr, body_cfg)
+
+    camera_cfg.prim_path = f"{{ENV_REGEX_NS}}/Robot/{palm_body_name}/wrist_cam"
+    body_cfg.prim_path = f"{{ENV_REGEX_NS}}/Robot/{palm_body_name}/wrist_camera_body"
+
+    body_pos, body_rot = _wrist_camera_body_pose(
+        camera_cfg.offset.pos,
+        camera_cfg.offset.rot,
+        camera_cfg.offset.convention,
+        body_cfg.spawn.size,
+    )
+    body_cfg.init_state.pos = body_pos
+    body_cfg.init_state.rot = body_rot
+
+
+def _configure_wrist_camera_attachments(scene_cfg, robot_config) -> None:
+    if robot_config.left_palm_body_name is not None and robot_config.right_palm_body_name is not None:
+        # Bimanual robots expose explicit scene entities for each hand. The
+        # legacy single-camera entity is disabled to avoid spawning duplicates.
+        scene_cfg.wrist_camera = None
+        scene_cfg.wrist_camera_body = None
+        _sync_wrist_camera_attachment(
+            scene_cfg, "right_wrist_camera", "right_wrist_camera_body", robot_config.right_palm_body_name
+        )
+        _sync_wrist_camera_attachment(
+            scene_cfg, "left_wrist_camera", "left_wrist_camera_body", robot_config.left_palm_body_name
+        )
+    else:
+        scene_cfg.right_wrist_camera = None
+        scene_cfg.left_wrist_camera = None
+        scene_cfg.right_wrist_camera_body = None
+        scene_cfg.left_wrist_camera_body = None
+        _sync_wrist_camera_attachment(scene_cfg, "wrist_camera", "wrist_camera_body", robot_config.palm_body_name)
+
+
+def make_default_object_cfg(
+    usd_parent_dir=DEBUG_YCB_OBJ_DIR,
+    object_ids: list[str] | None = None,
+    init_pos: tuple[float, float, float] = (0.55, 0.0, 0.14),
+    mass: float = 0.3,
+    *,
+    usd_paths: list[str] | None = None,
+    random_choice: bool = True,
+) -> RigidObjectCfg:
+    """Create a default object config for tabletop tasks.
+
+    When ``usd_paths`` is provided, it is used verbatim (``usd_parent_dir`` and
+    ``object_ids`` are ignored) which lets callers control both the concrete
+    asset set and the per-env order. With ``random_choice=False`` the
+    underlying ``MultiAssetSpawnerCfg`` assigns ``usd_paths[i % N]`` to
+    environment ``i``.
+    """
+    if usd_paths is not None:
+        assets_cfg = _obj_cfg_list_from_paths(usd_paths)
+    else:
+        assets_cfg = make_obj_cfg_list(usd_parent_dir=usd_parent_dir, object_ids=object_ids)
+    return RigidObjectCfg(
+        prim_path="{ENV_REGEX_NS}/Object",
+        spawn=sim_utils.MultiAssetSpawnerCfg(
+            assets_cfg=assets_cfg,
+            random_choice=random_choice,
+            rigid_props=sim_utils.RigidBodyPropertiesCfg(
+                rigid_body_enabled=True,
+                solver_position_iteration_count=16,
+                solver_velocity_iteration_count=0,
+                disable_gravity=False,
+            ),
+            collision_props=sim_utils.CollisionPropertiesCfg(),
+            mass_props=sim_utils.MassPropertiesCfg(mass=mass),
+        ),
+        init_state=RigidObjectCfg.InitialStateCfg(pos=init_pos),
+    )
+
+
+@clone
+def spawn_usd_with_rigid_properties(prim_path, cfg, *args, **kwargs):
+    """Spawn USD prim and apply rigid/collision/mass properties when present in cfg."""
+    from isaaclab.sim import schemas
+    from isaaclab.sim.spawners.from_files import spawn_from_usd
+
+    prim = spawn_from_usd(prim_path, cfg, *args, **kwargs)
+    prim_path_resolved = prim.GetPath().pathString
+    if cfg.rigid_props is not None:
+        schemas.define_rigid_body_properties(prim_path_resolved, cfg.rigid_props)
+    if cfg.collision_props is not None:
+        schemas.define_collision_properties(prim_path_resolved, cfg.collision_props)
+    if cfg.mass_props is not None:
+        schemas.define_mass_properties(prim_path_resolved, cfg.mass_props)
+    return prim
+
+
+@configclass
+class CollisionOffsetUsdFileCfg(sim_utils.UsdFileCfg):
+    """UsdFileCfg with per-collider PhysX collision offsets, authored after spawn
+    by :func:`author_collision_offsets` (pair with a ``func`` that calls it)."""
+
+    contact_offset: float | None = None
+    rest_offset: float | None = None
+
+
+def author_collision_offsets(prim, contact_offset: float | None, rest_offset: float | None) -> None:
+    """Author PhysX ``contact_offset`` / ``rest_offset`` on every prim under ``prim``
+    that already carries ``UsdPhysics.CollisionAPI``.
+
+    Per collision mesh -- NOT via ``collision_props`` at the root -- so the asset's
+    authored collider approximation (e.g. convex decomposition) stays intact. A
+    small positive ``rest_offset`` fattens the effective surface (contacts settle
+    slightly above the visual mesh); a larger ``contact_offset`` makes finger
+    contacts engage earlier, which stabilises grasps on thin parts (folder flaps,
+    tray rims). ``None`` leaves the respective attribute unauthored.
+    """
+    if contact_offset is None and rest_offset is None:
+        return
+    from pxr import PhysxSchema, Usd, UsdPhysics
+
+    for p in Usd.PrimRange(prim):
+        if p.HasAPI(UsdPhysics.CollisionAPI):
+            api = PhysxSchema.PhysxCollisionAPI.Apply(p)
+            if contact_offset is not None:
+                api.CreateContactOffsetAttr().Set(float(contact_offset))
+            if rest_offset is not None:
+                api.CreateRestOffsetAttr().Set(float(rest_offset))
+
+
+def spawn_usd_with_rigid_properties_and_collision_offsets(prim_path, cfg, *args, **kwargs):
+    """:func:`spawn_usd_with_rigid_properties` + :func:`author_collision_offsets`
+    (rigid objects; cfg is a :class:`CollisionOffsetUsdFileCfg`)."""
+    prim = spawn_usd_with_rigid_properties(prim_path, cfg, *args, **kwargs)
+    author_collision_offsets(prim, cfg.contact_offset, cfg.rest_offset)
+    return prim
+
+
+def spawn_usd_with_collision_offsets(prim_path, cfg, *args, **kwargs):
+    """Plain USD spawn + :func:`author_collision_offsets` (articulations, whose
+    rigid/joint/articulation props flow through the UsdFileCfg fields)."""
+    from isaaclab.sim.spawners.from_files import spawn_from_usd
+
+    prim = spawn_from_usd(prim_path, cfg, *args, **kwargs)
+    author_collision_offsets(prim, cfg.contact_offset, cfg.rest_offset)
+    return prim
+
+
+@configclass
+class SceneCfg(InteractiveSceneCfg):
+    robot: ArticulationCfg = MISSING
+    object: RigidObjectCfg | ArticulationCfg | None = None
+
+    table: RigidObjectCfg = RigidObjectCfg(
+        prim_path="{ENV_REGEX_NS}/table",
+        spawn=sim_utils.CuboidCfg(
+            size=DEFAULT_TABLE_SIZE,
+            rigid_props=sim_utils.RigidBodyPropertiesCfg(kinematic_enabled=True),
+            collision_props=sim_utils.CollisionPropertiesCfg(),
+            visual_material=sim_utils.PreviewSurfaceCfg(
+                diffuse_color=(0.5, 0.5, 0.5),  # Dark grey color
+                roughness=0.5,
+            ),
+            visible=True,
+        ),
+        init_state=RigidObjectCfg.InitialStateCfg(pos=DEFAULT_TABLE_INIT_POS, rot=DEFAULT_TABLE_INIT_ROT),
+    )
+    table_leg_front_left: RigidObjectCfg = make_table_leg_cfg("front_left", 1.0, 1.0)
+    table_leg_front_right: RigidObjectCfg = make_table_leg_cfg("front_right", 1.0, -1.0)
+    table_leg_back_left: RigidObjectCfg = make_table_leg_cfg("back_left", -1.0, 1.0)
+    table_leg_back_right: RigidObjectCfg = make_table_leg_cfg("back_right", -1.0, -1.0)
+
+    plane = AssetBaseCfg(
+        prim_path="/World/GroundPlane",
+        init_state=AssetBaseCfg.InitialStateCfg(),
+        spawn=sim_utils.GroundPlaneCfg(size=(5.0, 5.0)),
+        collision_group=-1,
+    )
+
+    sky_light = AssetBaseCfg(
+        prim_path="/World/skyLight",
+        spawn=sim_utils.DomeLightCfg(
+            intensity=750.0,
+            texture_file=f"{ISAAC_NUCLEUS_DIR}/Materials/Textures/Skies/PolyHaven/kloofendal_43d_clear_puresky_4k.hdr",
+        ),
+    )
+
+    third_person_camera: TiledCameraCfg = TiledCameraCfg(
+        prim_path="{ENV_REGEX_NS}/Camera",
+        offset=TiledCameraCfg.OffsetCfg(
+            pos=(-1.5, 0.0, 1.5),
+            rot=(0.985, 0.0, 0.175, 0.0),
+            convention="world",
+        ),
+        data_types=["rgb", "distance_to_image_plane"],
+        spawn=sim_utils.PinholeCameraCfg(
+            focal_length=24.0,
+            focus_distance=400.0,
+            horizontal_aperture=20.955,
+            clipping_range=(0.1, 10.0),
+        ),
+        width=256,
+        height=256,
+    )
+
+    # Two extra side-view cameras for multi-view methods (e.g. pi0.5).
+    # Placeholder poses — tune per method by overriding in a subclass.
+    third_person_camera_left: TiledCameraCfg | None = make_third_person_camera_left_cfg()
+    third_person_camera_right: TiledCameraCfg | None = make_third_person_camera_right_cfg()
+
+    wrist_camera: TiledCameraCfg | None = make_wrist_camera_cfg()
+    right_wrist_camera: TiledCameraCfg | None = None
+    left_wrist_camera: TiledCameraCfg | None = None
+
+    # Toggle collision with this single-hand override:
+    # env.scene.wrist_camera_body.spawn.collision_props.collision_enabled=false
+    # For bimanual robots, use right_wrist_camera_body / left_wrist_camera_body.
+    wrist_camera_body: AssetBaseCfg | None = make_wrist_camera_body_cfg(collision_enabled=True)
+    right_wrist_camera_body: AssetBaseCfg | None = None
+    left_wrist_camera_body: AssetBaseCfg | None = None
+
+
+@configclass
+class RobotConfig:
+    palm_body_name: str = "base"
+    """Name of the palm/base body for end-effector control."""
+    right_palm_body_name: str | None = None
+    """Right palm body name for bimanual wrist-mounted sensors. Defaults to palm_body_name."""
+    left_palm_body_name: str | None = None
+    """Left palm body name for bimanual wrist-mounted sensors. None means single-hand setup."""
+    fingertip_body_names: list[str] = ["thumb_fingertip", "fingertip", "fingertip2", "fingertip3"]
+    """List of fingertip body names for observations and rewards."""
+    hand_tips_body_names: list[str] | None = None
+    """List of body names for hand_tips_state_b observation.
+    If None, defaults to [palm_body_name] + fingertip_body_names."""
+    wrist_joint_name: str | None = "fr3_hand_joint"
+    """Name of the wrist joint for reset_robot_wrist_joint. If None, this reset is disabled."""
+    arm_joint_names_expr: str | list[str] | None = ["fr3_joint.*"]
+    """Joint name pattern(s) for arm joints used in IK reset functions. If None, IK resets are disabled."""
+    setup_contact_sensors: bool = False
+    """Whether to set up contact sensors for fingertips. Should be True in robot-specific configs."""
+    forbidden_zone_body_names: list[str] | None = None
+    """Robot bodies tested against forbidden zones / "do not touch" terminations
+    (regex list, resolved by :class:`SceneEntityCfg`). ``None`` (default) means
+    *every* body of the robot articulation -- palm, finger links, wrist and, for
+    arm-mounted hands, the arm links -- so a violation is caught whichever part of
+    the embodiment touches. Robot agents may narrow this (e.g. to exclude a
+    floating base's dummy links) but should keep it embodiment-complete."""
+
+    def __post_init__(self):
+        """Set default hand_tips_body_names if not provided."""
+        if self.right_palm_body_name is None:
+            self.right_palm_body_name = self.palm_body_name
+        if self.hand_tips_body_names is None:
+            self.hand_tips_body_names = [self.palm_body_name] + self.fingertip_body_names
+
+
+def _get_tabletop_robot_setup_builders():
+    """Build the robot_type -> setup builder registry for tabletop envs.
+
+    This branch supports the released Shadow right, left, and bimanual robots.
+    """
+    from dexverse.robot_agents.shadow.floating import (
+        build_tabletop_floating_shadow_bimanual_setup,
+        build_tabletop_floating_shadow_left_setup,
+        build_tabletop_floating_shadow_right_setup,
+    )
+
+    return {
+        "floating_shadow_right": build_tabletop_floating_shadow_right_setup,
+        "floating_shadow_left": build_tabletop_floating_shadow_left_setup,
+        "floating_shadow_bimanual": build_tabletop_floating_shadow_bimanual_setup,
+    }
+
+
+def _make_side_camera_image_obs_term(camera_name: str, data_type: str, *, normalize: bool = True) -> ObsTerm:
+    return ObsTerm(
+        func=mdp.image,
+        params={
+            "sensor_cfg": SceneEntityCfg(camera_name),
+            "data_type": data_type,
+            "normalize": normalize,
+        },
+    )
+
+
+def make_left_rgb_obs_term() -> ObsTerm:
+    # normalize=False keeps the camera output as raw 0..255 uint8.
+    # IsaacLab's mdp.image default centers rgb around zero (RL convention)
+    # which makes captured demos look black after the obs-encoder clips
+    # the negative half. Policies that want centered input should normalize
+    # at the model boundary instead.
+    return _make_side_camera_image_obs_term("third_person_camera_left", "rgb", normalize=False)
+
+
+def make_right_rgb_obs_term() -> ObsTerm:
+    return _make_side_camera_image_obs_term("third_person_camera_right", "rgb", normalize=False)
+
+
+def make_left_depth_obs_term() -> ObsTerm:
+    return _make_side_camera_image_obs_term("third_person_camera_left", "distance_to_image_plane")
+
+
+def make_right_depth_obs_term() -> ObsTerm:
+    return _make_side_camera_image_obs_term("third_person_camera_right", "distance_to_image_plane")
+
+
+def make_camera_point_cloud_obs_term() -> ObsTerm:
+    return ObsTerm(
+        func=mdp.camera_point_cloud_w,
+        params={
+            "sensor_cfg": SceneEntityCfg("third_person_camera"),
+            "table_cfg": SceneEntityCfg("table"),
+            "num_points": 4096,
+            "table_xy_inset": DEFAULT_CAMERA_POINT_CLOUD_TABLE_XY_INSET,
+            "table_z_min_offset": DEFAULT_CAMERA_POINT_CLOUD_TABLE_Z_MIN_OFFSET,
+            "table_z_max_offset": DEFAULT_CAMERA_POINT_CLOUD_TABLE_Z_MAX_OFFSET,
+            "flatten": True,
+            "visualize": False,
+        },
+    )
+
+
+def make_merged_point_cloud_obs_term() -> ObsTerm:
+    return ObsTerm(
+        func=mdp.merged_camera_point_cloud_w,
+        params={
+            "sensor_cfgs": [
+                SceneEntityCfg("third_person_camera"),
+                SceneEntityCfg("third_person_camera_left"),
+                SceneEntityCfg("third_person_camera_right"),
+            ],
+            "table_cfg": SceneEntityCfg("table"),
+            "num_points": 4096,
+            "table_xy_inset": DEFAULT_CAMERA_POINT_CLOUD_TABLE_XY_INSET,
+            "table_z_min_offset": DEFAULT_CAMERA_POINT_CLOUD_TABLE_Z_MIN_OFFSET,
+            "table_z_max_offset": DEFAULT_CAMERA_POINT_CLOUD_TABLE_Z_MAX_OFFSET,
+            "flatten": True,
+            "visualize": False,
+        },
+    )
+
+
+@configclass
+class CommandsCfg:
+    """Command terms for the MDP.
+
+    Base command configuration. Task-specific configs (e.g., TopDownGraspCommandsCfg)
+    should extend this to add task-specific commands like object_pose.
+    """
+
+
+@configclass
+class ObservationsCfg:
+    """Observation specifications for the MDP.
+
+    Groups are intentionally fine-grained so each consumer (policy, asymmetric
+    critic, perception backbones) can subscribe to exactly what it needs:
+
+    - ``policy``: previous action only.
+    - ``proprio``: robot joint positions (true proprioception).
+    - ``contact``: per-robot contact-sensor readings. The concrete ``contact``
+      term is ``MISSING`` here and must be filled in by each robot's setup
+      (typically gated on ``robot_config.setup_contact_sensors``).
+    - ``state``: observable, deployable task state for the IL policy —
+      object / articulation poses, joint positions, derived geometry (e.g.
+      tilt axis). Contains NO velocities. ``None`` on the root; sub-bases
+      that have task state populate it.
+    - ``privileged``: velocities (joint / object lin+ang vel) and other
+      sim-only quantities — recorded for completeness but NOT fed to the IL
+      policy (excluded from ``state_keys``). Cheap to read in sim,
+      unrealistic on hardware.
+    - ``goal``: command / target observations (non-privileged: real systems
+      know what they were asked to do). ``None`` here on the root — sub-bases
+      that wire an ``object_pose`` (or similar) command populate this.
+    - ``rgb`` / ``depth`` / ``pointcloud``: three separate sensor groups so
+      each can be toggled independently.
+    - ``debug_vis``: zero-sized visualization-only observations (frame
+      markers, goal markers, forbidden zone markers, …). ``None`` by default;
+      populated by sub-bases that have visualizers, and gated behind
+      ``DexVerseBaseEnvCfg.enable_debug_vis`` so trained policies
+      do not see these terms unless explicitly opted-in.
+    """
+
+    @configclass
+    class PolicyCfg(ObsGroup):
+        actions = ObsTerm(func=mdp.last_action)
+
+        def __post_init__(self):
+            self.enable_corruption = True
+            self.concatenate_terms = True
+            self.history_length = 0
+
+    @configclass
+    class ProprioObsCfg(ObsGroup):
+        joint_pos = ObsTerm(func=mdp.joint_pos, noise=Unoise(n_min=-0.0, n_max=0.0))
+
+        def __post_init__(self):
+            self.enable_corruption = True
+            self.concatenate_terms = True
+            self.history_length = 0
+
+    @configclass
+    class ContactObsCfg(ObsGroup):
+        # Filled in by each robot agent's setup, typically via
+        # ``mdp.fingers_contact_force_b`` over per-fingertip ContactSensorCfgs.
+        contact: ObsTerm = MISSING
+
+        def __post_init__(self):
+            self.enable_corruption = True
+            self.concatenate_terms = True
+            self.history_length = 0
+
+    @configclass
+    class PrivilegedObsCfg(ObsGroup):
+        joint_vel = ObsTerm(func=mdp.joint_vel, noise=Unoise(n_min=-0.0, n_max=0.0))
+        hand_tips_state_b = ObsTerm(
+            func=mdp.body_state_b_vis,
+            noise=Unoise(n_min=-0.0, n_max=0.0),
+            # Yunchao: below heuristics are from dexsuite's environments.
+            # good behaving number for position in m, velocity in m/s, rad/s,
+            # and quaternion are unlikely to exceed -2 to 2 range
+            clip=(-2.0, 2.0),
+            params={
+                "body_asset_cfg": SceneEntityCfg(
+                    "robot", body_names=["base", "thumb_fingertip", "fingertip", "fingertip2", "fingertip3"]
+                ),
+                "base_asset_cfg": SceneEntityCfg("robot"),
+            },
+        )
+
+        def __post_init__(self):
+            self.enable_corruption = True
+            self.concatenate_terms = True
+            self.history_length = 0
+
+    @configclass
+    class RgbObsCfg(ObsGroup):
+        # normalize=False keeps raw 0..255 uint8. See make_left_rgb_obs_term
+        # for the rationale; policies wanting centered input should normalize
+        # at the model boundary.
+        rgb_image = ObsTerm(
+            func=mdp.image,
+            params={
+                "sensor_cfg": SceneEntityCfg("third_person_camera"),
+                "data_type": "rgb",
+                "normalize": False,
+            },
+        )
+        left_rgb_image = make_left_rgb_obs_term()
+        right_rgb_image = make_right_rgb_obs_term()
+        # Wrist-camera RGB. ``__post_init__`` on the env nulls whichever of
+        # these don't apply for the active robot setup (single-arm robots
+        # use ``wrist_rgb_image``; bimanual robots use the right/left pair).
+        wrist_rgb_image = ObsTerm(
+            func=mdp.image,
+            params={
+                "sensor_cfg": SceneEntityCfg("wrist_camera"),
+                "data_type": "rgb",
+                "normalize": False,
+            },
+        )
+        right_wrist_rgb_image = ObsTerm(
+            func=mdp.image,
+            params={
+                "sensor_cfg": SceneEntityCfg("right_wrist_camera"),
+                "data_type": "rgb",
+                "normalize": False,
+            },
+        )
+        left_wrist_rgb_image = ObsTerm(
+            func=mdp.image,
+            params={
+                "sensor_cfg": SceneEntityCfg("left_wrist_camera"),
+                "data_type": "rgb",
+                "normalize": False,
+            },
+        )
+
+        def __post_init__(self):
+            self.enable_corruption = True
+            self.concatenate_dim = 0
+            self.concatenate_terms = False
+            self.flatten_history_dim = True
+            self.history_length = 0
+
+    @configclass
+    class DepthObsCfg(ObsGroup):
+        depth_image = ObsTerm(
+            func=mdp.image,
+            params={
+                "sensor_cfg": SceneEntityCfg("third_person_camera"),
+                "data_type": "distance_to_image_plane",
+            },
+        )
+        left_depth_image = make_left_depth_obs_term()
+        right_depth_image = make_right_depth_obs_term()
+        wrist_depth_image = ObsTerm(
+            func=mdp.image,
+            params={
+                "sensor_cfg": SceneEntityCfg("wrist_camera"),
+                "data_type": "distance_to_image_plane",
+            },
+        )
+        right_wrist_depth_image = ObsTerm(
+            func=mdp.image,
+            params={
+                "sensor_cfg": SceneEntityCfg("right_wrist_camera"),
+                "data_type": "distance_to_image_plane",
+            },
+        )
+        left_wrist_depth_image = ObsTerm(
+            func=mdp.image,
+            params={
+                "sensor_cfg": SceneEntityCfg("left_wrist_camera"),
+                "data_type": "distance_to_image_plane",
+            },
+        )
+
+        def __post_init__(self):
+            self.enable_corruption = True
+            self.concatenate_dim = 0
+            self.concatenate_terms = False
+            self.flatten_history_dim = True
+            self.history_length = 0
+
+    @configclass
+    class PointcloudObsCfg(ObsGroup):
+        camera_point_cloud_w = make_camera_point_cloud_obs_term()
+        # 3-view variant; nulled by default in DexVerseBaseEnvCfg.__post_init__
+        # and enabled (with single-source nulled) when ``multiview_cameras=True``.
+        merged_point_cloud_w = make_merged_point_cloud_obs_term()
+
+        def __post_init__(self):
+            self.enable_corruption = True
+            self.concatenate_terms = True
+            self.history_length = 0
+
+    policy: PolicyCfg = PolicyCfg()
+    proprio: ProprioObsCfg = ProprioObsCfg()
+    contact: ContactObsCfg = ContactObsCfg()
+    # ``state``: observable, deployable task state for the imitation-learning
+    # policy (object/articulation poses, joint positions, derived geometry).
+    # Holds NO velocities — those go in ``privileged``. ``None`` on the root;
+    # sub-bases / leaves that have task state populate it (mirrors ``goal``).
+    # Treated like ``privileged`` by the preset machinery: only present in the
+    # ``state`` preset, never in the vision presets.
+    state: ObsGroup | None = None
+    privileged: PrivilegedObsCfg = PrivilegedObsCfg()
+    goal: ObsGroup | None = None
+    rgb: RgbObsCfg = RgbObsCfg()
+    depth: DepthObsCfg = DepthObsCfg()
+    pointcloud: PointcloudObsCfg = PointcloudObsCfg()
+    debug_vis: ObsGroup | None = None
+
+    @configclass
+    class SceneVisObsCfg(ObsGroup):
+        """Visualizer-only side-effect terms (sphere goal markers, zone markers, …).
+
+        Conceptually separate from ``debug_vis``: terms here exist purely to
+        drive USD visualization markers each step (sphere goal, forbidden-zone
+        markers, frame markers, etc.). Trained policies don't subscribe to
+        this group, but the obs manager still ticks the terms so their side
+        effects fire. **Never nulled by observation presets**, so the scene
+        always looks correct in recorded videos regardless of which preset
+        the rest of the obs space uses.
+        """
+
+        def __post_init__(self):
+            self.enable_corruption = True
+            self.concatenate_terms = True
+            self.history_length = 0
+
+    scene_vis: SceneVisObsCfg | None = None
+
+
+@configclass
+class EventCfg:
+    """Configuration for randomization."""
+
+    # Disable startup-time physics randomization globally.
+    robot_physics_material = None
+    joint_stiffness_and_damping = None
+    joint_friction = None
+    # Added dynamically for floating Shadow variants in
+    # ``DexVerseBaseEnvCfg.__post_init__``; other robots retain authored limits.
+    set_shadow_wrist_joint_limits = None
+
+    reset_object = EventTerm(
+        func=mdp.reset_root_state_uniform,
+        mode="reset",
+        params={
+            "pose_range": {
+                "x": [0.0, 0.0],
+                "y": [0.0, 0.0],
+                "z": [-0.03, -0.03],
+                "roll": [0, 0],
+                "pitch": [0, 0],
+                "yaw": [-1.8, -1.3],
+            },
+            "velocity_range": {"x": [-0.0, 0.0], "y": [-0.0, 0.0], "z": [-0.0, 0.0]},
+            "asset_cfg": SceneEntityCfg("object"),
+        },
+    )
+
+    reset_robot_joints = EventTerm(
+        func=mdp.reset_joints_by_offset,
+        mode="reset",
+        params={
+            "position_range": [0.0, 0.0],
+            "velocity_range": [0.0, 0.0],
+        },
+    )
+
+    reset_robot_wrist_joint = EventTerm(
+        func=mdp.reset_joints_by_offset,
+        mode="reset",
+        params={
+            "asset_cfg": SceneEntityCfg("robot", joint_names="fr3_joint7"),
+            "position_range": [0.0, 0.0],
+            "velocity_range": [0.0, 0.0],
+        },
+    )
+
+    # Disabled for stable baselines: per-reset HDRI background + table-texture
+    # randomization. Keeping the scene visually fixed gives reproducible baseline
+    # results. (The texture randomizer additionally crashes on
+    # omni.replicator.core>=1.12.16, where rep.functional.get was removed.)
+    reset_environment_background = None
+    reset_table_texture = None
+
+
+@configclass
+class ActionsCfg:
+    pass
+
+
+@configclass
+class RewardsCfg:
+    action_l2 = RewTerm(func=mdp.action_l2_clamped, weight=-0.005)
+    action_rate_l2 = RewTerm(func=mdp.action_rate_l2_clamped, weight=-0.005)
+
+
+@configclass
+class TerminationsCfg:
+    time_out = DoneTerm(func=mdp.time_out, time_out=True)
+
+
+# ---------------------------------------------------------------------------
+# Observation presets
+# ---------------------------------------------------------------------------
+#
+# Each preset maps to ``(enabled_groups, history_length)``. The preset is
+# applied at the END of ``DexVerseBaseEnvCfg.__post_init__`` (after
+# every sub-base / leaf has finished populating its obs terms) by:
+#   1. Setting every group NOT in ``enabled`` to ``None``.
+#   2. Setting ``policy.history_length`` and ``proprio.history_length`` to
+#      the preset's value (with ``flatten_history_dim=True`` when > 0) so the
+#      policy gets the last ``N`` actions and the last ``N`` non-priv states.
+#
+# Contact + tactile are routed to the ``state`` preset only (large sim-to-real
+# gap on force readings); realistic visual presets compensate for the missing
+# privileged info with action / proprio history stacking.
+# The ``state`` preset feeds the policy the observable ``state`` group
+# (object/articulation poses, joint pos, derived geometry) and intentionally
+# EXCLUDES ``privileged`` — the sim-only velocities are not given to the
+# (deployable) state policy. ``privileged`` is still produced when no preset
+# is applied, for logging / analysis / privileged-teacher use.
+# ``debug_vis`` is NOT managed here — it is gated separately by
+# ``DexVerseBaseEnvCfg.enable_debug_vis``.
+_OBSERVATION_PRESETS: dict[str, dict] = {
+    "rgb": {"enabled": {"policy", "proprio", "goal", "rgb"}, "history_length": 3, "multiview": False},
+    "rgb_depth": {"enabled": {"policy", "proprio", "goal", "rgb", "depth"}, "history_length": 3, "multiview": False},
+    "pointcloud": {"enabled": {"policy", "proprio", "goal", "pointcloud"}, "history_length": 3, "multiview": False},
+    "state": {"enabled": {"policy", "proprio", "contact", "state", "goal"}, "history_length": 0, "multiview": False},
+    "3view_rgb": {"enabled": {"policy", "proprio", "goal", "rgb"}, "history_length": 3, "multiview": True},
+    "3view_rgb_depth": {
+        "enabled": {"policy", "proprio", "goal", "rgb", "depth"},
+        "history_length": 3,
+        "multiview": True,
+    },
+    "3view_pointcloud": {
+        "enabled": {"policy", "proprio", "goal", "pointcloud"},
+        "history_length": 3,
+        "multiview": True,
+    },
+}
+_OBSERVATION_PRESET_ALIASES: dict[str, str] = {"rgbd": "rgb_depth", "3view_rgbd": "3view_rgb_depth"}
+# Groups touched by ``_apply_observation_preset``: every entry not in a
+# preset's ``enabled`` set is set to ``None``. ``scene_vis`` and
+# ``debug_vis`` are intentionally NOT listed here — they live outside the
+# preset taxonomy. ``scene_vis`` always survives because it drives USD
+# marker side-effects that should render regardless of which preset the
+# trained obs vector uses; ``debug_vis`` is gated separately by
+# ``enable_debug_vis``.
+_OBSERVATION_PRESET_MANAGED_GROUPS: tuple[str, ...] = (
+    "policy",
+    "proprio",
+    "contact",
+    "state",
+    "privileged",
+    "goal",
+    "rgb",
+    "depth",
+    "pointcloud",
+)
+
+OBSERVATION_PRESET_NAMES: tuple[str, ...] = tuple(_OBSERVATION_PRESETS.keys())
+"""Public list of canonical preset names (``rgbd`` is also accepted as an alias for ``rgb_depth``)."""
+
+
+def resolve_observation_preset(name: str) -> str:
+    """Return the canonical preset name for ``name``; raise ``ValueError`` if unknown."""
+    canonical = _OBSERVATION_PRESET_ALIASES.get(name, name)
+    if canonical not in _OBSERVATION_PRESETS:
+        valid = sorted(_OBSERVATION_PRESETS.keys())
+        aliases = sorted(_OBSERVATION_PRESET_ALIASES.keys())
+        raise ValueError(f"Unknown observation preset {name!r}. Available: {valid} (+ aliases {aliases})")
+    return canonical
+
+
+@configclass
+class DexVerseBaseEnvCfg(ManagerBasedRLEnvCfg):
+    """Dexsuite reorientation task definition, also the base definition for derivative Lift task and evaluation task"""
+
+    viewer: ViewerCfg = ViewerCfg(eye=(-2.0, 0.0, 1.25), lookat=(0.0, 0.0, 0.45), origin_type="env")
+    scene: SceneCfg = SceneCfg(num_envs=4096, env_spacing=3, replicate_physics=False)
+    observations: ObservationsCfg = ObservationsCfg()
+    actions: ActionsCfg = ActionsCfg()
+    commands: CommandsCfg = CommandsCfg()
+    rewards: RewardsCfg = RewardsCfg()
+    terminations: TerminationsCfg = TerminationsCfg()
+    events: EventCfg = EventCfg()
+    curriculum: CurriculumCfg | None = None
+    robot_config: RobotConfig = RobotConfig()
+    robot_type: str | None = None
+    supports_object_pose_command: bool = False
+    seed: int = 42
+    enable_debug_vis: bool = False
+    """Central switch for **operator cues**: task-specific visualization markers
+    that help a human teleoperator (forbidden / no-touch zones, designated
+    contact zones, forbidden faces, slot targets, progress indicators, reference
+    points, ...). Tasks that have such markers override
+    :meth:`configure_debug_vis` to populate ``observations.scene_vis`` when this
+    is ``True`` (use :meth:`add_scene_vis_term`); every cue marker is tagged
+    ``purpose=guide`` (:func:`dexverse.baseline_v1.visual_purpose.hide_marker_from_cameras`)
+    by default. Teleop/recording launchers can disable camera hiding for XR
+    clients that do not display guide prims (``--cues_in_rgb``).
+
+    Defaults to ``False`` (RL, evaluation, audits, offscreen renders). The
+    teleoperation launchers (``scripts/teleop_agent.py``, ``scripts/record_demos.py``)
+    default it to ``True`` (``--no-enable_debug_vis`` turns cues off); other CLIs
+    override via a config rebuild ``cfg_cls(enable_debug_vis=True)``.
+
+    Deliberately does NOT control **goal markers** -- markers that *specify the
+    goal* (Isaac Lab's ``CommandTermCfg.debug_vis`` goal spheres on
+    ``commands.object_pose``, physical goal props, the carton's allowed faces).
+    Those stay on and camera-visible so vision policies can use them."""
+
+    def add_scene_vis_term(self, name: str, term: ObsTerm) -> None:
+        """Attach a visualizer-only observation term to ``observations.scene_vis``
+        (creating the group when needed). ``scene_vis`` terms return zero-size
+        tensors and exist only for their marker side effects; presets never null
+        the group, so this is the right home for both operator cues (gated by
+        ``enable_debug_vis`` in :meth:`configure_debug_vis`) and always-on goal
+        markers."""
+        if self.observations.scene_vis is None:
+            self.observations.scene_vis = ObservationsCfg.SceneVisObsCfg()
+        setattr(self.observations.scene_vis, name, term)
+
+    def forbidden_zone_asset_cfg(self) -> SceneEntityCfg:
+        """``SceneEntityCfg`` of the robot bodies that forbidden zones and no-touch
+        terminations must consider (see ``RobotConfig.forbidden_zone_body_names``;
+        ``None`` -> all bodies)."""
+        names = getattr(self.robot_config, "forbidden_zone_body_names", None)
+        return SceneEntityCfg("robot", body_names=list(names)) if names else SceneEntityCfg("robot")
+
+    def configure_debug_vis(self) -> None:
+        """Populate/depopulate this task's debug-only visualization markers
+        (zone boundaries, reference points, ...) in ``observations.scene_vis``
+        based on ``self.enable_debug_vis``.
+
+        No-op by default: tasks with nothing to visualize don't need to
+        override this. Leaf / sub-base ``__post_init__``s that define zone or
+        marker data should call ``self.configure_debug_vis()`` themselves,
+        *after* that data is computed — this can't be auto-chained from this
+        base ``__post_init__`` because it runs before subclasses add their own
+        terms (same ordering constraint documented below for
+        ``observation_preset``).
+        """
+        pass
+
+    observation_preset: str | None = None
+    """Optional observation-preset name applied at the end of ``__post_init__``.
+
+    See :data:`OBSERVATION_PRESET_NAMES`. ``None`` (default) leaves the obs
+    cfg as declared by sub-base / leaf — every populated group stays active.
+    """
+
+    multiview_cameras: bool = False
+    """Enable the two side-view third-person cameras (e.g. for pi0.5).
+
+    When ``False`` (default), the side cameras and their rgb/depth/pointcloud
+    obs terms are nulled so the env behaves exactly as the single-front-view
+    setup. When ``True``, the side cameras stay live, ``left_*``/``right_*``
+    rgb+depth terms are kept, and the pointcloud group swaps the single-source
+    term for ``merged_point_cloud_w`` over all three third-person cameras.
+    Side-camera poses are placeholders — tune them in a subclass.
+    """
+
+    def _apply_observation_preset(self, preset: str) -> None:
+        """Apply a named observation preset (idempotent).
+
+        Groups not in the preset's ``enabled`` set are set to ``None``; the
+        ``policy`` and ``proprio`` groups have their ``history_length`` set
+        to the preset's value (with ``flatten_history_dim=True`` when > 0).
+        ``debug_vis`` is left untouched (gated by ``enable_debug_vis``).
+
+        If the preset toggles ``multiview``, the scene's side cameras and the
+        matching obs terms are (re-)wired before group nulling.
+
+        Can be called manually from a CLI / launcher *after* the env-cfg
+        has been constructed; in that case the original ``__post_init__``
+        will have already produced a full obs cfg and this method narrows
+        it down.
+        """
+        canonical = resolve_observation_preset(preset)
+        spec = _OBSERVATION_PRESETS[canonical]
+        self.multiview_cameras = spec["multiview"]
+        self._apply_multiview_cameras(self.multiview_cameras)
+        for group in _OBSERVATION_PRESET_MANAGED_GROUPS:
+            if group in spec["enabled"]:
+                continue
+            if hasattr(self.observations, group):
+                setattr(self.observations, group, None)
+        history_length = spec["history_length"]
+        for group_name in ("policy", "proprio"):
+            group = getattr(self.observations, group_name, None)
+            if group is None:
+                continue
+            group.history_length = history_length
+            if history_length > 0:
+                group.flatten_history_dim = True
+
+    def _apply_multiview_cameras(self, enable: bool) -> None:
+        """Toggle the two side-view third-person cameras and their obs terms.
+
+        Idempotent and bidirectional. When ``enable`` is ``True``, missing
+        side cameras and side rgb/depth/merged-pc obs terms are recreated
+        from their factories; the single-source pointcloud term is nulled.
+        When ``False``, side cameras and side obs terms are nulled and the
+        single-source pointcloud term is restored.
+        """
+        if enable:
+            if self.scene.third_person_camera_left is None:
+                self.scene.third_person_camera_left = make_third_person_camera_left_cfg()
+            if self.scene.third_person_camera_right is None:
+                self.scene.third_person_camera_right = make_third_person_camera_right_cfg()
+            if self.observations.rgb is not None:
+                if getattr(self.observations.rgb, "left_rgb_image", None) is None:
+                    self.observations.rgb.left_rgb_image = make_left_rgb_obs_term()
+                if getattr(self.observations.rgb, "right_rgb_image", None) is None:
+                    self.observations.rgb.right_rgb_image = make_right_rgb_obs_term()
+            if self.observations.depth is not None:
+                if getattr(self.observations.depth, "left_depth_image", None) is None:
+                    self.observations.depth.left_depth_image = make_left_depth_obs_term()
+                if getattr(self.observations.depth, "right_depth_image", None) is None:
+                    self.observations.depth.right_depth_image = make_right_depth_obs_term()
+            if self.observations.pointcloud is not None:
+                self.observations.pointcloud.camera_point_cloud_w = None
+                if getattr(self.observations.pointcloud, "merged_point_cloud_w", None) is None:
+                    self.observations.pointcloud.merged_point_cloud_w = make_merged_point_cloud_obs_term()
+        else:
+            self.scene.third_person_camera_left = None
+            self.scene.third_person_camera_right = None
+            if self.observations.rgb is not None:
+                self.observations.rgb.left_rgb_image = None
+                self.observations.rgb.right_rgb_image = None
+            if self.observations.depth is not None:
+                self.observations.depth.left_depth_image = None
+                self.observations.depth.right_depth_image = None
+            if self.observations.pointcloud is not None:
+                self.observations.pointcloud.merged_point_cloud_w = None
+                if getattr(self.observations.pointcloud, "camera_point_cloud_w", None) is None:
+                    self.observations.pointcloud.camera_point_cloud_w = make_camera_point_cloud_obs_term()
+
+    def _apply_robot_setup(self, robot_setup):
+        """Apply a robot setup bundle returned by a robot-agent builder."""
+        self.robot_config = RobotConfig(**robot_setup.robot_config_kwargs)
+        self.scene.robot = robot_setup.scene_robot
+        self.actions = robot_setup.actions
+        self.controller_mode = robot_setup.controller_mode
+        self._teleop_config = dict(robot_setup.teleop_config)
+
+    def _configure_robot_from_type(self):
+        """Apply robot/articulation/action setup for unified robot_type configs."""
+        setup_builders = _get_tabletop_robot_setup_builders()
+        setup_builder = setup_builders.get(self.robot_type)
+        # Shared builders contain nested constants; keep task-specific edits local.
+        self._apply_robot_setup(deepcopy(setup_builder()))
+
+    def __post_init__(self):
+        """Post initialization."""
+        self.decimation = 2  # 60 Hz
+        self._configure_robot_from_type()
+        if self.robot_type in SHADOW_ROBOT_TYPES:
+            self.events.set_shadow_wrist_joint_limits = EventTerm(
+                func=mdp.events.set_joint_position_limits,
+                mode="startup",
+                params={
+                    "asset_cfg": SceneEntityCfg(
+                        "robot",
+                        joint_names=["(lh_|rh_)?(x|y|z)_rotation_joint"],
+                    ),
+                    "lower": SHADOW_WRIST_LIMITS[0],
+                    "upper": SHADOW_WRIST_LIMITS[1],
+                },
+            )
+        _sync_table_legs_to_table(self.scene)
+        _configure_wrist_camera_attachments(self.scene, self.robot_config)
+
+        # Null wrist-camera obs terms for cameras the active robot setup
+        # doesn't populate. ``_configure_wrist_camera_attachments`` leaves the
+        # unused camera attrs as ``None`` on the scene; we mirror that into
+        # the rgb / depth obs groups so the obs manager doesn't try to read
+        # from a missing sensor.
+        for _cam_attr, _rgb_term, _depth_term in (
+            ("wrist_camera", "wrist_rgb_image", "wrist_depth_image"),
+            ("right_wrist_camera", "right_wrist_rgb_image", "right_wrist_depth_image"),
+            ("left_wrist_camera", "left_wrist_rgb_image", "left_wrist_depth_image"),
+        ):
+            if getattr(self.scene, _cam_attr, None) is None:
+                if self.observations.rgb is not None:
+                    setattr(self.observations.rgb, _rgb_term, None)
+                if self.observations.depth is not None:
+                    setattr(self.observations.depth, _depth_term, None)
+
+        # Side-view (multi-view) cameras: nulled unless explicitly enabled. When
+        # enabled, pointcloud swaps from single-source to merged-3-view. The
+        # ``3view_*`` observation presets re-toggle this in
+        # ``_apply_observation_preset`` if invoked post-init.
+        self._apply_multiview_cameras(self.multiview_cameras)
+
+        if self.robot_config.wrist_joint_name is not None and self.events.reset_robot_wrist_joint is not None:
+            self.events.reset_robot_wrist_joint.params["asset_cfg"].joint_names = self.robot_config.wrist_joint_name
+        elif self.robot_config.wrist_joint_name is None:
+            self.events.reset_robot_wrist_joint = None
+
+        if self.scene.object is not None:
+            if hasattr(self.commands, "object_pose"):
+                self.commands.object_pose.position_only = False
+        else:
+            # Disable object-dependent terms when no object is present.
+            if hasattr(self.commands, "object_pose"):
+                self.commands.object_pose = None
+            self.observations.policy.object_quat_b = None
+            self.observations.policy.target_object_pose_b = None
+            self.observations.pointcloud.object_point_cloud = None
+            self.terminations.object_out_of_bound = None
+            self.events.object_physics_material = None
+            self.rewards.position_tracking = None
+            self.rewards.success = None
+
+        self.episode_length_s = 20.0
+        self.is_finite_horizon = True
+
+        if self.scene.object is not None and hasattr(self.commands, "object_pose"):
+            resample_time = self.episode_length_s + 1.0
+            self.commands.object_pose.resampling_time_range = (resample_time, resample_time)
+
+        # ``enable_debug_vis`` is read by sub-base / leaf ``__post_init__``s
+        # *before* they populate ``self.observations.debug_vis``. The flag
+        # cannot null the group here because sub-bases add terms after
+        # ``super().__post_init__()`` returns.
+        #
+        # ``observation_preset`` has the same ordering constraint and so is
+        # NOT auto-applied here either. CLI / launcher code should call
+        # ``env_cfg._apply_observation_preset(env_cfg.observation_preset)``
+        # *after* ``parse_env_cfg`` (i.e. after the full __post_init__ chain
+        # has run on the leaf cfg) and *before* the env is built.
+
+        # simulation settings
+        self.sim.dt = 1 / 120
+        self.sim.render_interval = self.decimation
+        self.sim.physx.bounce_threshold_velocity = 0.01
+        self.sim.physx.gpu_max_rigid_patch_count = 4 * 5 * 2**15
+
+        # RTX sensors (cameras) need a few renders to latch a newly-written
+        # scene after a teleport. The ``--set-state`` demo replay teleports the
+        # whole scene every step (``scene.reset_to``) and renders before reading
+        # camera obs; with a single render the captured frame can lag the
+        # just-set state by ~1 frame / show TAA ghosting. Render a couple of
+        # extra times so point cloud / RGB obs reflect the current state. This is
+        # read by both demo scripts via ``env.cfg.num_rerenders_on_reset`` and is
+        # a no-op when no RTX sensors are present (the replay refresh and the env
+        # reset both gate the rerender loop on ``sim.has_rtx_sensors()``).
+        self.num_rerenders_on_reset = 2

--- a/source/dexverse/dexverse/baseline_v1/mdp/__init__.py
+++ b/source/dexverse/dexverse/baseline_v1/mdp/__init__.py
@@ -1,0 +1,24 @@
+# Copyright (c) 2025-2026, The DexVerse Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# Copyright (c) 2022-2025, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""This sub-module contains the functions that are specific to the environment."""
+
+from isaaclab.envs.mdp import *  # noqa: F401, F403
+
+from . import events  # noqa: F401
+from .commands import *  # noqa: F401, F403
+from .curriculums import *  # noqa: F401, F403
+from .cut_sweep import *  # noqa: F401, F403
+from .events import *  # noqa: F401, F403
+from .observations import *  # noqa: F401, F403
+from .resets import *  # noqa: F401, F403
+from .rewards import *  # noqa: F401, F403
+from .stage_machine import *  # noqa: F401, F403
+from .terminations import *  # noqa: F401, F403

--- a/source/dexverse/dexverse/baseline_v1/mdp/commands/__init__.py
+++ b/source/dexverse/dexverse/baseline_v1/mdp/commands/__init__.py
@@ -1,0 +1,11 @@
+# Copyright (c) 2025-2026, The DexVerse Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# Copyright (c) 2022-2025, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+from .pose_commands_cfg import *  # noqa: F401, F403

--- a/source/dexverse/dexverse/baseline_v1/mdp/commands/pose_commands.py
+++ b/source/dexverse/dexverse/baseline_v1/mdp/commands/pose_commands.py
@@ -1,0 +1,276 @@
+# Copyright (c) 2025-2026, The DexVerse Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# Copyright (c) 2022-2025, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+
+"""Sub-module containing command generators for pose tracking."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import TYPE_CHECKING
+
+import torch
+from dexverse.baseline_v1.visual_purpose import hide_marker_from_cameras
+from isaaclab.assets import Articulation, RigidObject
+from isaaclab.managers import CommandTerm
+from isaaclab.markers import VisualizationMarkers
+from isaaclab.utils.math import (
+    combine_frame_transforms,
+    compute_pose_error,
+    quat_apply,
+    quat_from_euler_xyz,
+    quat_unique,
+)
+
+if TYPE_CHECKING:
+    from isaaclab.envs import ManagerBasedEnv
+
+    from . import pose_commands_cfg as dex_cmd_cfgs
+
+
+class ObjectUniformPoseCommand(CommandTerm):
+    """Uniform pose command generator for an object.
+
+    This command term samples target object poses by:
+      • Drawing (x, y, z) uniformly within configured Cartesian bounds, and
+      • Drawing roll-pitch-yaw uniformly within configured ranges, then converting
+        to a quaternion (w, x, y, z). Optionally makes quaternions unique by enforcing
+        a positive real part.
+
+    Frames:
+        With `use_world_frame`, ranges use world-aligned axes relative to each
+        environment origin. The sampled positions are translated to world space
+        before storage. Otherwise ranges are in the robot's base frame.
+        Metrics and visualization always use world-space targets.
+
+    Outputs:
+        The command buffer has shape (num_envs, 7): `(x, y, z, qw, qx, qy, qz)`.
+        If `use_world_frame=True`, this is in world frame. Otherwise, it's in robot base frame.
+
+    Metrics:
+        `position_error` and `orientation_error` are computed between the commanded
+        world-frame pose and the object's current world-frame pose.
+
+    Config:
+        `cfg` must provide the sampling ranges, whether to enforce quaternion uniqueness,
+        whether to use world frame, and optional visualization settings.
+    """
+
+    cfg: dex_cmd_cfgs.ObjectUniformPoseCommandCfg
+    """Configuration for the command generator."""
+
+    def __init__(self, cfg: dex_cmd_cfgs.ObjectUniformPoseCommandCfg, env: ManagerBasedEnv):
+        """Initialize the command generator class.
+
+        Args:
+            cfg: The configuration parameters for the command generator.
+            env: The environment object.
+        """
+        # initialize the base class
+        super().__init__(cfg, env)
+
+        # extract the robot and body index for which the command is generated
+        self.robot: Articulation = env.scene[cfg.asset_name]
+        self.object: RigidObject = env.scene[cfg.object_name]
+        self.success_vis_asset: RigidObject = env.scene[cfg.success_vis_asset_name]
+
+        # create buffers
+        # -- commands: (x, y, z, qw, qx, qy, qz) in root frame
+        self.pose_command_b = torch.zeros(self.num_envs, 7, device=self.device)
+        self.pose_command_b[:, 3] = 1.0
+        self.pose_command_w = torch.zeros_like(self.pose_command_b)
+        # -- metrics
+        self.metrics["position_error"] = torch.zeros(self.num_envs, device=self.device)
+        self.metrics["orientation_error"] = torch.zeros(self.num_envs, device=self.device)
+
+        # Only initialize success visualizer if markers are configured
+        # VisualizationMarkers requires at least one marker, so we skip initialization if empty
+        if env.cfg.enable_debug_vis and len(self.cfg.success_visualizer_cfg.markers) > 0:
+            self.success_visualizer = VisualizationMarkers(self.cfg.success_visualizer_cfg)
+            hide_marker_from_cameras(self.success_visualizer)
+            self.success_visualizer.set_visibility(True)
+        else:
+            self.success_visualizer = None
+
+    def __str__(self) -> str:
+        msg = "UniformPoseCommand:\n"
+        msg += f"\tCommand dimension: {tuple(self.command.shape[1:])}\n"
+        msg += f"\tResampling time range: {self.cfg.resampling_time_range}\n"
+        return msg
+
+    """
+    Properties
+    """
+
+    @property
+    def command(self) -> torch.Tensor:
+        """The desired pose command. Shape is (num_envs, 7).
+
+        The first three elements correspond to the position, followed by the quaternion orientation in (w, x, y, z).
+        """
+        return self.pose_command_b
+
+    """
+    Implementation specific functions.
+    """
+
+    def _update_metrics(self):
+        # transform command to world frame if needed
+        if self.cfg.use_world_frame:
+            # Commands are already in world frame
+            self.pose_command_w[:, :3] = self.pose_command_b[:, :3]
+            self.pose_command_w[:, 3:] = self.pose_command_b[:, 3:]
+        else:
+            # transform command from base frame to simulation world frame
+            self.pose_command_w[:, :3], self.pose_command_w[:, 3:] = combine_frame_transforms(
+                self.robot.data.root_pos_w,
+                self.robot.data.root_quat_w,
+                self.pose_command_b[:, :3],
+                self.pose_command_b[:, 3:],
+            )
+        # compute the error
+        pos_error, rot_error = compute_pose_error(
+            self.pose_command_w[:, :3],
+            self.pose_command_w[:, 3:],
+            self.object.data.root_state_w[:, :3],
+            self.object.data.root_state_w[:, 3:7],
+        )
+        self.metrics["position_error"] = torch.norm(pos_error, dim=-1)
+        self.metrics["orientation_error"] = torch.norm(rot_error, dim=-1)
+
+        success_id = self.metrics["position_error"] < 0.05
+        if not self.cfg.position_only:
+            success_id &= self.metrics["orientation_error"] < 0.5
+        # Only visualize if success visualizer is initialized (i.e., markers are configured)
+        if self.success_visualizer is not None:
+            self.success_visualizer.visualize(self.success_vis_asset.data.root_pos_w, marker_indices=success_id.int())
+
+    def _resample_command(self, env_ids: Sequence[int]):
+        # sample new pose targets
+        # -- position
+        r = torch.empty(len(env_ids), device=self.device)
+        if self.cfg.use_world_frame:
+            # Configured table/goal coordinates are relative to each cloned scene.
+            # Store world positions so observations, metrics and success predicates
+            # continue to compare against root_pos_w without another transform.
+            self.pose_command_b[env_ids, 0] = r.uniform_(*self.cfg.ranges.pos_x)
+            self.pose_command_b[env_ids, 1] = r.uniform_(*self.cfg.ranges.pos_y)
+            self.pose_command_b[env_ids, 2] = r.uniform_(*self.cfg.ranges.pos_z)
+            self.pose_command_b[env_ids, :3] += self._env.scene.env_origins[env_ids]
+            # When using world frame, also update pose_command_w immediately
+            self.pose_command_w[env_ids, :3] = self.pose_command_b[env_ids, :3]
+        else:
+            # Sample in robot base frame (original behavior)
+            self.pose_command_b[env_ids, 0] = r.uniform_(*self.cfg.ranges.pos_x)
+            self.pose_command_b[env_ids, 1] = r.uniform_(*self.cfg.ranges.pos_y)
+            self.pose_command_b[env_ids, 2] = r.uniform_(*self.cfg.ranges.pos_z)
+        # -- orientation
+        euler_angles = torch.zeros_like(self.pose_command_b[env_ids, :3])
+        euler_angles[:, 0].uniform_(*self.cfg.ranges.roll)
+        euler_angles[:, 1].uniform_(*self.cfg.ranges.pitch)
+        euler_angles[:, 2].uniform_(*self.cfg.ranges.yaw)
+        quat = quat_from_euler_xyz(euler_angles[:, 0], euler_angles[:, 1], euler_angles[:, 2])
+        # make sure the quaternion has real part as positive
+        quat_final = quat_unique(quat) if self.cfg.make_quat_unique else quat
+        self.pose_command_b[env_ids, 3:] = quat_final
+        # When using world frame, also update pose_command_w orientation immediately
+        if self.cfg.use_world_frame:
+            self.pose_command_w[env_ids, 3:] = quat_final
+
+    def _update_command(self):
+        pass
+
+    def _set_debug_vis_impl(self, debug_vis: bool):
+        # create markers if necessary for the first tome
+        if debug_vis:
+            if not hasattr(self, "goal_visualizer"):
+                # -- goal pose
+                # The goal marker is task information (a vision policy may rely on
+                # it), so unlike operator cues it stays visible to cameras.
+                self.goal_visualizer = VisualizationMarkers(self.cfg.goal_pose_visualizer_cfg)
+                # -- current body pose (a cue: hidden from recorded RGB)
+                self.curr_visualizer = None
+                if self._env.cfg.enable_debug_vis:
+                    self.curr_visualizer = VisualizationMarkers(self.cfg.curr_pose_visualizer_cfg)
+                    hide_marker_from_cameras(self.curr_visualizer)
+            # set their visibility to true
+            self.goal_visualizer.set_visibility(True)
+            if self.curr_visualizer is not None:
+                self.curr_visualizer.set_visibility(True)
+        else:
+            if hasattr(self, "goal_visualizer"):
+                self.goal_visualizer.set_visibility(False)
+                if self.curr_visualizer is not None:
+                    self.curr_visualizer.set_visibility(False)
+
+    def _debug_vis_callback(self, event):
+        # check if robot is initialized
+        # note: this is needed in-case the robot is de-initialized. we can't access the data
+        if not self.robot.is_initialized:
+            return
+        # update the markers
+        # marker indices: 0=frame, 1=position_far (red), 2=position_near (green)
+        # Always show frame markers (index 0) for both goal and current poses
+        frame_marker_indices = torch.zeros(self.num_envs, dtype=torch.int32, device=self.device)
+
+        self.goal_visualizer.visualize(
+            translations=self.pose_command_w[:, :3],
+            orientations=self.pose_command_w[:, 3:],
+            marker_indices=frame_marker_indices,
+        )
+        if self.curr_visualizer is not None:
+            self.curr_visualizer.visualize(
+                translations=self.object.data.root_pos_w[:, :3],
+                orientations=self.object.data.root_quat_w,
+                marker_indices=frame_marker_indices,
+            )
+
+
+class ObjectAssetTrackingPoseCommand(ObjectUniformPoseCommand):
+    """Pose command whose position tracks a target asset's pose plus a local offset.
+
+    Useful when the goal should follow a per-env-randomized prop (e.g. a
+    place-target whose location varies each episode). Orientation is still
+    drawn from the configured ranges (so visualizers and metrics behave
+    identically to :class:`ObjectUniformPoseCommand`); the position is
+    overwritten every step from
+    ``target.root_pos_w + R(target.root_quat_w) * local_offset``, which keeps
+    the goal locked to the target even if it moves at simulation time.
+    """
+
+    cfg: dex_cmd_cfgs.ObjectAssetTrackingPoseCommandCfg
+
+    def __init__(self, cfg: dex_cmd_cfgs.ObjectAssetTrackingPoseCommandCfg, env: ManagerBasedEnv):
+        super().__init__(cfg, env)
+        self.target = env.scene[cfg.target_asset_name]
+        self._local_offset = torch.tensor(cfg.local_offset, device=self.device, dtype=torch.float32)
+
+    def _goal_world_position(self) -> torch.Tensor:
+        target_pos = self.target.data.root_pos_w
+        target_quat = self.target.data.root_quat_w
+        offset_w = quat_apply(
+            target_quat,
+            self._local_offset.unsqueeze(0).expand(self.num_envs, -1),
+        )
+        return target_pos + offset_w
+
+    def _resample_command(self, env_ids: Sequence[int]):
+        super()._resample_command(env_ids)
+        goal_pos = self._goal_world_position()
+        self.pose_command_b[env_ids, :3] = goal_pos[env_ids]
+        if self.cfg.use_world_frame:
+            self.pose_command_w[env_ids, :3] = goal_pos[env_ids]
+
+    def _update_command(self):
+        # Refresh every step so the goal follows the target if it moves.
+        goal_pos = self._goal_world_position()
+        self.pose_command_b[:, :3] = goal_pos
+        if self.cfg.use_world_frame:
+            self.pose_command_w[:, :3] = goal_pos

--- a/source/dexverse/dexverse/baseline_v1/mdp/commands/pose_commands_cfg.py
+++ b/source/dexverse/dexverse/baseline_v1/mdp/commands/pose_commands_cfg.py
@@ -1,0 +1,121 @@
+# Copyright (c) 2025-2026, The DexVerse Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# Copyright (c) 2022-2025, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+from dataclasses import MISSING
+
+import isaaclab.sim as sim_utils
+from isaaclab.managers import CommandTermCfg
+from isaaclab.markers import VisualizationMarkersCfg
+from isaaclab.utils import configclass
+from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR
+
+from . import pose_commands as dex_cmd
+
+ALIGN_MARKER_CFG = VisualizationMarkersCfg(
+    markers={
+        "frame": sim_utils.UsdFileCfg(
+            usd_path=f"{ISAAC_NUCLEUS_DIR}/Props/UIElements/frame_prim.usd",
+            scale=(0.1, 0.1, 0.1),
+        ),
+        "position_far": sim_utils.SphereCfg(
+            radius=0.01,
+            visual_material=sim_utils.PreviewSurfaceCfg(diffuse_color=(1.0, 0.0, 0.0)),
+        ),
+        "position_near": sim_utils.SphereCfg(
+            radius=0.01,
+            visual_material=sim_utils.PreviewSurfaceCfg(diffuse_color=(0.0, 1.0, 0.0)),
+        ),
+    }
+)
+
+
+@configclass
+class ObjectUniformPoseCommandCfg(CommandTermCfg):
+    """Configuration for uniform pose command generator."""
+
+    class_type: type = dex_cmd.ObjectUniformPoseCommand
+
+    asset_name: str = MISSING
+    """Name of the coordinate referencing asset in the environment for which the commands are generated respect to."""
+
+    object_name: str = MISSING
+    """Name of the object in the environment for which the commands are generated."""
+
+    make_quat_unique: bool = False
+    """Whether to make the quaternion unique or not. Defaults to False.
+
+    If True, the quaternion is made unique by ensuring the real part is positive.
+    """
+
+    @configclass
+    class Ranges:
+        """Uniform distribution ranges for the pose commands."""
+
+        pos_x: tuple[float, float] = MISSING
+        """Range for the x position (in m)."""
+
+        pos_y: tuple[float, float] = MISSING
+        """Range for the y position (in m)."""
+
+        pos_z: tuple[float, float] = MISSING
+        """Range for the z position (in m)."""
+
+        roll: tuple[float, float] = MISSING
+        """Range for the roll angle (in rad)."""
+
+        pitch: tuple[float, float] = MISSING
+        """Range for the pitch angle (in rad)."""
+
+        yaw: tuple[float, float] = MISSING
+        """Range for the yaw angle (in rad)."""
+
+    ranges: Ranges = MISSING
+    """Ranges for the commands."""
+
+    use_world_frame: bool = False
+    """Use world-aligned ranges relative to each environment origin (True),
+    or robot-base-relative ranges (False). World-mode command buffers include
+    the environment origin; consumers receive absolute world positions.
+    """
+
+    position_only: bool = True
+    """Command goal position only. Command includes goal quat if False"""
+
+    # Pose Markers
+    goal_pose_visualizer_cfg: VisualizationMarkersCfg = ALIGN_MARKER_CFG.replace(prim_path="/Visuals/Command/goal_pose")
+    """The configuration for the goal pose visualization marker. Defaults to FRAME_MARKER_CFG."""
+
+    curr_pose_visualizer_cfg: VisualizationMarkersCfg = ALIGN_MARKER_CFG.replace(prim_path="/Visuals/Command/body_pose")
+    """The configuration for the current pose visualization marker. Defaults to FRAME_MARKER_CFG."""
+
+    success_vis_asset_name: str = MISSING
+    """Name of the asset in the environment for which the success color are indicated."""
+
+    # success markers
+    success_visualizer_cfg = VisualizationMarkersCfg(prim_path="/Visuals/SuccessMarkers", markers={})
+    """The configuration for the success visualization marker. User needs to add the markers"""
+
+
+@configclass
+class ObjectAssetTrackingPoseCommandCfg(ObjectUniformPoseCommandCfg):
+    """Pose command whose position is locked to a target asset's pose + offset.
+
+    Orientation is still sampled from the inherited ``ranges``; only the
+    ``pos_x/pos_y/pos_z`` ranges are ignored (the position is computed from
+    ``target_asset_name`` each step).
+    """
+
+    class_type: type = dex_cmd.ObjectAssetTrackingPoseCommand
+
+    target_asset_name: str = MISSING
+    """Name of the scene asset whose pose the goal tracks."""
+
+    local_offset: tuple[float, float, float] = (0.0, 0.0, 0.0)
+    """Goal offset from the target's root, expressed in the target's local frame (m)."""

--- a/source/dexverse/dexverse/baseline_v1/mdp/curriculums.py
+++ b/source/dexverse/dexverse/baseline_v1/mdp/curriculums.py
@@ -1,0 +1,118 @@
+# Copyright (c) 2025-2026, The DexVerse Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# Copyright (c) 2022-2025, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import TYPE_CHECKING
+
+import torch
+from isaaclab.assets import Articulation, RigidObject
+from isaaclab.envs import mdp
+from isaaclab.managers import ManagerTermBase, SceneEntityCfg
+from isaaclab.utils.math import combine_frame_transforms, compute_pose_error
+
+if TYPE_CHECKING:
+    from isaaclab.envs import ManagerBasedRLEnv
+
+
+def initial_final_interpolate_fn(env: ManagerBasedRLEnv, env_id, data, initial_value, final_value, difficulty_term_str):
+    """
+    Interpolate between initial value iv and final value fv, for any arbitrarily
+    nested structure of lists/tuples in 'data'. Scalars (int/float) are handled
+    at the leaves.
+    """
+    # get the fraction scalar on the device
+    difficulty_term: DifficultyScheduler = getattr(env.curriculum_manager.cfg, difficulty_term_str).func
+    frac = difficulty_term.difficulty_frac
+    if frac < 0.1:
+        # no-op during start, since the difficulty fraction near 0 is wasting of resource.
+        return mdp.modify_env_param.NO_CHANGE
+
+    # convert iv/fv to tensors, but we'll peel them apart in recursion
+    initial_value_tensor = torch.tensor(initial_value, device=env.device)
+    final_value_tensor = torch.tensor(final_value, device=env.device)
+
+    return _recurse(initial_value_tensor.tolist(), final_value_tensor.tolist(), data, frac)
+
+
+def _recurse(iv_elem, fv_elem, data_elem, frac):
+    # If it's a sequence, rebuild the same type with each element recursed
+    if isinstance(data_elem, Sequence) and not isinstance(data_elem, (str, bytes)):
+        # Note: we assume initial value element and final value element have the same structure as data
+        return type(data_elem)(_recurse(iv_e, fv_e, d_e, frac) for iv_e, fv_e, d_e in zip(iv_elem, fv_elem, data_elem))
+    # Otherwise it's a leaf scalar: do the interpolation
+    new_val = frac * (fv_elem - iv_elem) + iv_elem
+    if isinstance(data_elem, int):
+        return int(new_val.item())
+    else:
+        # cast floats or any numeric
+        return new_val.item()
+
+
+class DifficultyScheduler(ManagerTermBase):
+    """Adaptive difficulty scheduler for curriculum learning.
+
+    Tracks per-environment difficulty levels and adjusts them based on task performance. Difficulty increases when
+    position/orientation errors fall below given tolerances, and decreases otherwise (unless `promotion_only` is set).
+    The normalized average difficulty across environments is exposed as `difficulty_frac` for use in curriculum
+    interpolation.
+
+    Args:
+        cfg: Configuration object specifying scheduler parameters.
+        env: The manager-based RL environment.
+
+    """
+
+    def __init__(self, cfg, env):
+        super().__init__(cfg, env)
+        init_difficulty = self.cfg.params.get("init_difficulty", 0)
+        self.current_adr_difficulties = torch.ones(env.num_envs, device=env.device) * init_difficulty
+        self.difficulty_frac = 0
+
+    def get_state(self):
+        return self.current_adr_difficulties
+
+    def set_state(self, state: torch.Tensor):
+        self.current_adr_difficulties = state.clone().to(self._env.device)
+
+    def __call__(
+        self,
+        env: ManagerBasedRLEnv,
+        env_ids: Sequence[int],
+        asset_cfg: SceneEntityCfg = SceneEntityCfg("robot"),
+        object_cfg: SceneEntityCfg = SceneEntityCfg("object"),
+        pos_tol: float = 0.1,
+        rot_tol: float | None = None,
+        init_difficulty: int = 0,
+        min_difficulty: int = 0,
+        max_difficulty: int = 50,
+        promotion_only: bool = False,
+    ):
+        asset: Articulation = env.scene[asset_cfg.name]
+        object: RigidObject = env.scene[object_cfg.name]
+        command = env.command_manager.get_command("object_pose")
+        des_pos_w, des_quat_w = combine_frame_transforms(
+            asset.data.root_pos_w[env_ids], asset.data.root_quat_w[env_ids], command[env_ids, :3], command[env_ids, 3:7]
+        )
+        pos_err, rot_err = compute_pose_error(
+            des_pos_w, des_quat_w, object.data.root_pos_w[env_ids], object.data.root_quat_w[env_ids]
+        )
+        pos_dist = torch.norm(pos_err, dim=1)
+        rot_dist = torch.norm(rot_err, dim=1)
+        move_up = (pos_dist < pos_tol) & (rot_dist < rot_tol) if rot_tol else pos_dist < pos_tol
+        demot = self.current_adr_difficulties[env_ids] if promotion_only else self.current_adr_difficulties[env_ids] - 1
+        self.current_adr_difficulties[env_ids] = torch.where(
+            move_up,
+            self.current_adr_difficulties[env_ids] + 1,
+            demot,
+        ).clamp(min=min_difficulty, max=max_difficulty)
+        self.difficulty_frac = torch.mean(self.current_adr_difficulties) / max(max_difficulty, 1)
+        return self.difficulty_frac

--- a/source/dexverse/dexverse/baseline_v1/mdp/cut_sweep.py
+++ b/source/dexverse/dexverse/baseline_v1/mdp/cut_sweep.py
@@ -1,0 +1,578 @@
+# Copyright (c) 2025-2026, The DexVerse Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Cut-progress machinery for the "cut" tasks (utility knife seam, scissors strip).
+
+Cutting is represented by geometric predicates while the workpiece stays
+kinematic. Individual tasks decide whether material/blade collision is enabled:
+the utility-knife tape is filtered, while the scissors paper collides normally.
+
+Two mechanisms live here:
+
+- **Frontier sweep** (utility knife): a per-env scalar *frontier* -- how far
+  along the workpiece's seam the cut has advanced -- that only moves while all
+  gates hold at once (blade extended, tip pressed into the slot within lateral
+  tolerance, blade aligned with the seam) and only *contiguously*: the tip must
+  be at the current frontier (small backlash) and the frontier advances at a
+  capped per-step rate. Teleporting the tip, tapping the far end, or waving
+  above the tape accrues nothing.
+
+- **Blade contact** (scissors): each blade's inward-facing cutting edge carries
+  a continuous rectangular contact zone in the blade link's frame. Success
+  requires both functional blade regions to touch the colliding paper.
+
+Shared-state architecture copies :mod:`.stage_machine`: a module registry keyed
+by ``task_key`` plus per-env runtime state cached on the env object, with one
+``evaluate_*`` entry point memoized per environment step so termination,
+reward, observation and visualization terms all read a single consistent
+result (and state advances at most once per step). Per-env resets are detected
+from ``episode_length_buf`` exactly like the stage machine does.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+import torch
+from isaaclab.envs import ManagerBasedRLEnv
+from isaaclab.managers import ManagerTermBase, SceneEntityCfg
+
+from .terminations import joint_relative_move
+from .utils import asset_axis_w
+
+# =====================================================================================
+# Frontier sweep (utility knife)
+# =====================================================================================
+
+
+@dataclass(frozen=True)
+class CutSweepSpec:
+    """Static definition of one seam-sweep cut, registered per task key.
+
+    Assets are referenced by scene-entity *name* (ids resolve lazily at first
+    evaluation). The seam is a segment in the workpiece's root frame; the tool
+    tip is a fixed offset in ``tip_body_name``'s link frame (scaled asset
+    coordinates).
+    """
+
+    workpiece_asset_name: str
+    seam_start_local: tuple[float, float, float]
+    seam_end_local: tuple[float, float, float]
+    tool_asset_name: str
+    tip_body_name: str
+    tip_local_offset: tuple[float, float, float]
+    ext_joint_name: str
+    # Blade-extension gate, in joint_relative_move "progress" units (scale-invariant).
+    ext_threshold: float = 0.4
+    # Tip must be within this horizontal distance of the seam line (m).
+    lateral_tol: float = 0.012
+    # Seam surface height in the workpiece frame; the tip must dip below
+    # ``z_surface_local - min_dip`` (i.e. through the tape, into the slot).
+    z_surface_local: float = 0.045
+    min_dip: float = 0.003
+    # Optional undirected *heading* gate: the horizontal projection (in the
+    # workpiece frame) of this tool-root axis must align with the seam
+    # direction within the cosine threshold. Only yaw counts -- the natural
+    # tip-down cutting pitch is free. None disables the gate.
+    align_axis_tool_local: tuple[float, float, float] | None = (0.0, 1.0, 0.0)
+    align_threshold_cos: float = 0.90
+    # Contiguity: the tip may lead the frontier by at most ``backlash`` (m) for
+    # cutting to count, and the frontier advances at most ``max_step_advance``
+    # (m) per env step.
+    backlash: float = 0.02
+    max_step_advance: float = 0.01
+    # Frontier fraction at which the cut counts as complete.
+    complete_frac: float = 0.95
+
+
+_CUT_SWEEP_REGISTRY: dict[str, CutSweepSpec] = {}
+# Set DEXVERSE_CUT_DEBUG=1 to print a per-gate trace for env 0 every
+# DEXVERSE_CUT_DEBUG_EVERY steps (default 10).
+_CUT_DEBUG = os.environ.get("DEXVERSE_CUT_DEBUG", "0") not in ("", "0", "false", "False")
+_CUT_DEBUG_EVERY = max(int(os.environ.get("DEXVERSE_CUT_DEBUG_EVERY", "10")), 1)
+
+
+def register_cut_sweep(task_key: str, spec: CutSweepSpec, *, override: bool = False) -> None:
+    """Register (or replace, with ``override=True``) a sweep spec for a task key."""
+    if not override and task_key in _CUT_SWEEP_REGISTRY and _CUT_SWEEP_REGISTRY[task_key] != spec:
+        raise ValueError(f"Cut sweep '{task_key}' already registered with a different spec; pass override=True.")
+    _CUT_SWEEP_REGISTRY[task_key] = spec
+
+
+def get_cut_sweep_spec(task_key: str) -> CutSweepSpec:
+    if task_key not in _CUT_SWEEP_REGISTRY:
+        raise KeyError(f"Cut sweep '{task_key}' is not registered. Available: {sorted(_CUT_SWEEP_REGISTRY)}")
+    return _CUT_SWEEP_REGISTRY[task_key]
+
+
+def _get_episode_length_buf(env: ManagerBasedRLEnv) -> torch.Tensor | None:
+    episode_length_buf = getattr(env, "episode_length_buf", None)
+    if isinstance(episode_length_buf, torch.Tensor) and episode_length_buf.ndim == 1:
+        return episode_length_buf
+    return None
+
+
+def _compute_reset_mask(
+    episode_length_buf: torch.Tensor | None,
+    previous_step_buf: torch.Tensor | None,
+) -> torch.Tensor | None:
+    if episode_length_buf is None:
+        return None
+    if isinstance(previous_step_buf, torch.Tensor) and previous_step_buf.shape == episode_length_buf.shape:
+        # A counter that went *backwards* is an unambiguous new episode. Relying on
+        # ``== 0`` alone only works if this state happens to be evaluated at the
+        # very first step -- lazy consumers (a strict stage graph only evaluates
+        # its first pending stage's predicate; obs presets can drop the terms
+        # that would touch it) otherwise inherit the previous episode's progress
+        # (Aug 2026: the cut frontier stayed at 1.0 into the next replayed demo,
+        # so success fired as soon as the blade extended).
+        return ((episode_length_buf == 0) & (previous_step_buf != 0)) | (episode_length_buf < previous_step_buf)
+    return episode_length_buf == 0
+
+
+class _CutSweepState:
+    """Per-task mutable runtime state cached on the env object."""
+
+    def __init__(self):
+        self.frontier_m: torch.Tensor | None = None
+        self.last_step_buf: torch.Tensor | None = None
+        self.memo_step_buf: torch.Tensor | None = None
+        self.memo_out: dict[str, torch.Tensor] | None = None
+        self.tip_body_id: int | None = None
+        self.ext_joint_cfg: SceneEntityCfg | None = None
+
+
+def _get_sweep_state(env: ManagerBasedRLEnv, task_key: str) -> _CutSweepState:
+    cache = getattr(env, "_cut_sweep_runtime_cache", None)
+    if cache is None:
+        cache = {}
+        env._cut_sweep_runtime_cache = cache
+    if task_key not in cache:
+        cache[task_key] = _CutSweepState()
+    return cache[task_key]
+
+
+def _advance_frontier(
+    frontier_m: torch.Tensor,
+    s_tip: torch.Tensor,
+    gates_ok: torch.Tensor,
+    *,
+    backlash: float,
+    max_step_advance: float,
+    seam_length: float,
+    reset_mask: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Pure frontier-advance rule (unit-testable without a simulator).
+
+    The frontier advances toward ``s_tip`` only when ``gates_ok`` holds and the
+    tip's *lead* over the frontier is at most ``backlash`` (a lagging tip
+    re-cuts finished material: no advance, no penalty), by at most
+    ``max_step_advance`` per call. Monotone within an episode; ``reset_mask``
+    zeroes it first.
+    """
+    if reset_mask is not None:
+        frontier_m = torch.where(reset_mask, torch.zeros_like(frontier_m), frontier_m)
+    lead = s_tip - frontier_m
+    ok = gates_ok & (lead <= backlash)
+    advance = torch.clamp(lead, min=0.0, max=max_step_advance) * ok.to(frontier_m.dtype)
+    return torch.clamp(frontier_m + advance, min=0.0, max=seam_length)
+
+
+def evaluate_cut_sweep(env: ManagerBasedRLEnv, task_key: str) -> dict[str, torch.Tensor]:
+    """Advance (at most once per env step) and return the sweep signals.
+
+    Returns a dict with ``frontier_frac`` (E,), ``frontier_m`` (E,),
+    ``tip_w`` (E, 3), ``frontier_point_w`` (E, 3), ``ext_ok`` (E,) bool and
+    ``gates_ok`` (E,) bool. Repeated calls within one step return the memoized
+    result, so termination / reward / obs / vis terms stay consistent.
+    """
+    spec = get_cut_sweep_spec(task_key)
+    state = _get_sweep_state(env, task_key)
+    device = env.device
+
+    episode_length_buf = _get_episode_length_buf(env)
+    if (
+        state.memo_out is not None
+        and episode_length_buf is not None
+        and isinstance(state.memo_step_buf, torch.Tensor)
+        and torch.equal(state.memo_step_buf, episode_length_buf)
+    ):
+        return state.memo_out
+
+    workpiece = env.scene[spec.workpiece_asset_name]
+    tool = env.scene[spec.tool_asset_name]
+    if state.tip_body_id is None:
+        body_ids, _ = tool.find_bodies(spec.tip_body_name)
+        if len(body_ids) != 1:
+            raise ValueError(f"Cut sweep '{task_key}': tip body '{spec.tip_body_name}' matched {len(body_ids)} bodies.")
+        state.tip_body_id = body_ids[0]
+    if state.ext_joint_cfg is None:
+        state.ext_joint_cfg = SceneEntityCfg(spec.tool_asset_name, joint_names=[spec.ext_joint_name])
+
+    from isaaclab.utils.math import quat_apply, quat_apply_inverse
+
+    # Blade-tip world point from the (non-root) blade link pose.
+    tip_pos_w = tool.data.body_pos_w[:, state.tip_body_id]
+    tip_quat_w = tool.data.body_quat_w[:, state.tip_body_id]
+    tip_offset = torch.tensor(spec.tip_local_offset, device=device, dtype=tip_pos_w.dtype)
+    tip_w = tip_pos_w + quat_apply(tip_quat_w, tip_offset.unsqueeze(0).expand(tip_pos_w.shape[0], -1))
+
+    # Tip in the workpiece root frame, decomposed against the seam segment.
+    wp_pos_w = workpiece.data.root_pos_w
+    wp_quat_w = workpiece.data.root_quat_w
+    tip_local = quat_apply_inverse(wp_quat_w, tip_w - wp_pos_w)
+    seam_start = torch.tensor(spec.seam_start_local, device=device, dtype=tip_w.dtype)
+    seam_end = torch.tensor(spec.seam_end_local, device=device, dtype=tip_w.dtype)
+    seam_vec = seam_end - seam_start
+    seam_length = float(torch.linalg.norm(seam_vec))
+    seam_dir = seam_vec / max(seam_length, 1e-9)
+    rel = tip_local - seam_start.unsqueeze(0)
+    s_tip = torch.clamp(rel @ seam_dir, min=0.0, max=seam_length)
+    perp = rel - s_tip.unsqueeze(-1) * seam_dir.unsqueeze(0)
+    lateral = torch.linalg.norm(perp[:, :2], dim=1)
+    z_tip = tip_local[:, 2]
+
+    # Gates.
+    ext_ok = joint_relative_move(
+        env, threshold=spec.ext_threshold, asset_cfg=state.ext_joint_cfg, mode="progress", op=">=", reduce="any"
+    )
+    in_slot = (lateral <= spec.lateral_tol) & (z_tip <= spec.z_surface_local - spec.min_dip)
+    gates_ok = ext_ok & in_slot
+    aligned = None
+    if spec.align_axis_tool_local is not None:
+        # Heading-only alignment: project the tool axis into the workpiece
+        # frame, drop z, and compare its direction with the (horizontal) seam
+        # direction. A near-vertical tool has no meaningful heading -> not aligned.
+        tool_axis_w = asset_axis_w(env, asset_cfg=SceneEntityCfg(spec.tool_asset_name), axis_local=spec.align_axis_tool_local)
+        tool_axis_wp = quat_apply_inverse(wp_quat_w, tool_axis_w)
+        tool_axis_h = tool_axis_wp.clone()
+        tool_axis_h[:, 2] = 0.0
+        seam_dir_h = seam_dir.clone()
+        seam_dir_h[2] = 0.0
+        seam_dir_h = seam_dir_h / torch.clamp(torch.linalg.norm(seam_dir_h), min=1e-9)
+        h_norm = torch.linalg.norm(tool_axis_h, dim=1)
+        cos = torch.abs(tool_axis_h @ seam_dir_h) / torch.clamp(h_norm, min=1e-9)
+        aligned = (h_norm > 0.3) & (cos >= spec.align_threshold_cos)
+        gates_ok = gates_ok & aligned
+
+    # Frontier update with per-env reset detection.
+    if state.frontier_m is None or state.frontier_m.shape[0] != env.num_envs:
+        state.frontier_m = torch.zeros(env.num_envs, device=device, dtype=tip_w.dtype)
+        state.last_step_buf = None
+    reset_mask = _compute_reset_mask(episode_length_buf, state.last_step_buf)
+    if episode_length_buf is not None:
+        state.last_step_buf = episode_length_buf.clone()
+    state.frontier_m = _advance_frontier(
+        state.frontier_m,
+        s_tip,
+        gates_ok,
+        backlash=spec.backlash,
+        max_step_advance=spec.max_step_advance,
+        seam_length=seam_length,
+        reset_mask=reset_mask,
+    )
+
+    frontier_point_local = seam_start.unsqueeze(0) + state.frontier_m.unsqueeze(-1) * seam_dir.unsqueeze(0)
+    frontier_point_w = wp_pos_w + quat_apply(wp_quat_w, frontier_point_local)
+
+    out = {
+        "frontier_m": state.frontier_m,
+        "frontier_frac": state.frontier_m / max(seam_length, 1e-9),
+        "tip_w": tip_w,
+        "frontier_point_w": frontier_point_w,
+        "ext_ok": ext_ok,
+        "gates_ok": gates_ok,
+    }
+    if _CUT_DEBUG:
+        # Throttled per-gate trace for env 0 (set DEXVERSE_CUT_DEBUG=1), e.g. to
+        # see which gate stalls the frontier during a teleop drag.
+        state.debug_tick = getattr(state, "debug_tick", 0) + 1
+        if state.debug_tick % _CUT_DEBUG_EVERY == 0:
+            lead = float(s_tip[0] - state.frontier_m[0])
+            print(
+                f"[cut_sweep:{task_key}] frontier={float(out['frontier_frac'][0]):.3f} "
+                f"s_tip={float(s_tip[0]):.3f} lead={lead:+.3f} (backlash {spec.backlash}) "
+                f"lateral={float(lateral[0]):.4f}/{spec.lateral_tol} "
+                f"z_tip={float(z_tip[0]):.4f} (need<={spec.z_surface_local - spec.min_dip:.4f}) "
+                f"ext_ok={bool(ext_ok[0])} in_slot={bool(in_slot[0])} "
+                f"aligned={bool(aligned[0]) if spec.align_axis_tool_local is not None else 'n/a'} "
+                f"gates_ok={bool(gates_ok[0])}"
+            )
+    state.memo_out = out
+    state.memo_step_buf = episode_length_buf.clone() if episode_length_buf is not None else None
+    return out
+
+
+def cut_sweep_complete(env: ManagerBasedRLEnv, task_key: str, threshold: float | None = None) -> torch.Tensor:
+    """Per-env bool: the sweep frontier passed ``threshold`` (spec default) of the seam."""
+    out = evaluate_cut_sweep(env, task_key)
+    thr = get_cut_sweep_spec(task_key).complete_frac if threshold is None else threshold
+    return out["frontier_frac"] >= thr
+
+
+def cut_sweep_frontier(env: ManagerBasedRLEnv, task_key: str) -> torch.Tensor:
+    """Observation: sweep frontier fraction, shape (E, 1)."""
+    return evaluate_cut_sweep(env, task_key)["frontier_frac"].unsqueeze(-1)
+
+
+def cut_sweep_progress_reward(env: ManagerBasedRLEnv, task_key: str) -> torch.Tensor:
+    """Dense reward: frontier fraction in [0, 1] (monotone within an episode)."""
+    return evaluate_cut_sweep(env, task_key)["frontier_frac"]
+
+
+def cut_sweep_tip_tracking_reward(
+    env: ManagerBasedRLEnv,
+    task_key: str,
+    distance_gain: float = 10.0,
+    require_ext: bool = True,
+) -> torch.Tensor:
+    """Dense reward: ``exp(-gain * |tip - frontier_point|)``, optionally gated
+    on the blade-extension condition so tracking only pays with the blade out."""
+    out = evaluate_cut_sweep(env, task_key)
+    dist = torch.linalg.norm(out["tip_w"] - out["frontier_point_w"], dim=1)
+    reward = torch.exp(-distance_gain * dist)
+    if require_ext:
+        reward = reward * out["ext_ok"].to(reward.dtype)
+    return reward
+
+
+class cut_frontier_vis(ManagerTermBase):
+    """Sphere marker riding the cut frontier, red -> green with progress.
+
+    Visualization-only side-effect term (wire into ``observations.scene_vis``).
+    Unlike the physical tape/seam target, this is a debug progress cue and
+    follows the shared v1 camera-visibility policy.
+    """
+
+    def __init__(self, cfg, env: ManagerBasedRLEnv):
+        super().__init__(cfg, env)
+
+        import isaaclab.sim as sim_utils
+        from isaaclab.markers import VisualizationMarkers, VisualizationMarkersCfg
+
+        self._task_key: str = cfg.params["task_key"]
+        radius = float(cfg.params.get("radius", 0.02))
+        opacity = float(cfg.params.get("opacity", 0.8))
+        self._visible = bool(cfg.params.get("visible", True))
+        num_steps = max(int(cfg.params.get("num_color_steps", 11)), 2)
+        prim_path_prefix = cfg.params.get("prim_path_prefix", "/Visuals/CutFrontierMarker")
+        self._num_steps = num_steps
+
+        markers = {}
+        for i in range(num_steps):
+            t = i / (num_steps - 1)
+            markers[f"step_{i}"] = sim_utils.SphereCfg(
+                radius=radius,
+                visual_material=sim_utils.PreviewSurfaceCfg(diffuse_color=(1.0 - t, t, 0.0), opacity=opacity),
+            )
+        self._visualizer = VisualizationMarkers(VisualizationMarkersCfg(prim_path=prim_path_prefix, markers=markers))
+        from dexverse.baseline_v1.visual_purpose import hide_marker_from_cameras
+
+        hide_marker_from_cameras(self._visualizer)
+        self._visualizer.set_visibility(self._visible)
+
+    def __call__(
+        self,
+        env: ManagerBasedRLEnv,
+        task_key: str | None = None,
+        radius: float | None = None,
+        opacity: float | None = None,
+        visible: bool | None = None,
+        num_color_steps: int | None = None,
+        prim_path_prefix: str | None = None,
+    ) -> torch.Tensor:
+        if visible is not None and bool(visible) != self._visible:
+            self._visible = bool(visible)
+            self._visualizer.set_visibility(self._visible)
+        if not self._visible:
+            return torch.zeros(env.num_envs, 0, device=env.device)
+
+        out = evaluate_cut_sweep(env, task_key or self._task_key)
+        progress = out["frontier_frac"]
+        indices = (progress * (self._num_steps - 1)).round().clamp(0, self._num_steps - 1).to(torch.int32)
+        self._visualizer.visualize(translations=out["frontier_point_w"], marker_indices=indices)
+        return torch.zeros(env.num_envs, 0, device=env.device)
+
+
+# =====================================================================================
+# Blade contact (scissors)
+# =====================================================================================
+
+
+def point_in_asset_zone(
+    env: ManagerBasedRLEnv,
+    point_asset_cfg: SceneEntityCfg,
+    point_local_offset: tuple[float, float, float],
+    zone_asset_cfg: SceneEntityCfg,
+    zone_center_local: tuple[float, float, float],
+    zone_half_extents: tuple[float, float, float],
+) -> torch.Tensor:
+    """Per-env bool: a fixed local point on one asset lies inside an
+    axis-aligned box in another asset's root frame."""
+    from isaaclab.utils.math import quat_apply, quat_apply_inverse
+
+    point_asset = env.scene[point_asset_cfg.name]
+    zone_asset = env.scene[zone_asset_cfg.name]
+    dtype = point_asset.data.root_pos_w.dtype
+    offset = torch.tensor(point_local_offset, device=env.device, dtype=dtype)
+    point_w = point_asset.data.root_pos_w + quat_apply(
+        point_asset.data.root_quat_w, offset.unsqueeze(0).expand(env.num_envs, -1)
+    )
+    point_zone = quat_apply_inverse(zone_asset.data.root_quat_w, point_w - zone_asset.data.root_pos_w)
+    center = torch.tensor(zone_center_local, device=env.device, dtype=dtype)
+    half = torch.tensor(zone_half_extents, device=env.device, dtype=dtype)
+    return (torch.abs(point_zone - center) <= half).all(dim=1)
+
+
+def scissors_inner_blades_touch_strip(
+    env: ManagerBasedRLEnv,
+    scissors_cfg: SceneEntityCfg,
+    blade_body_names: tuple[str, str],
+    blade_zone_center_local: tuple[float, float, float],
+    blade_zone_half_extents: tuple[float, float, float],
+    strip_cfg: SceneEntityCfg,
+    strip_box_center_local: tuple[float, float, float],
+    strip_box_half_extents: tuple[float, float, float],
+    contact_inflation: tuple[float, float, float] = (0.004, 0.004, 0.006),
+    strip_edge_margin_xy: tuple[float, float] = (0.0, 0.0),
+    hold_steps: int = 1,
+) -> torch.Tensor:
+    """Per-env bool: both inward-facing blade regions touch the paper strip.
+
+    Each blade region is an oriented box in that blade link's frame. Contact is
+    the exact box-vs-box overlap test (15-axis separating-axis theorem) against
+    the paper box, inflated by ``contact_inflation`` to include resting contact
+    without requiring penetration. This continuous rectangle avoids the dead
+    gaps created by discrete edge samples. Requiring both blade regions and
+    their centres to lie on opposite sides of the paper plane excludes handles,
+    fingers, a single blade resting on the paper, and scissors laid flat on
+    top. The midpoint between those centres must also pass through an inset
+    region of the paper's top face, so touching a vertical side edge does not
+    count. The valid configuration must persist for ``hold_steps`` consecutive
+    environment steps; losing contact resets that counter. The stage graph
+    separately requires that the scissors were opened earlier.
+    """
+    from isaaclab.utils.math import quat_apply
+
+    scissors = env.scene[scissors_cfg.name]
+    strip = env.scene[strip_cfg.name]
+    dtype = strip.data.root_pos_w.dtype
+    zone_center = torch.tensor(blade_zone_center_local, device=env.device, dtype=dtype)
+    zone_half = torch.tensor(blade_zone_half_extents, device=env.device, dtype=dtype)
+    strip_center_local = torch.tensor(strip_box_center_local, device=env.device, dtype=dtype)
+    strip_half = torch.tensor(strip_box_half_extents, device=env.device, dtype=dtype) + torch.tensor(
+        contact_inflation, device=env.device, dtype=dtype
+    )
+    strip_pos = strip.data.root_pos_w
+    strip_quat = strip.data.root_quat_w
+
+    basis = torch.eye(3, device=env.device, dtype=dtype)
+
+    def _box_axes(quat: torch.Tensor) -> torch.Tensor:
+        E = quat.shape[0]
+        return quat_apply(
+            quat.unsqueeze(1).expand(-1, 3, -1).reshape(-1, 4),
+            basis.unsqueeze(0).expand(E, -1, -1).reshape(-1, 3),
+        ).reshape(E, 3, 3)
+
+    def _obb_overlap(
+        center_a: torch.Tensor,
+        axes_a: torch.Tensor,
+        half_a: torch.Tensor,
+        center_b: torch.Tensor,
+        axes_b: torch.Tensor,
+        half_b: torch.Tensor,
+    ) -> torch.Tensor:
+        """Batched 3-D OBB overlap using all 15 separating axes."""
+        # R[i,j] = A_i dot B_j; translation expressed in A's frame.
+        R = torch.einsum("eik,ejk->eij", axes_a, axes_b)
+        abs_R = R.abs() + 1.0e-6  # stabilize nearly parallel cross axes
+        delta = center_b - center_a
+        t = torch.einsum("eik,ek->ei", axes_a, delta)
+
+        overlap = (t.abs() <= half_a + torch.einsum("eij,j->ei", abs_R, half_b)).all(dim=1)
+        t_b = torch.einsum("ei,eij->ej", t, R)
+        overlap &= (t_b.abs() <= half_b + torch.einsum("eij,i->ej", abs_R, half_a)).all(dim=1)
+
+        for i in range(3):
+            i1, i2 = (i + 1) % 3, (i + 2) % 3
+            for j in range(3):
+                j1, j2 = (j + 1) % 3, (j + 2) % 3
+                lhs = (t[:, i2] * R[:, i1, j] - t[:, i1] * R[:, i2, j]).abs()
+                rhs = (
+                    half_a[i1] * abs_R[:, i2, j]
+                    + half_a[i2] * abs_R[:, i1, j]
+                    + half_b[j1] * abs_R[:, i, j2]
+                    + half_b[j2] * abs_R[:, i, j1]
+                )
+                overlap &= lhs <= rhs
+        return overlap
+
+    strip_center = strip_pos + quat_apply(
+        strip_quat, strip_center_local.unsqueeze(0).expand(env.num_envs, -1)
+    )
+    strip_axes = _box_axes(strip_quat)
+
+    blade_contact = []
+    blade_side = []
+    blade_center_in_strip = []
+    for body_name in blade_body_names:
+        body_ids, _ = scissors.find_bodies(body_name)
+        bid = body_ids[0]
+        pos = scissors.data.body_pos_w[:, bid]  # (E, 3)
+        quat = scissors.data.body_quat_w[:, bid]
+        blade_center = pos + quat_apply(quat, zone_center.unsqueeze(0).expand(env.num_envs, -1))
+        # Signed distance along the paper normal. A real snip places one inner
+        # edge on either side; broad-side contact puts both on the same side.
+        blade_center_strip = torch.einsum("eik,ek->ei", strip_axes, blade_center - strip_center)
+        blade_side.append(blade_center_strip[:, 2])
+        blade_center_in_strip.append(blade_center_strip)
+        blade_contact.append(
+            _obb_overlap(blade_center, _box_axes(quat), zone_half, strip_center, strip_axes, strip_half)
+        )
+    opposite_sides = blade_side[0] * blade_side[1] <= 0.0
+    cut_midpoint = 0.5 * (blade_center_in_strip[0] + blade_center_in_strip[1])
+    edge_margin = torch.tensor(strip_edge_margin_xy, device=env.device, dtype=dtype)
+    cut_half_xy = torch.clamp(
+        torch.tensor(strip_box_half_extents[:2], device=env.device, dtype=dtype) - edge_margin,
+        min=0.0,
+    )
+    through_top_face = (cut_midpoint[:, :2].abs() <= cut_half_xy).all(dim=1)
+    valid_contact = blade_contact[0] & blade_contact[1] & opposite_sides & through_top_face
+
+    hold_steps = max(int(hold_steps), 1)
+    if hold_steps == 1:
+        return valid_contact
+
+    # Keep this small temporal latch outside the scene: the predicate may be
+    # read by termination, reward, and observations in one simulation step, so
+    # memoize by episode_length_buf to increment at most once per step.
+    cache = getattr(env, "_scissors_strip_contact_hold_cache", None)
+    if cache is None:
+        cache = {}
+        env._scissors_strip_contact_hold_cache = cache
+    cache_key = (scissors_cfg.name, strip_cfg.name, tuple(strip_edge_margin_xy), hold_steps)
+    state = cache.get(cache_key)
+    current_step = env.episode_length_buf.to(dtype=torch.long)
+    if state is None or state["count"].shape != current_step.shape:
+        state = {
+            "count": torch.zeros_like(current_step),
+            "last_step": None,
+            "memo": None,
+        }
+        cache[cache_key] = state
+
+    last_step = state["last_step"]
+    reset_rows = current_step == 0
+    if isinstance(last_step, torch.Tensor):
+        reset_rows &= last_step != 0
+        if torch.equal(last_step, current_step):
+            return state["memo"]
+    state["count"][reset_rows] = 0
+    state["count"] = torch.where(valid_contact, state["count"] + 1, torch.zeros_like(state["count"]))
+    state["memo"] = state["count"] >= hold_steps
+    state["last_step"] = current_step.clone()
+    return state["memo"]

--- a/source/dexverse/dexverse/baseline_v1/mdp/door_latch.py
+++ b/source/dexverse/dexverse/baseline_v1/mdp/door_latch.py
@@ -1,0 +1,75 @@
+"""Contact-based cutaway-door evaluation; the catch is entirely physical."""
+
+import torch
+
+from dexverse.teleop_utils.door_latch_progress import new_door_latch_state, update_door_latch_state
+
+BUFFER = "cutaway_door_progress"
+
+
+def reset_door_latch(env, env_ids, buffer_name=BUFFER, door_preload_angle=-0.20):
+    state = getattr(env, buffer_name, None)
+    if state is None:
+        state = new_door_latch_state(env.num_envs, env.device)
+        setattr(env, buffer_name, state)
+    ids = slice(None) if env_ids is None else env_ids
+    state[ids] = 0
+    state[ids, 5] = -1
+    asset = env.scene["articulation"]
+    # Reset explicit drive targets too: never retain teleop/debug targets.
+    targets = torch.zeros_like(asset.data.default_joint_pos[ids])
+    targets[:, asset.find_joints("door_hinge")[0][0]] = door_preload_angle
+    asset.set_joint_position_target(targets, env_ids=env_ids)
+    asset.set_joint_velocity_target(torch.zeros_like(asset.data.default_joint_vel[ids]), env_ids=env_ids)
+
+
+def _force(env, name):
+    matrix = env.scene[name].data.force_matrix_w
+    if matrix is None:
+        raise RuntimeError(f"{name} requires filtered contact reporting")
+    return matrix.norm(dim=-1).reshape(env.num_envs, -1).sum(dim=1)
+
+
+def _evaluate(env, hold_steps=60):
+    asset = env.scene["articulation"]
+    door_id = asset.find_joints("door_hinge")[0][0]
+    latch_id = asset.find_joints("latch_slide")[0][0]
+    q, qd = asset.data.joint_pos, asset.data.joint_vel
+    # Actual filtered forces, not broad proximity regions. A nearby released
+    # hand is allowed, but supporting either the panel or catch resets dwell.
+    door_touch = _force(env, "door_hand_contact") > 0.01
+    latch_touch = _force(env, "latch_hand_contact") > 0.01
+    clear = ~door_touch & ~latch_touch
+    state = getattr(env, BUFFER, None)
+    if state is None:
+        state = new_door_latch_state(env.num_envs, env.device)
+        setattr(env, BUFFER, state)
+    return update_door_latch_state(
+        state,
+        env.episode_length_buf,
+        q[:, door_id],
+        qd[:, door_id],
+        q[:, latch_id],
+        qd[:, latch_id],
+        door_touch,
+        _force(env, "door_latch_contact") > 0.05,
+        clear,
+        hold_steps,
+    )
+
+
+def door_latched_and_released(env, hold_steps=60):
+    return _evaluate(env, hold_steps)[0]
+
+
+def door_reclosed(env, hold_steps=60):
+    return _evaluate(env, hold_steps)[1]
+
+
+def door_latch_signals(env, hold_steps=60):
+    state = getattr(env, BUFFER, None)
+    if state is None:
+        return torch.zeros((env.num_envs, 5), device=env.device)
+    result = state[:, :5].clone()
+    result[:, 4] /= float(hold_steps)
+    return result

--- a/source/dexverse/dexverse/baseline_v1/mdp/events.py
+++ b/source/dexverse/dexverse/baseline_v1/mdp/events.py
@@ -1,0 +1,384 @@
+# Copyright (c) 2025-2026, The DexVerse Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# Copyright (c) 2022-2025, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Event helpers for manager-based tasks (non-termination utilities)."""
+
+from __future__ import annotations
+
+import torch
+from isaaclab.assets import Articulation, RigidObject
+from isaaclab.envs import ManagerBasedRLEnv
+from isaaclab.managers import SceneEntityCfg
+from isaaclab.utils.math import quat_apply, quat_from_euler_xyz, quat_mul
+
+from .resets import reset_joints_to_init
+from .utils import resolve_env_ids, resolve_joint_ids
+
+
+def reset_board_and_switch_xy(
+    env: ManagerBasedRLEnv,
+    env_ids: torch.Tensor,
+    board_cfg: SceneEntityCfg,
+    switch_cfg: SceneEntityCfg,
+    switch_joint_cfg: SceneEntityCfg | None = None,
+    xy_range: tuple[float, float] | None = None,
+    x_range: tuple[float, float] | None = None,
+    y_range: tuple[float, float] | None = None,
+):
+    """Reset board and switch positions with the same XY offset."""
+    board = env.scene[board_cfg.name]
+    switch = env.scene[switch_cfg.name]
+
+    env_ids_t = resolve_env_ids(env, env_ids)
+
+    if x_range is None:
+        if xy_range is None:
+            raise ValueError("reset_board_and_switch_xy requires xy_range or x_range.")
+        x_range = xy_range
+    if y_range is None:
+        if xy_range is None:
+            raise ValueError("reset_board_and_switch_xy requires xy_range or y_range.")
+        y_range = xy_range
+
+    # sample offsets
+    offsets = torch.zeros((env_ids_t.shape[0], 3), device=env.device)
+    offsets[:, 0].uniform_(x_range[0], x_range[1])
+    offsets[:, 1].uniform_(y_range[0], y_range[1])
+
+    board_state = board.data.default_root_state[env_ids_t].clone()
+    switch_state = switch.data.default_root_state[env_ids_t].clone()
+    board_state[:, :3] += offsets
+    switch_state[:, :3] += offsets
+
+    board.write_root_pose_to_sim(board_state[:, 0:7], env_ids=env_ids_t)
+    switch.write_root_pose_to_sim(switch_state[:, 0:7], env_ids=env_ids_t)
+    if switch_joint_cfg is not None:
+        reset_joints_to_init(env, env_ids_t, switch_joint_cfg)
+
+
+def reset_book_cluster_and_command(
+    env: ManagerBasedRLEnv,
+    env_ids: torch.Tensor,
+    object_cfg: SceneEntityCfg,
+    left_book_cfg: SceneEntityCfg,
+    right_book_cfg: SceneEntityCfg,
+    y_range: tuple[float, float],
+    target_pos_x: float,
+    target_pos_z: float,
+    target_pitch_rad: float,
+    command_name: str = "object_pose",
+):
+    """Reset the three-book cluster with one shared Y offset and align the goal pose."""
+    env_ids_t = resolve_env_ids(env, env_ids)
+    num_envs = env_ids_t.shape[0]
+    if num_envs == 0:
+        return
+
+    y_offsets = torch.empty(num_envs, device=env.device)
+    y_offsets.uniform_(y_range[0], y_range[1])
+
+    target_book = env.scene[object_cfg.name]
+    left_book = env.scene[left_book_cfg.name]
+    right_book = env.scene[right_book_cfg.name]
+
+    # Target book is dynamic: reset pose and zero velocity.
+    target_root_state = target_book.data.default_root_state[env_ids_t].clone()
+    target_root_state[:, 1] += y_offsets
+    target_root_state[:, 7:13] = 0.0
+    target_book.write_root_pose_to_sim(target_root_state[:, 0:7], env_ids=env_ids_t)
+    target_book.write_root_velocity_to_sim(target_root_state[:, 7:13], env_ids=env_ids_t)
+
+    # Neighbor books are kinematic in this task: only write pose.
+    for asset in (left_book, right_book):
+        root_state = asset.data.default_root_state[env_ids_t].clone()
+        root_state[:, 1] += y_offsets
+        asset.write_root_pose_to_sim(root_state[:, 0:7], env_ids=env_ids_t)
+
+    command_term = env.command_manager.get_term(command_name)
+    command_term.pose_command_b[env_ids_t, 0] = target_pos_x
+    command_term.pose_command_b[env_ids_t, 1] = y_offsets
+    command_term.pose_command_b[env_ids_t, 2] = target_pos_z
+
+    zero = torch.zeros(num_envs, device=env.device)
+    quat = quat_from_euler_xyz(zero, torch.full_like(zero, target_pitch_rad), zero)
+    command_term.pose_command_b[env_ids_t, 3:] = quat
+
+    if getattr(command_term.cfg, "use_world_frame", False):
+        command_term.pose_command_w[env_ids_t, :3] = command_term.pose_command_b[env_ids_t, :3]
+        command_term.pose_command_w[env_ids_t, 3:] = quat
+
+
+def set_joint_position_limits(
+    env: ManagerBasedRLEnv,
+    env_ids: torch.Tensor | None,
+    asset_cfg: SceneEntityCfg = SceneEntityCfg("object"),
+    lower: float | None = None,
+    upper: float | None = None,
+):
+    """Set joint position limits for an articulation asset."""
+    asset: Articulation = env.scene[asset_cfg.name]
+    joint_ids = resolve_joint_ids(env, asset_cfg)
+    env_ids_t = resolve_env_ids(env, env_ids)
+
+    limits = asset.data.default_joint_pos_limits.clone()
+    # Outer-product indexing: (N, 1) x (1, J) -> every selected joint of every
+    # selected env. Pairing the two flat index tensors directly only works when
+    # one of them has length 1 (e.g. single-env teleop).
+    joint_ids_t = torch.as_tensor(joint_ids, device=limits.device, dtype=torch.long)
+    rows, cols = env_ids_t[:, None], joint_ids_t[None, :]
+    if lower is not None:
+        limits[rows, cols, 0] = lower
+    if upper is not None:
+        limits[rows, cols, 1] = upper
+    # Clamp to PhysX supported range for revolute joints.
+    limits[rows, cols] = torch.clamp(limits[rows, cols], -2.0 * torch.pi, 2.0 * torch.pi)
+    limits_to_set = limits[rows, cols]  # (N, J, 2)
+    asset.write_joint_position_limit_to_sim(
+        limits_to_set, joint_ids=joint_ids, env_ids=env_ids_t, warn_limit_violation=False
+    )
+
+
+def _resolve_single_body_index(env: ManagerBasedRLEnv, body_cfg: SceneEntityCfg) -> int:
+    """Body index for a one-body ``SceneEntityCfg`` (resolving it lazily if needed)."""
+    if isinstance(body_cfg.body_ids, slice):
+        body_cfg.resolve(env.scene)
+    ids = body_cfg.body_ids
+    if isinstance(ids, slice):
+        return 0
+    return int(ids[0])
+
+
+def over_center_hinge(
+    env: ManagerBasedRLEnv,
+    env_ids: torch.Tensor | None,
+    asset_cfg: SceneEntityCfg,
+    over_center_angle: float,
+    close_torque: float,
+    lock_torque: float,
+    transition_width: float = 0.05,
+    open_sign: float = -1.0,
+    max_open_angle: float | None = None,
+):
+    """Bistable ("over-centre") spring on a revolute joint, as a per-step feed-forward torque.
+
+    Emulates a stapler-style top hinge. With ``phi`` the opening angle:
+
+    * ``phi < over_center_angle - transition_width``: constant closing torque
+      ``close_torque`` (N*m) -- the spring pulls the top shut all the way.
+    * the ``transition_width`` band below the over-centre angle: the closing
+      torque ramps linearly to zero (a sharp crossing, so the part's own
+      gravity cannot pull it open before the over-centre point).
+    * ``phi >= over_center_angle``: a small opening ``lock_torque`` growing
+      toward the open limit parks the joint there ("locked open") until it is
+      pushed back across the over-centre angle, whereupon the closing branch
+      takes over and snaps it shut.
+
+    ``open_sign`` is the joint direction that opens (``-1`` when the open limit
+    is the negative one). Register with ``mode="interval",
+    interval_range_s=(0.0, 0.0)`` so it runs every env step, and give the joint
+    an implicit actuator with ``stiffness=0`` (the effort target is applied as
+    feed-forward on top of the drive's damping / joint friction).
+    ``max_open_angle`` defaults to the joint's opening limit.
+    """
+    asset: Articulation = env.scene[asset_cfg.name]
+    joint_ids = resolve_joint_ids(env, asset_cfg)
+    env_ids_t = resolve_env_ids(env, env_ids)
+    if env_ids_t.shape[0] == 0:
+        return
+    joint_ids_t = torch.as_tensor(joint_ids, device=env.device, dtype=torch.long)
+    q = asset.data.joint_pos[env_ids_t][:, joint_ids_t]
+    phi = open_sign * q  # opening angle >= 0
+    if max_open_angle is None:
+        limits = asset.data.joint_pos_limits[env_ids_t][:, joint_ids_t]  # (N, J, 2)
+        phi_max = limits[..., 1] if open_sign > 0 else -limits[..., 0]
+    else:
+        phi_max = torch.full_like(phi, float(max_open_angle))
+    oc = float(over_center_angle)
+    w = max(float(transition_width), 1e-6)
+    closing = float(close_torque) * torch.clamp((oc - phi) / w, 0.0, 1.0)
+    lock_frac = torch.clamp((phi - oc) / (phi_max - oc).clamp_min(1e-6), 0.0, 1.0)
+    locking = float(lock_torque) * lock_frac
+    tau = torch.where(phi < oc, -open_sign * closing, open_sign * locking)
+    asset.set_joint_effort_target(tau, joint_ids=joint_ids, env_ids=env_ids_t)
+
+
+def follow_body_when_stage(
+    env: ManagerBasedRLEnv,
+    env_ids: torch.Tensor | None,
+    target_cfg: SceneEntityCfg,
+    body_cfg: SceneEntityCfg,
+    task_key: str,
+    stage_name: str,
+    local_pos: tuple[float, float, float] = (0.0, 0.0, 0.0),
+    local_quat: tuple[float, float, float, float] = (1.0, 0.0, 0.0, 0.0),
+    persistent: bool = True,
+):
+    """Pin a rigid object to an articulation body once a stage-graph stage is latched.
+
+    Every env step (register with ``mode="interval", interval_range_s=(0, 0)``)
+    the envs whose ``stage_name`` flag is set get ``target`` teleported to
+    ``body`` pose * (``local_pos``, ``local_quat``) with zero velocity -- a
+    "seated" object riding its holder (e.g. a loaded staple strip in a
+    magazine, standing in for the follower spring). Envs where the stage is
+    not (yet) reached are untouched.
+    """
+    from .stage_machine import evaluate_stage_graph
+
+    env_ids_t = resolve_env_ids(env, env_ids)
+    if env_ids_t.shape[0] == 0:
+        return
+    flags = evaluate_stage_graph(env, task_key=task_key, persistent=persistent)
+    mask = flags[stage_name][env_ids_t]
+    if not bool(mask.any()):
+        return
+    ids = env_ids_t[mask]
+    body: Articulation = env.scene[body_cfg.name]
+    bidx = _resolve_single_body_index(env, body_cfg)
+    body_pos = body.data.body_pos_w[ids, bidx]
+    body_quat = body.data.body_quat_w[ids, bidx]
+    n = ids.shape[0]
+    offset = torch.tensor(local_pos, device=env.device, dtype=body_pos.dtype).unsqueeze(0).expand(n, -1)
+    lq = torch.tensor(local_quat, device=env.device, dtype=body_quat.dtype).unsqueeze(0).expand(n, -1)
+    pos = body_pos + quat_apply(body_quat, offset)
+    quat = quat_mul(body_quat, lq)
+    target: RigidObject = env.scene[target_cfg.name]
+    target.write_root_pose_to_sim(torch.cat([pos, quat], dim=-1), env_ids=ids)
+    target.write_root_velocity_to_sim(torch.zeros((n, 6), device=env.device, dtype=pos.dtype), env_ids=ids)
+
+
+def hide_prims(
+    env: ManagerBasedRLEnv,
+    env_ids: torch.Tensor | None,
+    prim_paths: list[str],
+):
+    """Make USD prims invisible (per env; paths may contain ``{ENV_REGEX_NS}``).
+
+    Physics is unaffected (colliders keep colliding). Register as
+    ``mode="prestartup"`` or ``"startup"``; e.g. to blank out a part modelled
+    into an asset that the task supplies separately (a stapler's built-in
+    staple row when the task is to load one).
+    """
+    from isaaclab.sim.utils.queries import find_matching_prims
+    from pxr import UsdGeom
+
+    for pattern in prim_paths:
+        prims = find_matching_prims(pattern.format(ENV_REGEX_NS=env.scene.env_regex_ns))
+        if not prims:
+            raise RuntimeError(f"hide_prims: no prims match '{pattern}'.")
+        for prim in prims:
+            UsdGeom.Imageable(prim).MakeInvisible()
+
+def debug_reset_reasons(
+    env: ManagerBasedRLEnv,
+    env_ids: torch.Tensor,
+    prefix: str = "Env reset",
+):
+    """Print reset reasons for each env_id based on active termination terms."""
+    env_ids_t = resolve_env_ids(env, env_ids)
+
+    term_names = env.termination_manager.active_terms
+    if not term_names:
+        for env_id in env_ids_t.tolist():
+            print(f"{prefix} [{env_id}]: no termination terms active")
+        return
+
+    term_buffers = {name: env.termination_manager.get_term(name) for name in term_names}
+    for env_id in env_ids_t.tolist():
+        reasons = [name for name in term_names if bool(term_buffers[name][env_id])]
+        if reasons:
+            print(f"{prefix} [{env_id}]: {', '.join(reasons)}")
+        else:
+            print(f"{prefix} [{env_id}]: unknown")
+
+
+def update_articulation_root_from_object(
+    env: ManagerBasedRLEnv,
+    env_ids: torch.Tensor | None,
+    target_cfg: SceneEntityCfg,
+    source_cfg: SceneEntityCfg,
+):
+    """Update an articulation root pose to follow a rigid object's root pose."""
+    target: Articulation = env.scene[target_cfg.name]
+    source = env.scene[source_cfg.name]
+
+    env_ids_t = resolve_env_ids(env, env_ids)
+
+    pos = source.data.root_pos_w[env_ids_t]
+    quat = source.data.root_quat_w[env_ids_t]
+    root_pose = torch.cat([pos, quat], dim=-1)
+    target.write_root_pose_to_sim(root_pose, env_ids=env_ids_t)
+
+
+def update_marker_from_body(
+    env: ManagerBasedRLEnv,
+    env_ids: torch.Tensor | None,
+    marker_cfg: SceneEntityCfg,
+    body_cfg: SceneEntityCfg,
+    offset: tuple[float, float, float] = (0.0, 0.0, 0.0),
+):
+    """Update a marker pose to follow a given articulation body with a local offset."""
+    marker: RigidObject = env.scene[marker_cfg.name]
+    asset: Articulation = env.scene[body_cfg.name]
+
+    if isinstance(body_cfg.body_ids, slice) and body_cfg.body_ids == slice(None) and body_cfg.body_names is not None:
+        body_cfg.resolve(env.scene)
+    body_ids = body_cfg.body_ids
+    if isinstance(body_ids, slice):
+        body_id = 0
+    else:
+        body_id = body_ids[0]
+
+    env_ids_t = resolve_env_ids(env, env_ids)
+
+    body_pose = asset.data.body_pose_w[env_ids_t, body_id]
+    offset_t = torch.tensor(offset, device=env.device, dtype=body_pose.dtype).unsqueeze(0).repeat(env_ids_t.shape[0], 1)
+    pos = body_pose[:, 0:3] + quat_apply(body_pose[:, 3:7], offset_t)
+    root_pose = torch.cat([pos, body_pose[:, 3:7]], dim=-1)
+    marker.write_root_pose_to_sim(root_pose, env_ids=env_ids_t)
+
+
+def filter_collision_pairs(
+    env: ManagerBasedRLEnv,
+    env_ids: torch.Tensor | None,
+    source_prim_path: str,
+    target_prim_paths: list[str],
+):
+    """Author PhysX filtered pairs so ``source_prim_path`` never collides with
+    ``target_prim_paths`` (same-env pairs only).
+
+    Must be registered with ``mode="prestartup"``: it edits the USD stage
+    (``UsdPhysics.FilteredPairsAPI``) and so has to run after scene cloning
+    but *before* PhysX parses the stage -- exactly when prestartup events run
+    (they also require ``replicate_physics=False``, the dexverse default).
+    Paths may contain ``{ENV_REGEX_NS}``; each matched source prim is paired
+    only with the target paths of its own ``env_N`` instance. Idempotent
+    (re-running rewrites the same relationship targets).
+    """
+    import re
+
+    from isaaclab.sim.utils.queries import find_matching_prims
+    from pxr import UsdPhysics
+
+    source_pattern = source_prim_path.format(ENV_REGEX_NS=env.scene.env_regex_ns)
+    env_prefix_re = re.compile(env.scene.env_regex_ns.replace(".*", "[0-9]+"))
+    prims = find_matching_prims(source_pattern)
+    if not prims:
+        raise RuntimeError(f"filter_collision_pairs: no prims match '{source_pattern}'.")
+    for prim in prims:
+        path = prim.GetPath().pathString
+        match = env_prefix_re.match(path)
+        if match is None:
+            raise RuntimeError(f"filter_collision_pairs: '{path}' is outside the env namespace.")
+        env_prefix = match.group(0)
+        api = UsdPhysics.FilteredPairsAPI.Apply(prim)
+        rel = api.CreateFilteredPairsRel()
+        rel.ClearTargets(True)
+        for target in target_prim_paths:
+            rel.AddTarget(target.format(ENV_REGEX_NS=env_prefix))

--- a/source/dexverse/dexverse/baseline_v1/mdp/observations.py
+++ b/source/dexverse/dexverse/baseline_v1/mdp/observations.py
@@ -1,0 +1,1823 @@
+# Copyright (c) 2025-2026, The DexVerse Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# Copyright (c) 2022-2025, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+from __future__ import annotations
+
+import torch
+from dexverse.baseline_v1.visual_purpose import hide_marker_from_cameras
+from isaaclab.assets import Articulation, RigidObject
+from isaaclab.envs import ManagerBasedRLEnv
+from isaaclab.managers import ManagerTermBase
+from isaaclab.managers import ObservationTermCfg as ObsTerm
+from isaaclab.managers import SceneEntityCfg
+from isaaclab.sensors import ContactSensorCfg
+from isaaclab.sensors.camera.utils import create_pointcloud_from_depth, transform_points
+from isaaclab.utils.math import (
+    quat_apply,
+    quat_apply_inverse,
+    quat_inv,
+    quat_mul,
+    subtract_frame_transforms,
+)
+
+from .utils import (
+    asset_axis_w,
+    axis_in_frame_from_quat,
+    axis_tilt_angle,
+    axis_to_plane_angle,
+    command_axis_w,
+    compute_body_pose_vel_b,
+    compute_body_state_b,
+    root_height_delta,
+    sample_object_point_cloud,
+)
+
+
+def object_pos_b(
+    env: ManagerBasedRLEnv,
+    robot_cfg: SceneEntityCfg = SceneEntityCfg("robot"),
+    object_cfg: SceneEntityCfg = SceneEntityCfg("object"),
+):
+    """Object position in the robot's root frame.
+
+    Args:
+        env: The environment.
+        robot_cfg: Scene entity for the robot (reference frame). Defaults to ``SceneEntityCfg("robot")``.
+        object_cfg: Scene entity for the object. Defaults to ``SceneEntityCfg("object")``.
+
+    Returns:
+        Tensor of shape ``(num_envs, 3)``: object position [x, y, z] expressed in the robot root frame.
+    """
+    robot: RigidObject = env.scene[robot_cfg.name]
+    object: RigidObject = env.scene[object_cfg.name]
+    return quat_apply_inverse(robot.data.root_quat_w, object.data.root_pos_w - robot.data.root_pos_w)
+
+
+def object_quat_b(
+    env: ManagerBasedRLEnv,
+    robot_cfg: SceneEntityCfg = SceneEntityCfg("robot"),
+    object_cfg: SceneEntityCfg = SceneEntityCfg("object"),
+) -> torch.Tensor:
+    """Object orientation in the robot's root frame.
+
+    Args:
+        env: The environment.
+        robot_cfg: Scene entity for the robot (reference frame). Defaults to ``SceneEntityCfg("robot")``.
+        object_cfg: Scene entity for the object. Defaults to ``SceneEntityCfg("object")``.
+
+    Returns:
+        Tensor of shape ``(num_envs, 4)``: object quaternion ``(w, x, y, z)`` in the robot root frame.
+    """
+    robot: RigidObject = env.scene[robot_cfg.name]
+    object: RigidObject = env.scene[object_cfg.name]
+    return quat_mul(quat_inv(robot.data.root_quat_w), object.data.root_quat_w)
+
+
+def object_height_delta(
+    env: ManagerBasedRLEnv,
+    object_cfg: SceneEntityCfg = SceneEntityCfg("object"),
+) -> torch.Tensor:
+    """Object root height risen above its spawn pose, in meters.
+
+    This is the same quantity the height-based lift success uses
+    (:func:`root_height_delta`): ``root_pos_w.z - default_root_state.z``. It is
+    observable / deployable (height above the known reset, equivalently above the
+    table), so it belongs in the ``state`` group, not ``privileged``. Named
+    distinctly from the ``object_lift_height`` *reward* to avoid an ``mdp``
+    namespace collision.
+
+    Returns:
+        Tensor of shape ``(num_envs, 1)``.
+    """
+    asset: RigidObject = env.scene[object_cfg.name]
+    return root_height_delta(asset).unsqueeze(1)
+
+
+def scalar_obs(
+    env: ManagerBasedRLEnv,
+    value: float | bool,
+) -> torch.Tensor:
+    """Constant scalar observation, repeated once per environment."""
+    return torch.full((env.num_envs, 1), float(value), device=env.device)
+
+
+def asset_pos_b(
+    env: ManagerBasedRLEnv,
+    robot_cfg: SceneEntityCfg = SceneEntityCfg("robot"),
+    asset_cfg: SceneEntityCfg = SceneEntityCfg("object"),
+) -> torch.Tensor:
+    """Asset root position in the robot's root frame."""
+    robot: RigidObject = env.scene[robot_cfg.name]
+    asset: Articulation | RigidObject = env.scene[asset_cfg.name]
+    return quat_apply_inverse(robot.data.root_quat_w, asset.data.root_pos_w - robot.data.root_pos_w)
+
+
+def object_local_point_pos_b(
+    env: ManagerBasedRLEnv,
+    local_offset: tuple[float, float, float] | None = None,
+    robot_cfg: SceneEntityCfg = SceneEntityCfg("robot"),
+    object_cfg: SceneEntityCfg = SceneEntityCfg("object"),
+) -> torch.Tensor:
+    """Position of an object-local functional point in the robot root frame."""
+    robot: RigidObject = env.scene[robot_cfg.name]
+    object: RigidObject = env.scene[object_cfg.name]
+    point_w = object.data.root_pos_w
+    if local_offset is not None:
+        offset = torch.as_tensor(local_offset, device=env.device, dtype=point_w.dtype)
+        offset = offset.unsqueeze(0).expand(env.num_envs, -1)
+        point_w = point_w + quat_apply(object.data.root_quat_w, offset)
+    return quat_apply_inverse(robot.data.root_quat_w, point_w - robot.data.root_pos_w)
+
+
+def object_up_b(
+    env: ManagerBasedRLEnv,
+    robot_cfg: SceneEntityCfg = SceneEntityCfg("robot"),
+    object_cfg: SceneEntityCfg = SceneEntityCfg("object"),
+) -> torch.Tensor:
+    """Object local +Z axis expressed in the robot's root frame."""
+    return object_rot_axis_b(env, axis_local=(0.0, 0.0, 1.0), robot_cfg=robot_cfg, object_cfg=object_cfg)
+
+
+def object_tilt_angle(
+    env: ManagerBasedRLEnv,
+    object_cfg: SceneEntityCfg = SceneEntityCfg("object"),
+) -> torch.Tensor:
+    """Angle (rad) between object's +Z axis and world +Z (0=up, pi=down)."""
+    object: RigidObject = env.scene[object_cfg.name]
+    return axis_tilt_angle(object.data.root_quat_w, axis_local=(0.0, 0.0, 1.0), world_axis=(0.0, 0.0, 1.0)).unsqueeze(1)
+
+
+def object_lin_vel_b(
+    env: ManagerBasedRLEnv,
+    robot_cfg: SceneEntityCfg = SceneEntityCfg("robot"),
+    object_cfg: SceneEntityCfg = SceneEntityCfg("object"),
+) -> torch.Tensor:
+    """Object linear velocity in the robot root frame."""
+    robot: RigidObject = env.scene[robot_cfg.name]
+    object: RigidObject = env.scene[object_cfg.name]
+    return quat_apply_inverse(robot.data.root_quat_w, object.data.root_lin_vel_w)
+
+
+def object_ang_vel_b(
+    env: ManagerBasedRLEnv,
+    robot_cfg: SceneEntityCfg = SceneEntityCfg("robot"),
+    object_cfg: SceneEntityCfg = SceneEntityCfg("object"),
+) -> torch.Tensor:
+    """Object angular velocity in the robot root frame."""
+    robot: RigidObject = env.scene[robot_cfg.name]
+    object: RigidObject = env.scene[object_cfg.name]
+    return quat_apply_inverse(robot.data.root_quat_w, object.data.root_ang_vel_w)
+
+
+def object_rot_axis_b(
+    env: ManagerBasedRLEnv,
+    axis_local: tuple[float, float, float] = (0.0, 0.0, 1.0),
+    robot_cfg: SceneEntityCfg = SceneEntityCfg("robot"),
+    object_cfg: SceneEntityCfg = SceneEntityCfg("object"),
+) -> torch.Tensor:
+    """Object local axis direction in the robot root frame."""
+    robot: RigidObject = env.scene[robot_cfg.name]
+    axis_w = asset_axis_w(env, asset_cfg=object_cfg, axis_local=axis_local)
+    return axis_in_frame_from_quat(axis_w, robot.data.root_quat_w)
+
+
+def target_rot_axis_b(
+    env: ManagerBasedRLEnv,
+    command_name: str,
+    axis_local: tuple[float, float, float] = (0.0, 0.0, 1.0),
+    robot_cfg: SceneEntityCfg = SceneEntityCfg("robot"),
+) -> torch.Tensor:
+    """Target local axis direction from pose command in the robot root frame."""
+    axis_w = command_axis_w(env, command_name=command_name, axis_local=axis_local, robot_cfg=robot_cfg)
+    robot: RigidObject = env.scene[robot_cfg.name]
+    return axis_in_frame_from_quat(axis_w, robot.data.root_quat_w)
+
+
+def body_state_b(
+    env: ManagerBasedRLEnv,
+    body_asset_cfg: SceneEntityCfg,
+    base_asset_cfg: SceneEntityCfg,
+) -> torch.Tensor:
+    """Body state (pos, quat, lin vel, ang vel) in the base asset's root frame.
+
+    The state for each body is stacked horizontally as
+    ``[position(3), quaternion(4)(wxyz), linvel(3), angvel(3)]`` and then concatenated over bodies.
+
+    Args:
+        env: The environment.
+        body_asset_cfg: Scene entity for the articulated body whose links are observed.
+        base_asset_cfg: Scene entity providing the reference (root) frame.
+
+    Returns:
+        Tensor of shape ``(num_envs, num_bodies * 13)`` with per-body states expressed in the base root frame.
+    """
+    out, _ = compute_body_state_b(env, body_asset_cfg=body_asset_cfg, base_asset_cfg=base_asset_cfg)
+    return out
+
+
+def body_pose_b(
+    env: ManagerBasedRLEnv,
+    body_asset_cfg: SceneEntityCfg,
+    base_asset_cfg: SceneEntityCfg,
+) -> torch.Tensor:
+    """Body pose (pos, quat) in the base asset's root frame — the velocity-free
+    half of :func:`body_state_b`, for the observable ``state`` group.
+
+    Per-body layout ``[position(3), quaternion(4)(wxyz)]`` concatenated over bodies.
+
+    Returns:
+        Tensor of shape ``(num_envs, num_bodies * 7)``.
+    """
+    pose_b, _, _ = compute_body_pose_vel_b(env, body_asset_cfg=body_asset_cfg, base_asset_cfg=base_asset_cfg)
+    return pose_b
+
+
+def body_vel_b(
+    env: ManagerBasedRLEnv,
+    body_asset_cfg: SceneEntityCfg,
+    base_asset_cfg: SceneEntityCfg,
+) -> torch.Tensor:
+    """Body velocity (lin, ang) in the base asset's root frame — the sim-only
+    half of :func:`body_state_b`, for the ``privileged`` group.
+
+    Per-body layout ``[linvel(3), angvel(3)]`` concatenated over bodies.
+
+    Returns:
+        Tensor of shape ``(num_envs, num_bodies * 6)``.
+    """
+    _, vel_b, _ = compute_body_pose_vel_b(env, body_asset_cfg=body_asset_cfg, base_asset_cfg=base_asset_cfg)
+    return vel_b
+
+
+class body_state_b_vis(ManagerTermBase):
+    """Body state with optional viewport visualization of observed body links.
+
+    The red sphere markers are off by default. The PointInstancer that backs
+    ``VisualizationMarkers`` isn't reliably hidden from RTX cameras by the
+    ``purpose=guide`` tag that ``hide_marker_from_cameras`` sets, so the
+    markers were contaminating RGB observations / demos / training images.
+    To re-enable the viewport markers, pass ``"draw_markers": True`` in
+    ``ObsTerm.params``.
+    """
+
+    def __init__(self, cfg, env: ManagerBasedRLEnv):
+        super().__init__(cfg, env)
+        self.body_asset_cfg: SceneEntityCfg = cfg.params.get("body_asset_cfg", SceneEntityCfg("robot"))
+        self.base_asset_cfg: SceneEntityCfg = cfg.params.get("base_asset_cfg", SceneEntityCfg("robot"))
+        self.draw_markers: bool = bool(cfg.params.get("draw_markers", False))
+
+        self.visualizer = None
+        if self.draw_markers:
+            import isaaclab.sim as sim_utils
+            from isaaclab.markers import VisualizationMarkers, VisualizationMarkersCfg
+
+            marker_cfg = VisualizationMarkersCfg(
+                prim_path="/Visuals/BodyStateMarkers",
+                markers={
+                    "dot": sim_utils.SphereCfg(
+                        radius=0.01,
+                        visual_material=sim_utils.PreviewSurfaceCfg(diffuse_color=(1.0, 0.0, 0.0)),
+                    ),
+                },
+            )
+            self.visualizer = VisualizationMarkers(marker_cfg)
+            hide_marker_from_cameras(self.visualizer)
+
+    def __call__(
+        self,
+        env: ManagerBasedRLEnv,
+        body_asset_cfg: SceneEntityCfg = None,
+        base_asset_cfg: SceneEntityCfg = None,
+        draw_markers: bool = False,
+    ) -> torch.Tensor:
+        """Compute body state and (optionally) visualize body positions."""
+        body_asset_cfg = body_asset_cfg or self.body_asset_cfg
+        base_asset_cfg = base_asset_cfg or self.base_asset_cfg
+
+        out, body_pos_w_flat = compute_body_state_b(env, body_asset_cfg=body_asset_cfg, base_asset_cfg=base_asset_cfg)
+        if self.visualizer is not None:
+            self.visualizer.visualize(translations=body_pos_w_flat)
+        return out
+
+
+class robot_fingertips_vis(ManagerTermBase):
+    """Visualize robot fingertips with colored spheres matching human fingertips.
+
+    Colors match the retargeter visualization:
+    - thumb_fingertip: Red
+    - fingertip (index): Green
+    - fingertip_2 (middle): Blue
+    - fingertip_3 (ring): Yellow
+    - fingertip_4 (little/pinky): Magenta
+    """
+
+    def __init__(self, cfg, env: ManagerBasedRLEnv):
+        super().__init__(cfg, env)
+        self.body_asset_cfg: SceneEntityCfg = cfg.params.get("body_asset_cfg", SceneEntityCfg("robot"))
+
+        import isaaclab.sim as sim_utils
+        from isaaclab.markers import VisualizationMarkers, VisualizationMarkersCfg
+
+        # Create markers with colors matching human fingertips
+        marker_cfg = VisualizationMarkersCfg(
+            prim_path="/Visuals/RobotFingertipMarkers",
+            markers={
+                "thumb_tip": sim_utils.SphereCfg(
+                    radius=0.015,
+                    visual_material=sim_utils.PreviewSurfaceCfg(diffuse_color=(1.0, 0.0, 0.0)),  # Red for thumb
+                ),
+                "index_tip": sim_utils.SphereCfg(
+                    radius=0.015,
+                    visual_material=sim_utils.PreviewSurfaceCfg(diffuse_color=(0.0, 1.0, 0.0)),  # Green for index
+                ),
+                "middle_tip": sim_utils.SphereCfg(
+                    radius=0.015,
+                    visual_material=sim_utils.PreviewSurfaceCfg(diffuse_color=(0.0, 0.0, 1.0)),  # Blue for middle
+                ),
+                "ring_tip": sim_utils.SphereCfg(
+                    radius=0.015,
+                    visual_material=sim_utils.PreviewSurfaceCfg(diffuse_color=(1.0, 1.0, 0.0)),  # Yellow for ring
+                ),
+                "little_tip": sim_utils.SphereCfg(
+                    radius=0.015,
+                    visual_material=sim_utils.PreviewSurfaceCfg(
+                        diffuse_color=(1.0, 0.0, 1.0)
+                    ),  # Magenta for little/pinky
+                ),
+            },
+        )
+        self.visualizer = VisualizationMarkers(marker_cfg)
+        hide_marker_from_cameras(self.visualizer)
+
+        # Map robot fingertip body names to marker indices
+        # Using tip_head links: thumb_tip_head=0 (Red), index_tip_head=1 (Green), middle_tip_head=2 (Blue), ring_tip_head=3 (Yellow), little_tip_head=4 (Magenta)
+        # Also support standard naming conventions (thdistal, ffdistal, mfdistal, rfdistal, lfdistal for Shadow Hand)
+        self.fingertip_marker_map = {
+            "thumb_tip_head": 0,  # Red
+            "index_tip_head": 1,  # Green (index)
+            "middle_tip_head": 2,  # Blue (middle)
+            "ring_tip_head": 3,  # Yellow (ring)
+            "little_tip_head": 4,  # Magenta (little/pinky)
+            # Shadow Hand standard naming (fallback)
+            "thdistal": 0,  # Red (thumb)
+            "ffdistal": 1,  # Green (index/first finger)
+            "mfdistal": 2,  # Blue (middle finger)
+            "rfdistal": 3,  # Yellow (ring finger)
+            "lfdistal": 4,  # Magenta (little finger)
+        }
+
+    def __call__(
+        self,
+        env: ManagerBasedRLEnv,
+        body_asset_cfg: SceneEntityCfg = None,
+    ) -> torch.Tensor:
+        """Visualize robot fingertip positions with colored spheres."""
+        body_asset_cfg = body_asset_cfg or self.body_asset_cfg
+
+        body_asset: Articulation = env.scene[body_asset_cfg.name]
+        fingertip_body_names = body_asset_cfg.body_names
+
+        if fingertip_body_names is None or len(fingertip_body_names) == 0:
+            return torch.zeros(env.num_envs, 0, device=env.device)
+
+        # Debug: Print available body names and requested fingertip names (only once)
+        if not hasattr(self, "_debug_printed"):
+            import logging
+
+            logger = logging.getLogger(__name__)
+            logger.info(f"Robot fingertip visualization - Available body names: {body_asset.body_names}")
+            logger.info(f"Robot fingertip visualization - Requested fingertip names: {fingertip_body_names}")
+            self._debug_printed = True
+
+        # Get fingertip body indices
+        fingertip_body_ids = []
+        marker_indices_list = []
+        for idx, body_name in enumerate(fingertip_body_names):
+            if body_name in body_asset.body_names:
+                body_idx = body_asset.body_names.index(body_name)
+                fingertip_body_ids.append(body_idx)
+                # Get marker index: use mapping if available, otherwise use order (thumb=0, index=1, middle=2, ring=3, little=4)
+                marker_idx = self.fingertip_marker_map.get(body_name, min(idx, 4))
+                marker_indices_list.append(marker_idx)
+
+        if len(fingertip_body_ids) == 0:
+            return torch.zeros(env.num_envs, 0, device=env.device)
+
+        # Get fingertip positions in world frame
+        fingertip_pos_w = body_asset.data.body_pos_w[:, fingertip_body_ids]  # Shape: (num_envs, num_fingertips, 3)
+
+        # Flatten for visualization: (num_envs * num_fingertips, 3)
+        fingertip_pos_w_flat = fingertip_pos_w.view(-1, 3)
+
+        # Create marker indices tensor: (num_envs * num_fingertips,)
+        marker_indices = torch.tensor(marker_indices_list * env.num_envs, dtype=torch.int32, device=env.device)
+
+        # Visualize fingertip positions with colored markers
+        self.visualizer.visualize(translations=fingertip_pos_w_flat, marker_indices=marker_indices)
+
+        # Return empty tensor (this is just for visualization, not used as observation)
+        return torch.zeros(env.num_envs, 0, device=env.device)
+
+
+class object_world_frame_vis(ManagerTermBase):
+    """Visualize object and world frames with axis markers."""
+
+    def __init__(self, cfg, env: ManagerBasedRLEnv):
+        super().__init__(cfg, env)
+        self.object_cfg: SceneEntityCfg = cfg.params.get("object_cfg", SceneEntityCfg("object"))
+        frame_scale = cfg.params.get("frame_scale", (0.08, 0.08, 0.08))
+
+        from isaaclab.markers import VisualizationMarkers
+        from isaaclab.markers.config import FRAME_MARKER_CFG
+
+        frame_cfg = FRAME_MARKER_CFG.copy()
+        frame_cfg.markers["frame"].scale = frame_scale
+        self.object_frame_vis = VisualizationMarkers(frame_cfg.replace(prim_path="/Visuals/ObjectFrame"))
+        hide_marker_from_cameras(self.object_frame_vis)
+        self.world_frame_vis = VisualizationMarkers(frame_cfg.replace(prim_path="/Visuals/WorldFrame"))
+        hide_marker_from_cameras(self.world_frame_vis)
+
+    def __call__(
+        self,
+        env: ManagerBasedRLEnv,
+        object_cfg: SceneEntityCfg | None = None,
+    ) -> torch.Tensor:
+        object_cfg = object_cfg or self.object_cfg
+        obj: RigidObject = env.scene[object_cfg.name]
+
+        marker_indices = torch.zeros(env.num_envs, dtype=torch.int32, device=env.device)
+        self.object_frame_vis.visualize(
+            translations=obj.data.root_pos_w,
+            orientations=obj.data.root_quat_w,
+            marker_indices=marker_indices,
+        )
+
+        world_pos = env.scene.env_origins
+        world_quat = (
+            torch.tensor([1.0, 0.0, 0.0, 0.0], device=env.device, dtype=world_pos.dtype)
+            .unsqueeze(0)
+            .repeat(env.num_envs, 1)
+        )
+        self.world_frame_vis.visualize(
+            translations=world_pos,
+            orientations=world_quat,
+            marker_indices=marker_indices,
+        )
+
+        return torch.zeros(env.num_envs, 0, device=env.device)
+
+
+class insertion_reference_points_vis(ManagerTermBase):
+    """Visualize held insertion point and fixed target point as debug markers."""
+
+    def __init__(self, cfg, env: ManagerBasedRLEnv):
+        super().__init__(cfg, env)
+        self._held_cfg: SceneEntityCfg = cfg.params.get("held_cfg", SceneEntityCfg("object"))
+        self._fixed_cfg: SceneEntityCfg = cfg.params.get("fixed_cfg", SceneEntityCfg("target"))
+        self._held_local_offset = cfg.params.get("held_local_offset", (0.0, 0.0, 0.0))
+        self._target_local_offset = cfg.params.get("target_local_offset", (0.0, 0.0, 0.0))
+        self._radius = float(cfg.params.get("radius", 0.01))
+        self._prim_path = cfg.params.get("prim_path", "/Visuals/InsertionReferencePoints")
+        self._held_color = cfg.params.get("held_color", (0.95, 0.15, 0.15))
+        self._target_color = cfg.params.get("target_color", (0.10, 0.85, 0.20))
+        self._show_frames = bool(cfg.params.get("show_frames", False))
+        self._frame_scale = cfg.params.get("frame_scale", (0.04, 0.04, 0.04))
+        self._held_frame_prim_path = cfg.params.get("held_frame_prim_path", f"{self._prim_path}/HeldFrame")
+        self._target_frame_prim_path = cfg.params.get("target_frame_prim_path", f"{self._prim_path}/TargetFrame")
+
+        import isaaclab.sim as sim_utils
+        from isaaclab.markers import VisualizationMarkers, VisualizationMarkersCfg
+
+        marker_cfg = VisualizationMarkersCfg(
+            prim_path=self._prim_path,
+            markers={
+                "held": sim_utils.SphereCfg(
+                    radius=self._radius,
+                    visual_material=sim_utils.PreviewSurfaceCfg(diffuse_color=self._held_color),
+                ),
+                "target": sim_utils.SphereCfg(
+                    radius=self._radius,
+                    visual_material=sim_utils.PreviewSurfaceCfg(diffuse_color=self._target_color),
+                ),
+            },
+        )
+        self._visualizer = VisualizationMarkers(marker_cfg)
+        hide_marker_from_cameras(self._visualizer)
+
+        self._held_frame_visualizer = None
+        self._target_frame_visualizer = None
+        if self._show_frames:
+            from isaaclab.markers.config import FRAME_MARKER_CFG
+
+            frame_cfg = FRAME_MARKER_CFG.copy()
+            frame_cfg.markers["frame"].scale = self._frame_scale
+            self._held_frame_visualizer = VisualizationMarkers(frame_cfg.replace(prim_path=self._held_frame_prim_path))
+            hide_marker_from_cameras(self._held_frame_visualizer)
+            self._target_frame_visualizer = VisualizationMarkers(
+                frame_cfg.replace(prim_path=self._target_frame_prim_path)
+            )
+            hide_marker_from_cameras(self._target_frame_visualizer)
+
+    def __call__(
+        self,
+        env: ManagerBasedRLEnv,
+        held_cfg: SceneEntityCfg | None = None,
+        fixed_cfg: SceneEntityCfg | None = None,
+        held_local_offset: tuple[float, float, float] | None = None,
+        target_local_offset: tuple[float, float, float] | None = None,
+        radius: float | None = None,
+        prim_path: str | None = None,
+        held_color: tuple[float, float, float] | None = None,
+        target_color: tuple[float, float, float] | None = None,
+        show_frames: bool | None = None,
+        frame_scale: tuple[float, float, float] | None = None,
+        held_frame_prim_path: str | None = None,
+        target_frame_prim_path: str | None = None,
+    ) -> torch.Tensor:
+        _ = (
+            radius,
+            prim_path,
+            held_color,
+            target_color,
+            show_frames,
+            frame_scale,
+            held_frame_prim_path,
+            target_frame_prim_path,
+        )
+        held_cfg = held_cfg or self._held_cfg
+        fixed_cfg = fixed_cfg or self._fixed_cfg
+        held_local_offset = held_local_offset or self._held_local_offset
+        target_local_offset = target_local_offset or self._target_local_offset
+
+        held: Articulation | RigidObject = env.scene[held_cfg.name]
+        fixed: Articulation | RigidObject = env.scene[fixed_cfg.name]
+
+        held_offset = torch.tensor(held_local_offset, device=env.device, dtype=held.data.root_pos_w.dtype)
+        held_offset = held_offset.unsqueeze(0).repeat(env.num_envs, 1)
+        target_offset = torch.tensor(target_local_offset, device=env.device, dtype=fixed.data.root_pos_w.dtype)
+        target_offset = target_offset.unsqueeze(0).repeat(env.num_envs, 1)
+
+        held_point_w = held.data.root_pos_w + quat_apply(held.data.root_quat_w, held_offset)
+        target_point_w = fixed.data.root_pos_w + quat_apply(fixed.data.root_quat_w, target_offset)
+
+        translations = torch.cat([held_point_w, target_point_w], dim=0)
+        marker_indices = torch.cat(
+            [
+                torch.zeros(env.num_envs, dtype=torch.int32, device=env.device),
+                torch.ones(env.num_envs, dtype=torch.int32, device=env.device),
+            ],
+            dim=0,
+        )
+        self._visualizer.visualize(translations=translations, marker_indices=marker_indices)
+        if self._held_frame_visualizer is not None and self._target_frame_visualizer is not None:
+            frame_marker_indices = torch.zeros(env.num_envs, dtype=torch.int32, device=env.device)
+            self._held_frame_visualizer.visualize(
+                translations=held_point_w,
+                orientations=held.data.root_quat_w,
+                marker_indices=frame_marker_indices,
+            )
+            self._target_frame_visualizer.visualize(
+                translations=target_point_w,
+                orientations=fixed.data.root_quat_w,
+                marker_indices=frame_marker_indices,
+            )
+        return torch.zeros(env.num_envs, 0, device=env.device)
+
+
+class forbidden_zones_vis(ManagerTermBase):
+    """Render forbidden zones (red, semi-transparent) attached to the object frame.
+
+    Each zone is defined in the object's local frame; markers are repositioned
+    every step so they track the object as it moves. ``sphere_zones``,
+    ``box_zones``, and ``cylinder_zones`` use the same flat encoding as
+    :class:`success_no_forbidden_contact`.
+    """
+
+    def __init__(self, cfg, env: ManagerBasedRLEnv):
+        super().__init__(cfg, env)
+        sphere_zones = cfg.params.get("sphere_zones") or []
+        box_zones = cfg.params.get("box_zones") or []
+        cylinder_zones = cfg.params.get("cylinder_zones") or []
+        self.object_cfg: SceneEntityCfg = cfg.params.get("object_cfg", SceneEntityCfg("object"))
+        color = cfg.params.get("color", (0.9, 0.1, 0.1))
+        opacity = cfg.params.get("opacity", 0.4)
+        prim_path_prefix = cfg.params.get("prim_path_prefix", "/Visuals/ForbiddenZone")
+
+        import isaaclab.sim as sim_utils
+        from isaaclab.markers import VisualizationMarkers, VisualizationMarkersCfg
+
+        device = env.device
+        self._visualizers = []
+        centers = []
+        quats = []
+        identity_quat = (1.0, 0.0, 0.0, 0.0)
+
+        for i, zone in enumerate(sphere_zones):
+            cx, cy, cz, r = zone
+            mcfg = VisualizationMarkersCfg(
+                prim_path=f"{prim_path_prefix}/Sphere_{i}",
+                markers={
+                    "z": sim_utils.SphereCfg(
+                        radius=float(r),
+                        visual_material=sim_utils.PreviewSurfaceCfg(diffuse_color=tuple(color), opacity=float(opacity)),
+                    )
+                },
+            )
+            vis = VisualizationMarkers(mcfg)
+            hide_marker_from_cameras(vis)
+            self._visualizers.append(vis)
+            centers.append([float(cx), float(cy), float(cz)])
+            quats.append(identity_quat)
+
+        for i, zone in enumerate(box_zones):
+            cx, cy, cz, hx, hy, hz = zone
+            mcfg = VisualizationMarkersCfg(
+                prim_path=f"{prim_path_prefix}/Box_{i}",
+                markers={
+                    "z": sim_utils.CuboidCfg(
+                        size=(2.0 * float(hx), 2.0 * float(hy), 2.0 * float(hz)),
+                        visual_material=sim_utils.PreviewSurfaceCfg(diffuse_color=tuple(color), opacity=float(opacity)),
+                    )
+                },
+            )
+            vis = VisualizationMarkers(mcfg)
+            hide_marker_from_cameras(vis)
+            self._visualizers.append(vis)
+            centers.append([float(cx), float(cy), float(cz)])
+            quats.append(identity_quat)
+
+        for i, zone in enumerate(cylinder_zones):
+            if len(zone) == 5:
+                cx, cy, cz, r, half_height = zone
+                quat = identity_quat
+            elif len(zone) == 9:
+                cx, cy, cz, r, half_height, qw, qx, qy, qz = zone
+                quat = (float(qw), float(qx), float(qy), float(qz))
+            else:
+                raise ValueError(
+                    "Cylinder zones must be (cx, cy, cz, radius, half_height) "
+                    "or (cx, cy, cz, radius, half_height, qw, qx, qy, qz)."
+                )
+            mcfg = VisualizationMarkersCfg(
+                prim_path=f"{prim_path_prefix}/Cylinder_{i}",
+                markers={
+                    "z": sim_utils.CylinderCfg(
+                        radius=float(r),
+                        height=2.0 * float(half_height),
+                        visual_material=sim_utils.PreviewSurfaceCfg(diffuse_color=tuple(color), opacity=float(opacity)),
+                    )
+                },
+            )
+            vis = VisualizationMarkers(mcfg)
+            hide_marker_from_cameras(vis)
+            self._visualizers.append(vis)
+            centers.append([float(cx), float(cy), float(cz)])
+            quats.append(quat)
+
+        if centers:
+            self._centers_obj = torch.tensor(centers, device=device, dtype=torch.float32)
+            self._quats_obj = torch.tensor(quats, device=device, dtype=torch.float32)
+            quat_norm = torch.linalg.norm(self._quats_obj, dim=-1, keepdim=True)
+            identity = torch.tensor(identity_quat, device=device, dtype=torch.float32)
+            self._quats_obj = torch.where(
+                quat_norm > 1.0e-8,
+                self._quats_obj / quat_norm.clamp_min(1.0e-8),
+                identity.expand_as(self._quats_obj),
+            )
+        else:
+            self._centers_obj = torch.zeros(0, 3, device=device)
+            self._quats_obj = torch.zeros(0, 4, device=device)
+
+    def __call__(
+        self,
+        env: ManagerBasedRLEnv,
+        sphere_zones: list | None = None,
+        box_zones: list | None = None,
+        cylinder_zones: list | None = None,
+        object_cfg: SceneEntityCfg | None = None,
+        color: tuple[float, float, float] | None = None,
+        opacity: float | None = None,
+        prim_path_prefix: str | None = None,
+    ) -> torch.Tensor:
+        if not self._visualizers:
+            return torch.zeros(env.num_envs, 0, device=env.device)
+
+        object_cfg = object_cfg or self.object_cfg
+        obj: RigidObject = env.scene[object_cfg.name]
+        obj_pos_w = obj.data.root_pos_w  # (E, 3)
+        obj_quat_w = obj.data.root_quat_w  # (E, 4)
+
+        Z = self._centers_obj.shape[0]
+        E = env.num_envs
+        centers_e = self._centers_obj.unsqueeze(0).expand(E, -1, -1)  # (E, Z, 3)
+        quat_e = obj_quat_w.unsqueeze(1).expand(-1, Z, -1).reshape(-1, 4)
+        rotated = quat_apply(quat_e, centers_e.reshape(-1, 3)).reshape(E, Z, 3)
+        world_centers = obj_pos_w.unsqueeze(1) + rotated  # (E, Z, 3)
+
+        marker_indices = torch.zeros(E, dtype=torch.int32, device=env.device)
+        for z_idx, viz in enumerate(self._visualizers):
+            zone_quat_obj = self._quats_obj[z_idx].unsqueeze(0).expand(E, -1)
+            zone_quat_w = quat_mul(obj_quat_w, zone_quat_obj)
+            viz.visualize(
+                translations=world_centers[:, z_idx, :],
+                orientations=zone_quat_w,
+                marker_indices=marker_indices,
+            )
+
+        return torch.zeros(env.num_envs, 0, device=env.device)
+
+
+class contact_zones_vis(forbidden_zones_vis):
+    """Render designated contact zones attached to the object frame."""
+
+
+class object_point_cloud_b(ManagerTermBase):
+    """Object surface point cloud expressed in a reference asset's root frame.
+
+    Points are pre-sampled on the object's surface in its local frame and transformed to world,
+    then into the reference (e.g., robot) root frame. Optionally visualizes the points.
+
+    Args (from ``cfg.params``):
+        object_cfg: Scene entity for the object to sample. Defaults to ``SceneEntityCfg("object")``.
+        ref_asset_cfg: Scene entity providing the reference frame. Defaults to ``SceneEntityCfg("robot")``.
+        num_points: Number of points to sample on the object surface. Defaults to ``10``.
+        visualize: Whether to draw markers for the points. Defaults to ``True``.
+        static: If ``True``, cache world-space points on reset and reuse them (no per-step resampling).
+
+    Returns (from ``__call__``):
+        If ``flatten=False``: tensor of shape ``(num_envs, num_points, 3)``.
+        If ``flatten=True``: tensor of shape ``(num_envs, 3 * num_points)``.
+    """
+
+    def __init__(self, cfg, env: ManagerBasedRLEnv):
+        super().__init__(cfg, env)
+
+        self.object_cfg: SceneEntityCfg = cfg.params.get("object_cfg", SceneEntityCfg("object"))
+        self.ref_asset_cfg: SceneEntityCfg = cfg.params.get("ref_asset_cfg", SceneEntityCfg("robot"))
+        num_points: int = cfg.params.get("num_points", 10)
+        self.object: RigidObject = env.scene[self.object_cfg.name]
+        self.ref_asset: Articulation = env.scene[self.ref_asset_cfg.name]
+        # lazy initialize visualizer and point cloud
+        if cfg.params.get("visualize", True):
+            from isaaclab.markers import VisualizationMarkers
+            from isaaclab.markers.config import RAY_CASTER_MARKER_CFG
+
+            ray_cfg = RAY_CASTER_MARKER_CFG.replace(prim_path="/Visuals/ObservationPointCloud")
+            ray_cfg.markers["hit"].radius = 0.0025
+            self.visualizer = VisualizationMarkers(ray_cfg)
+            hide_marker_from_cameras(self.visualizer)
+        self.points_local = sample_object_point_cloud(
+            env.num_envs, num_points, self.object.cfg.prim_path, device=env.device
+        )
+        self.points_w = torch.zeros_like(self.points_local)
+
+    def __call__(
+        self,
+        env: ManagerBasedRLEnv,
+        ref_asset_cfg: SceneEntityCfg = SceneEntityCfg("robot"),
+        object_cfg: SceneEntityCfg = SceneEntityCfg("object"),
+        num_points: int = 10,
+        flatten: bool = False,
+        visualize: bool = True,
+    ):
+        """Compute the object point cloud in the reference asset's root frame.
+
+        Note:
+            Points are pre-sampled at initialization using ``self.num_points``; the ``num_points`` argument is
+            kept for API symmetry and does not change the sampled set at runtime.
+
+        Args:
+            env: The environment.
+            ref_asset_cfg: Reference frame provider (root). Defaults to ``SceneEntityCfg("robot")``.
+            object_cfg: Object to sample. Defaults to ``SceneEntityCfg("object")``.
+            num_points: Unused at runtime; see note above.
+            flatten: If ``True``, return a flattened tensor ``(num_envs, 3 * num_points)``.
+            visualize: If ``True``, draw markers for the points.
+
+        Returns:
+            Tensor of shape ``(num_envs, num_points, 3)`` or flattened if requested.
+        """
+        ref_pos_w = self.ref_asset.data.root_pos_w.unsqueeze(1).repeat(1, num_points, 1)
+        ref_quat_w = self.ref_asset.data.root_quat_w.unsqueeze(1).repeat(1, num_points, 1)
+
+        object_pos_w = self.object.data.root_pos_w.unsqueeze(1).repeat(1, num_points, 1)
+        object_quat_w = self.object.data.root_quat_w.unsqueeze(1).repeat(1, num_points, 1)
+        # apply rotation + translation
+        self.points_w = quat_apply(object_quat_w, self.points_local) + object_pos_w
+        if visualize:
+            self.visualizer.visualize(translations=self.points_w.view(-1, 3))
+        object_point_cloud_pos_b, _ = subtract_frame_transforms(ref_pos_w, ref_quat_w, self.points_w, None)
+
+        return object_point_cloud_pos_b.view(env.num_envs, -1) if flatten else object_point_cloud_pos_b
+
+
+class camera_point_cloud_w(ManagerTermBase):
+    """World-frame point cloud derived from the camera depth image.
+
+    Unlike ``object_point_cloud_b``, this term does not use ground-truth object geometry. It
+    back-projects the rendered depth image so the result naturally reflects occlusions and only
+    includes surfaces visible to the camera. The output is downsampled or padded to a fixed size.
+
+    Args (from ``cfg.params``):
+        sensor_cfg: Scene entity for the camera sensor. Defaults to ``SceneEntityCfg("tiled_camera")``.
+        table_cfg: Scene entity for the table used to derive a default crop box. Defaults to ``SceneEntityCfg("table")``.
+        data_type: Depth buffer to back-project. Defaults to ``"distance_to_image_plane"``.
+        num_points: Number of points returned per environment. Defaults to ``4096``.
+        bbox_min_w: Explicit minimum world-frame XYZ crop bounds. If set together with ``bbox_max_w``, these
+            override the table-derived crop box.
+        bbox_max_w: Explicit maximum world-frame XYZ crop bounds. If set together with ``bbox_min_w``, these
+            override the table-derived crop box.
+        table_xy_inset: Optional XY inset applied symmetrically to the table bounds. Defaults to ``0.0``.
+        table_z_min_offset: Offset above the table top used as the crop-box floor. Defaults to ``0.01``.
+        table_z_max_offset: Offset above the table top used as the crop-box ceiling. Defaults to ``0.60``.
+        flatten: If ``True``, return ``(num_envs, 3 * num_points)``. Otherwise return
+            ``(num_envs, num_points, 3)``.
+        visualize: Whether to draw the sampled world-frame points. Defaults to ``False``.
+    """
+
+    def __init__(self, cfg, env: ManagerBasedRLEnv):
+        super().__init__(cfg, env)
+        if cfg.params.get("visualize", False):
+            from isaaclab.markers import VisualizationMarkers
+            from isaaclab.markers.config import RAY_CASTER_MARKER_CFG
+
+            marker_cfg = RAY_CASTER_MARKER_CFG.replace(prim_path="/Visuals/CameraPointCloud")
+            marker_cfg.markers["hit"].radius = 0.002
+            self.visualizer = VisualizationMarkers(marker_cfg)
+            hide_marker_from_cameras(self.visualizer)
+
+    @staticmethod
+    def _sample_or_pad_points(points_w: torch.Tensor, num_points: int) -> torch.Tensor:
+        """Return exactly ``num_points`` world-frame points."""
+        points_w = points_w.reshape(-1, 3)
+        if points_w.shape[0] == 0:
+            return torch.zeros((num_points, 3), device=points_w.device, dtype=points_w.dtype)
+        if points_w.shape[0] >= num_points:
+            indices = torch.randperm(points_w.shape[0], device=points_w.device)[:num_points]
+            return points_w[indices]
+        pad_indices = torch.randint(points_w.shape[0], (num_points - points_w.shape[0],), device=points_w.device)
+        return torch.cat((points_w, points_w[pad_indices]), dim=0)
+
+    @staticmethod
+    def _filter_points_in_aabb(
+        points_w: torch.Tensor,
+        bbox_min_w: tuple[float, float, float] | None,
+        bbox_max_w: tuple[float, float, float] | None,
+    ) -> torch.Tensor:
+        """Keep only points inside the provided world-frame axis-aligned bounding box."""
+        if bbox_min_w is None or bbox_max_w is None:
+            return points_w
+
+        bbox_min = torch.tensor(bbox_min_w, device=points_w.device, dtype=points_w.dtype)
+        bbox_max = torch.tensor(bbox_max_w, device=points_w.device, dtype=points_w.dtype)
+        in_bounds = torch.logical_and(points_w >= bbox_min, points_w <= bbox_max).all(dim=1)
+        return points_w[in_bounds]
+
+    @staticmethod
+    def _compute_table_aabb(
+        table: RigidObject,
+        env_id: int,
+        device: str,
+        dtype: torch.dtype,
+        table_xy_inset: float,
+        table_z_min_offset: float,
+        table_z_max_offset: float,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Compute a world-frame crop box from the table pose and configured table size."""
+        table_size = torch.tensor(table.cfg.spawn.size, device=device, dtype=dtype)
+        table_pos_w = table.data.root_pos_w[env_id]
+        half_extent_xy = table_size[:2] * 0.5 - table_xy_inset
+        table_top_z = table_pos_w[2] + table_size[2] * 0.5
+
+        bbox_min = torch.stack((
+            table_pos_w[0] - half_extent_xy[0],
+            table_pos_w[1] - half_extent_xy[1],
+            table_top_z + table_z_min_offset,
+        ))
+        bbox_max = torch.stack((
+            table_pos_w[0] + half_extent_xy[0],
+            table_pos_w[1] + half_extent_xy[1],
+            table_top_z + table_z_max_offset,
+        ))
+        return bbox_min, bbox_max
+
+    def __call__(
+        self,
+        env: ManagerBasedRLEnv,
+        sensor_cfg: SceneEntityCfg = SceneEntityCfg("tiled_camera"),
+        table_cfg: SceneEntityCfg = SceneEntityCfg("table"),
+        data_type: str = "distance_to_image_plane",
+        num_points: int = 4096,
+        bbox_min_w: tuple[float, float, float] | None = None,
+        bbox_max_w: tuple[float, float, float] | None = None,
+        table_xy_inset: float = 0.0,
+        table_z_min_offset: float = 0.01,
+        table_z_max_offset: float = 0.60,
+        flatten: bool = False,
+        visualize: bool = False,
+    ) -> torch.Tensor:
+        """Compute a fixed-size world-frame point cloud from the camera depth image."""
+        camera = env.scene[sensor_cfg.name]
+        table = env.scene[table_cfg.name]
+        depth_images = camera.data.output[data_type]
+        point_cloud_w = torch.zeros((env.num_envs, num_points, 3), device=env.device, dtype=depth_images.dtype)
+
+        for env_id in range(env.num_envs):
+            depth_image = depth_images[env_id]
+            if depth_image.ndim == 3 and depth_image.shape[-1] == 1:
+                depth_image = depth_image.squeeze(-1)
+
+            visible_points_w = create_pointcloud_from_depth(
+                intrinsic_matrix=camera.data.intrinsic_matrices[env_id],
+                depth=depth_image,
+                position=camera.data.pos_w[env_id],
+                orientation=camera.data.quat_w_ros[env_id],
+                device=env.device,
+            ).reshape(-1, 3)
+            visible_points_w = visible_points_w[torch.isfinite(visible_points_w).all(dim=1)]
+            if bbox_min_w is None or bbox_max_w is None:
+                bbox_min_tensor, bbox_max_tensor = self._compute_table_aabb(
+                    table=table,
+                    env_id=env_id,
+                    device=env.device,
+                    dtype=visible_points_w.dtype,
+                    table_xy_inset=table_xy_inset,
+                    table_z_min_offset=table_z_min_offset,
+                    table_z_max_offset=table_z_max_offset,
+                )
+                visible_points_w = visible_points_w[
+                    torch.logical_and(visible_points_w >= bbox_min_tensor, visible_points_w <= bbox_max_tensor).all(
+                        dim=1
+                    )
+                ]
+            else:
+                visible_points_w = self._filter_points_in_aabb(visible_points_w, bbox_min_w, bbox_max_w)
+            point_cloud_w[env_id] = self._sample_or_pad_points(visible_points_w, num_points)
+
+        if visualize and hasattr(self, "visualizer"):
+            self.visualizer.visualize(translations=point_cloud_w.reshape(-1, 3))
+
+        return point_cloud_w.view(env.num_envs, -1) if flatten else point_cloud_w
+
+
+class merged_camera_point_cloud_w(camera_point_cloud_w):
+    """World-frame point cloud merged from several camera depth images.
+
+    Behaves like :class:`camera_point_cloud_w`, but back-projects the depth images from
+    multiple cameras, unions their visible world-frame points, applies one shared crop
+    box, and downsamples/pads the union to ``num_points``. Merging complementary views
+    fills occlusions that any single camera misses.
+
+    Args (from ``cfg.params``):
+        sensor_cfgs: Scene entities for the camera sensors to merge. Defaults to
+            ``[SceneEntityCfg("tiled_camera")]``.
+        table_cfg, data_type, num_points, bbox_min_w, bbox_max_w, table_xy_inset,
+        table_z_min_offset, table_z_max_offset, flatten, visualize: Identical to
+        :class:`camera_point_cloud_w`.
+    """
+
+    def __init__(self, cfg, env: ManagerBasedRLEnv):
+        # Skip camera_point_cloud_w.__init__ so the visualizer uses a distinct prim path.
+        ManagerTermBase.__init__(self, cfg, env)
+        if cfg.params.get("visualize", False):
+            from isaaclab.markers import VisualizationMarkers
+            from isaaclab.markers.config import RAY_CASTER_MARKER_CFG
+
+            marker_cfg = RAY_CASTER_MARKER_CFG.replace(prim_path="/Visuals/MergedCameraPointCloud")
+            marker_cfg.markers["hit"].radius = 0.002
+            self.visualizer = VisualizationMarkers(marker_cfg)
+            hide_marker_from_cameras(self.visualizer)
+
+    def __call__(
+        self,
+        env: ManagerBasedRLEnv,
+        sensor_cfgs: list[SceneEntityCfg] | None = None,
+        table_cfg: SceneEntityCfg = SceneEntityCfg("table"),
+        data_type: str = "distance_to_image_plane",
+        num_points: int = 4096,
+        bbox_min_w: tuple[float, float, float] | None = None,
+        bbox_max_w: tuple[float, float, float] | None = None,
+        table_xy_inset: float = 0.0,
+        table_z_min_offset: float = 0.01,
+        table_z_max_offset: float = 0.60,
+        flatten: bool = False,
+        visualize: bool = False,
+    ) -> torch.Tensor:
+        """Compute a fixed-size world-frame point cloud merged across cameras."""
+        if sensor_cfgs is None:
+            sensor_cfgs = [SceneEntityCfg("tiled_camera")]
+        cameras = [env.scene[sensor_cfg.name] for sensor_cfg in sensor_cfgs]
+        table = env.scene[table_cfg.name]
+        dtype = cameras[0].data.output[data_type].dtype
+        point_cloud_w = torch.zeros((env.num_envs, num_points, 3), device=env.device, dtype=dtype)
+
+        for env_id in range(env.num_envs):
+            per_camera_points = []
+            for camera in cameras:
+                depth_image = camera.data.output[data_type][env_id]
+                if depth_image.ndim == 3 and depth_image.shape[-1] == 1:
+                    depth_image = depth_image.squeeze(-1)
+
+                points_w = create_pointcloud_from_depth(
+                    intrinsic_matrix=camera.data.intrinsic_matrices[env_id],
+                    depth=depth_image,
+                    position=camera.data.pos_w[env_id],
+                    orientation=camera.data.quat_w_ros[env_id],
+                    device=env.device,
+                ).reshape(-1, 3)
+                per_camera_points.append(points_w[torch.isfinite(points_w).all(dim=1)])
+
+            visible_points_w = torch.cat(per_camera_points, dim=0)
+            if bbox_min_w is None or bbox_max_w is None:
+                bbox_min_tensor, bbox_max_tensor = self._compute_table_aabb(
+                    table=table,
+                    env_id=env_id,
+                    device=env.device,
+                    dtype=visible_points_w.dtype,
+                    table_xy_inset=table_xy_inset,
+                    table_z_min_offset=table_z_min_offset,
+                    table_z_max_offset=table_z_max_offset,
+                )
+                visible_points_w = visible_points_w[
+                    torch.logical_and(visible_points_w >= bbox_min_tensor, visible_points_w <= bbox_max_tensor).all(
+                        dim=1
+                    )
+                ]
+            else:
+                visible_points_w = self._filter_points_in_aabb(visible_points_w, bbox_min_w, bbox_max_w)
+            point_cloud_w[env_id] = self._sample_or_pad_points(visible_points_w, num_points)
+
+        if visualize and hasattr(self, "visualizer"):
+            self.visualizer.visualize(translations=point_cloud_w.reshape(-1, 3))
+
+        return point_cloud_w.view(env.num_envs, -1) if flatten else point_cloud_w
+
+
+class camera_point_cloud_c(ManagerTermBase):
+    """Camera-frame point cloud derived from the camera depth image.
+
+    This term back-projects depth into camera coordinates (ROS camera convention).
+    For table/bbox cropping compatibility, points are temporarily transformed to world
+    for mask computation, but the returned points remain in camera frame.
+    """
+
+    def __init__(self, cfg, env: ManagerBasedRLEnv):
+        super().__init__(cfg, env)
+        if cfg.params.get("visualize", False):
+            from isaaclab.markers import VisualizationMarkers
+            from isaaclab.markers.config import RAY_CASTER_MARKER_CFG
+
+            marker_cfg = RAY_CASTER_MARKER_CFG.replace(prim_path="/Visuals/CameraPointCloudCameraFrame")
+            marker_cfg.markers["hit"].radius = 0.002
+            self.visualizer = VisualizationMarkers(marker_cfg)
+
+    @staticmethod
+    def _sample_or_pad_points(points_c: torch.Tensor, num_points: int) -> torch.Tensor:
+        points_c = points_c.reshape(-1, 3)
+        if points_c.shape[0] == 0:
+            return torch.zeros((num_points, 3), device=points_c.device, dtype=points_c.dtype)
+        if points_c.shape[0] >= num_points:
+            indices = torch.randperm(points_c.shape[0], device=points_c.device)[:num_points]
+            return points_c[indices]
+        pad_indices = torch.randint(points_c.shape[0], (num_points - points_c.shape[0],), device=points_c.device)
+        return torch.cat((points_c, points_c[pad_indices]), dim=0)
+
+    @staticmethod
+    def _compute_table_aabb(
+        table: RigidObject,
+        env_id: int,
+        device: str,
+        dtype: torch.dtype,
+        table_xy_inset: float,
+        table_z_min_offset: float,
+        table_z_max_offset: float,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        table_size = torch.tensor(table.cfg.spawn.size, device=device, dtype=dtype)
+        table_pos_w = table.data.root_pos_w[env_id]
+        half_extent_xy = table_size[:2] * 0.5 - table_xy_inset
+        table_top_z = table_pos_w[2] + table_size[2] * 0.5
+        bbox_min = torch.stack((
+            table_pos_w[0] - half_extent_xy[0],
+            table_pos_w[1] - half_extent_xy[1],
+            table_top_z + table_z_min_offset,
+        ))
+        bbox_max = torch.stack((
+            table_pos_w[0] + half_extent_xy[0],
+            table_pos_w[1] + half_extent_xy[1],
+            table_top_z + table_z_max_offset,
+        ))
+        return bbox_min, bbox_max
+
+    def __call__(
+        self,
+        env: ManagerBasedRLEnv,
+        sensor_cfg: SceneEntityCfg = SceneEntityCfg("tiled_camera"),
+        table_cfg: SceneEntityCfg = SceneEntityCfg("table"),
+        data_type: str = "distance_to_image_plane",
+        num_points: int = 4096,
+        bbox_min_w: tuple[float, float, float] | None = None,
+        bbox_max_w: tuple[float, float, float] | None = None,
+        table_xy_inset: float = 0.0,
+        table_z_min_offset: float = 0.01,
+        table_z_max_offset: float = 0.60,
+        flatten: bool = False,
+        visualize: bool = False,
+    ) -> torch.Tensor:
+        camera = env.scene[sensor_cfg.name]
+        table = env.scene[table_cfg.name]
+        depth_images = camera.data.output[data_type]
+        point_cloud_c = torch.zeros((env.num_envs, num_points, 3), device=env.device, dtype=depth_images.dtype)
+
+        for env_id in range(env.num_envs):
+            depth_image = depth_images[env_id]
+            if depth_image.ndim == 3 and depth_image.shape[-1] == 1:
+                depth_image = depth_image.squeeze(-1)
+
+            visible_points_c = create_pointcloud_from_depth(
+                intrinsic_matrix=camera.data.intrinsic_matrices[env_id],
+                depth=depth_image,
+                device=env.device,
+            ).reshape(-1, 3)
+
+            visible_points_c = visible_points_c[torch.isfinite(visible_points_c).all(dim=1)]
+            if visible_points_c.shape[0] == 0:
+                point_cloud_c[env_id] = self._sample_or_pad_points(visible_points_c, num_points)
+                continue
+
+            visible_points_w = transform_points(
+                visible_points_c,
+                position=camera.data.pos_w[env_id],
+                orientation=camera.data.quat_w_ros[env_id],
+                device=env.device,
+            ).reshape(-1, 3)
+            visible_points_w = visible_points_w[torch.isfinite(visible_points_w).all(dim=1)]
+
+            if bbox_min_w is None or bbox_max_w is None:
+                bbox_min_tensor, bbox_max_tensor = self._compute_table_aabb(
+                    table=table,
+                    env_id=env_id,
+                    device=env.device,
+                    dtype=visible_points_w.dtype,
+                    table_xy_inset=table_xy_inset,
+                    table_z_min_offset=table_z_min_offset,
+                    table_z_max_offset=table_z_max_offset,
+                )
+            else:
+                bbox_min_tensor = torch.tensor(bbox_min_w, device=env.device, dtype=visible_points_w.dtype)
+                bbox_max_tensor = torch.tensor(bbox_max_w, device=env.device, dtype=visible_points_w.dtype)
+
+            keep_mask = torch.logical_and(visible_points_w >= bbox_min_tensor, visible_points_w <= bbox_max_tensor).all(
+                dim=1
+            )
+            visible_points_c = visible_points_c[keep_mask]
+            point_cloud_c[env_id] = self._sample_or_pad_points(visible_points_c, num_points)
+
+        if visualize and hasattr(self, "visualizer"):
+            self.visualizer.visualize(translations=point_cloud_c.reshape(-1, 3))
+
+        return point_cloud_c.view(env.num_envs, -1) if flatten else point_cloud_c
+
+
+def fingers_contact_force_b(
+    env: ManagerBasedRLEnv,
+    contact_sensor_names: list[str],
+    asset_cfg: SceneEntityCfg = SceneEntityCfg("robot"),
+) -> torch.Tensor:
+    """base-frame contact forces from listed sensors, concatenated per env.
+
+    Args:
+        env: The environment.
+        contact_sensor_names: Names of contact sensors in ``env.scene.sensors`` to read.
+
+    Returns:
+        Tensor of shape ``(num_envs, 3 * num_sensors)`` with forces stacked horizontally as
+        ``[fx, fy, fz]`` per sensor.
+    """
+    force_w = [env.scene.sensors[name].data.force_matrix_w.view(env.num_envs, 3) for name in contact_sensor_names]
+    force_w = torch.stack(force_w, dim=1)  # Shape: (num_envs, num_sensors, 3)
+    robot: Articulation = env.scene[asset_cfg.name]
+    forces_b = quat_apply_inverse(robot.data.root_link_quat_w.unsqueeze(1).repeat(1, force_w.shape[1], 1), force_w)
+    # Flatten to (num_envs, 3 * num_sensors) for concatenation with other observations
+    return forces_b.view(env.num_envs, -1)
+
+
+def max_joint_pos(
+    env: ManagerBasedRLEnv,
+    asset_cfg: SceneEntityCfg = SceneEntityCfg("robot"),
+) -> torch.Tensor:
+    """Maximum absolute joint position for the given asset."""
+    asset: Articulation = env.scene[asset_cfg.name]
+    joint_pos = asset.data.joint_pos[:, asset_cfg.joint_ids]
+    max_abs = torch.abs(joint_pos).max(dim=1).values
+    return max_abs.unsqueeze(1)
+
+
+def max_joint_pos_signed(
+    env: ManagerBasedRLEnv,
+    asset_cfg: SceneEntityCfg = SceneEntityCfg("robot"),
+) -> torch.Tensor:
+    """Maximum joint position (signed) for the given asset."""
+    asset: Articulation = env.scene[asset_cfg.name]
+    joint_pos = asset.data.joint_pos[:, asset_cfg.joint_ids]
+    max_pos = joint_pos.max(dim=1).values
+    return max_pos.unsqueeze(1)
+
+
+class pour_progress_marker_vis(ManagerTermBase):
+    """Sphere marker at the goal that animates color from red → green as a
+    configured tilt criterion approaches its threshold.
+
+    Visualization helper for pour-style tasks. The sphere position tracks the
+    ``goal_asset_cfg`` root (i.e. the success marker / goal), and its color
+    is selected from a precomputed gradient based on the current tilt
+    progress — useful for "am I tilted enough yet?" feedback at a glance.
+
+    Progress is the *max* of the two tilt-criteria progresses that
+    :class:`mdp.lift_and_tilt_with_contact_zones` evaluates, each clamped to
+    ``[0, 1]``:
+
+    * Primary axis-vs-axis: ``angle / threshold_rad`` when ``primary_tilt_ge``
+      is True (or its complement against ``π`` when False). With a negative
+      ``primary_threshold_rad`` (effectively disabled), this contributes 1.
+    * Plane-angle: ``axis_to_plane_angle(...) / plane_threshold_rad``.
+
+    Either criterion may be omitted by leaving its threshold ``None``.
+
+    Args (from ``cfg.params``):
+        goal_asset_cfg: Scene asset whose root the marker tracks. Defaults to
+            ``SceneEntityCfg("success_marker")``.
+        object_cfg: Scene asset whose orientation drives the tilt metrics.
+            Defaults to ``SceneEntityCfg("object")``.
+        primary_threshold_rad: Threshold for ``axis_tilt_angle`` (rad).
+        primary_axis_local / primary_world_axis / primary_tilt_ge: Mirror
+            ``lift_and_tilt_with_contact_zones`` parameters.
+        plane_threshold_rad: Threshold for ``axis_to_plane_angle`` (rad).
+        plane_axis_local / plane_normal: Mirror the same parameters.
+        radius: Sphere radius (m). Default 0.04.
+        visible: Whether to render the marker. Default True.
+        opacity: Material opacity in ``[0, 1]``. Default 0.7.
+        num_color_steps: Number of discrete colors in the red→green gradient.
+            Default 11 (≈10% steps).
+        prim_path_prefix: USD prim path prefix for the markers. Default
+            ``"/Visuals/PourProgressMarker"``.
+    """
+
+    def __init__(self, cfg, env: ManagerBasedRLEnv):
+        super().__init__(cfg, env)
+
+        import isaaclab.sim as sim_utils
+        from isaaclab.markers import VisualizationMarkers, VisualizationMarkersCfg
+
+        self._goal_cfg: SceneEntityCfg = cfg.params.get("goal_asset_cfg", SceneEntityCfg("success_marker"))
+        self._object_cfg: SceneEntityCfg = cfg.params.get("object_cfg", SceneEntityCfg("object"))
+
+        self._primary_threshold = cfg.params.get("primary_threshold_rad")
+        self._primary_axis_local = cfg.params.get("primary_axis_local", (0.0, 0.0, 1.0))
+        self._primary_world_axis = cfg.params.get("primary_world_axis", (0.0, 0.0, 1.0))
+        self._primary_tilt_ge = bool(cfg.params.get("primary_tilt_ge", True))
+
+        self._plane_threshold = cfg.params.get("plane_threshold_rad")
+        self._plane_axis_local = cfg.params.get("plane_axis_local")
+        self._plane_normal = cfg.params.get("plane_normal", (0.0, 0.0, 1.0))
+
+        radius = float(cfg.params.get("radius", 0.04))
+        self._visible = bool(cfg.params.get("visible", True))
+        opacity = float(cfg.params.get("opacity", 0.7))
+        num_steps = int(cfg.params.get("num_color_steps", 11))
+        prim_path_prefix = cfg.params.get("prim_path_prefix", "/Visuals/PourProgressMarker")
+
+        if num_steps < 2:
+            num_steps = 2
+        self._num_steps = num_steps
+
+        markers = {}
+        for i in range(num_steps):
+            t = i / (num_steps - 1)
+            # Linear red→green; keeps the cue obvious without a yellow
+            # intermediate. Tune in cfg if a different ramp is wanted.
+            color = (1.0 - t, t, 0.0)
+            markers[f"step_{i}"] = sim_utils.SphereCfg(
+                radius=radius,
+                visual_material=sim_utils.PreviewSurfaceCfg(diffuse_color=color, opacity=opacity),
+            )
+
+        self._visualizer = VisualizationMarkers(VisualizationMarkersCfg(prim_path=prim_path_prefix, markers=markers))
+        # goal marker (red->green progress): deliberately NOT camera-hidden
+        self._visualizer.set_visibility(self._visible)
+
+    def _primary_progress(self, quat_w: torch.Tensor) -> torch.Tensor:
+        thr = self._primary_threshold
+        if thr is None:
+            return torch.zeros(quat_w.shape[0], device=quat_w.device, dtype=quat_w.dtype)
+        thr = float(thr)
+        angle = axis_tilt_angle(
+            quat_w,
+            axis_local=self._primary_axis_local,
+            world_axis=self._primary_world_axis,
+        )
+        if self._primary_tilt_ge:
+            if thr <= 0.0:
+                return torch.ones_like(angle)
+            return torch.clamp(angle / thr, 0.0, 1.0)
+        # tilt_ge=False: success when angle <= thr; map "shrinking angle" to progress.
+        denom = max(float(torch.pi) - thr, 1e-6)
+        return torch.clamp((float(torch.pi) - angle) / denom, 0.0, 1.0)
+
+    def _plane_progress(self, quat_w: torch.Tensor) -> torch.Tensor:
+        thr = self._plane_threshold
+        if thr is None or self._plane_axis_local is None:
+            return torch.zeros(quat_w.shape[0], device=quat_w.device, dtype=quat_w.dtype)
+        thr = max(float(thr), 1e-6)
+        angle = axis_to_plane_angle(
+            quat_w,
+            axis_local=self._plane_axis_local,
+            plane_normal=self._plane_normal,
+        )
+        return torch.clamp(angle / thr, 0.0, 1.0)
+
+    def __call__(
+        self,
+        env: ManagerBasedRLEnv,
+        goal_asset_cfg: SceneEntityCfg | None = None,
+        object_cfg: SceneEntityCfg | None = None,
+        primary_threshold_rad: float | None = None,
+        primary_axis_local: tuple[float, float, float] | None = None,
+        primary_world_axis: tuple[float, float, float] | None = None,
+        primary_tilt_ge: bool | None = None,
+        plane_threshold_rad: float | None = None,
+        plane_axis_local: tuple[float, float, float] | None = None,
+        plane_normal: tuple[float, float, float] | None = None,
+        radius: float | None = None,
+        visible: bool | None = None,
+        opacity: float | None = None,
+        num_color_steps: int | None = None,
+        prim_path_prefix: str | None = None,
+    ) -> torch.Tensor:
+        if visible is not None and bool(visible) != self._visible:
+            self._visible = bool(visible)
+            self._visualizer.set_visibility(self._visible)
+        if not self._visible:
+            return torch.zeros(env.num_envs, 0, device=env.device)
+
+        goal_cfg = goal_asset_cfg or self._goal_cfg
+        obj_cfg = object_cfg or self._object_cfg
+        goal: RigidObject = env.scene[goal_cfg.name]
+        obj: RigidObject = env.scene[obj_cfg.name]
+
+        progress = torch.maximum(
+            self._primary_progress(obj.data.root_quat_w),
+            self._plane_progress(obj.data.root_quat_w),
+        )
+        indices = (progress * (self._num_steps - 1)).round().clamp(0, self._num_steps - 1).to(torch.int32)
+
+        self._visualizer.visualize(
+            translations=goal.data.root_pos_w,
+            marker_indices=indices,
+        )
+        return torch.zeros(env.num_envs, 0, device=env.device)
+
+
+def setup_fingertip_contact_observation(env_cfg, target_prim: str = "Object", clip: float = 20.0) -> None:
+    """Wire fingertip→object contact sensors and the ``contact`` observation.
+
+    Config-build helper (call from a task's ``__post_init__``). For each robot
+    fingertip body, adds a :class:`ContactSensorCfg` filtered against
+    ``{ENV_REGEX_NS}/<target_prim>`` and exposes the aggregated contact force as
+    ``observations.contact.contact`` (set to ``None`` if the robot has no contact
+    sensors). Also points the privileged ``hand_tips_state_b`` observation at the
+    robot's hand-tip bodies.
+    """
+    if env_cfg.robot_config.setup_contact_sensors:
+        tip_prim_prefix = "{ENV_REGEX_NS}/Robot/"
+        finger_tip_body_list = env_cfg.robot_config.fingertip_body_names
+        for link_name in finger_tip_body_list:
+            setattr(
+                env_cfg.scene,
+                f"{link_name}_object_s",
+                ContactSensorCfg(
+                    prim_path=f"{tip_prim_prefix}{link_name}",
+                    filter_prim_paths_expr=[f"{{ENV_REGEX_NS}}/{target_prim}"],
+                ),
+            )
+        env_cfg.observations.contact.contact = ObsTerm(
+            func=fingers_contact_force_b,
+            params={"contact_sensor_names": [f"{link}_object_s" for link in finger_tip_body_list]},
+            clip=(-clip, clip),
+        )
+    else:
+        env_cfg.observations.contact = None
+    env_cfg.observations.privileged.hand_tips_state_b.params["body_asset_cfg"].body_names = (
+        env_cfg.robot_config.hand_tips_body_names
+    )
+
+
+def rack_level_height(env: ManagerBasedRLEnv) -> torch.Tensor:
+    """Shelf-top height (rack-local z, metres) of the level the object was spawned
+    on by :func:`~dexverse.tasks.mdp.resets.reset_object_on_rack_level`.
+    Zeros before the first reset. Shape ``(num_envs, 1)``."""
+    buf = getattr(env, "rack_level_z", None)
+    if buf is None or buf.shape[0] != env.num_envs:
+        return torch.zeros((env.num_envs, 1), device=env.device)
+    return buf.unsqueeze(1)
+
+
+def rack_level_index(env: ManagerBasedRLEnv) -> torch.Tensor:
+    """Index of the spawn level chosen by ``reset_object_on_rack_level`` (float,
+    ``(num_envs, 1)``; zeros before the first reset)."""
+    buf = getattr(env, "rack_level_index", None)
+    if buf is None or buf.shape[0] != env.num_envs:
+        return torch.zeros((env.num_envs, 1), device=env.device)
+    return buf.to(torch.float32).unsqueeze(1)
+
+
+def env_choice_one_hot(env: ManagerBasedRLEnv, buffer_name: str, num_choices: int) -> torch.Tensor:
+    """One-hot of the per-env choice sampled by ``mdp.sample_env_choice`` into
+    ``env.<buffer_name>``. Zeros before the first reset. ``(num_envs, num_choices)``."""
+    buf = getattr(env, buffer_name, None)
+    out = torch.zeros((env.num_envs, num_choices), device=env.device)
+    if buf is not None and buf.shape[0] == env.num_envs:
+        out.scatter_(1, buf.clamp(0, num_choices - 1).unsqueeze(1), 1.0)
+    return out
+
+
+class env_choice_points_vis(ManagerTermBase):
+    """Draw the K spheres of the per-episode choice ``env.<buffer_name>`` at
+    fixed local offsets of an asset's root -- e.g. the 8 corners of a goal cue
+    whose shape depends on which face must be down. ``points_per_choice``: list
+    over choices of K (x, y, z) offsets (same K for every choice). Camera-visible
+    by default (a vision-policy cue).
+    """
+
+    def __init__(self, cfg, env: ManagerBasedRLEnv):
+        super().__init__(cfg, env)
+        import isaaclab.sim as sim_utils
+        from isaaclab.markers import VisualizationMarkers, VisualizationMarkersCfg
+
+        self.asset_cfg: SceneEntityCfg = cfg.params["asset_cfg"]
+        self.buffer_name: str = cfg.params["buffer_name"]
+        color = tuple(cfg.params.get("color", (0.15, 0.75, 0.25)))
+        self._vis = VisualizationMarkers(
+            VisualizationMarkersCfg(
+                prim_path=cfg.params.get("prim_path", "/Visuals/ChoicePoints"),
+                markers={
+                    "pt": sim_utils.SphereCfg(
+                        radius=float(cfg.params.get("radius", 0.01)),
+                        visual_material=sim_utils.PreviewSurfaceCfg(diffuse_color=color, opacity=float(cfg.params.get("opacity", 1.0))),
+                    )
+                },
+            )
+        )
+        if cfg.params.get("hide_from_cameras", False):
+            hide_marker_from_cameras(self._vis)
+        self._points = torch.tensor(cfg.params["points_per_choice"], device=env.device, dtype=torch.float32)  # (C,K,3)
+
+    def __call__(
+        self,
+        env: ManagerBasedRLEnv,
+        asset_cfg: SceneEntityCfg,
+        buffer_name: str,
+        points_per_choice: list,
+        radius: float = 0.01,
+        color: tuple[float, float, float] | None = None,
+        opacity: float | None = None,
+        prim_path: str | None = None,
+        hide_from_cameras: bool = False,
+    ) -> torch.Tensor:
+        asset = env.scene[self.asset_cfg.name]
+        pos, quat = asset.data.root_pos_w, asset.data.root_quat_w
+        E, K = pos.shape[0], self._points.shape[1]
+        choice = getattr(env, self.buffer_name, None)
+        if choice is None or choice.shape[0] != E:
+            choice = torch.zeros(E, dtype=torch.long, device=env.device)
+        pts_local = self._points[choice]  # (E,K,3)
+        pts = quat_apply(quat.unsqueeze(1).expand(-1, K, -1).reshape(-1, 4), pts_local.reshape(-1, 3)).reshape(E, K, 3) + pos.unsqueeze(1)
+        self._vis.visualize(translations=pts.reshape(-1, 3))
+        return torch.zeros(env.num_envs, 0, device=env.device)
+
+
+class env_choice_patches_vis(ManagerTermBase):
+    """Draw the patches of the per-episode choice ``env.<buffer_name>`` (see
+    ``mdp.sample_env_choice``) attached to an object's root frame.
+
+    ``patches_per_choice``: list over choices, each a list of patches
+    ``(center_local(3), quat_local(4), size(3))`` drawn as flat cuboids -- e.g.
+    the graspable face of a carton plus its wrap strips (choice = face index).
+    Generic replacement for :class:`required_faces_vis` when choices do not map
+    to face pairs. ``hide_from_cameras=False`` (default) makes it a task
+    marking the vision policy sees; set True for operator-only cues.
+    """
+
+    def __init__(self, cfg, env: ManagerBasedRLEnv):
+        super().__init__(cfg, env)
+        import isaaclab.sim as sim_utils
+        from isaaclab.markers import VisualizationMarkers, VisualizationMarkersCfg
+
+        patches_per_choice = cfg.params["patches_per_choice"]
+        self.buffer_name = cfg.params["buffer_name"]
+        self.object_cfg = cfg.params.get("object_cfg", SceneEntityCfg("object"))
+        color = tuple(cfg.params.get("color", (0.95, 0.75, 0.10)))
+        opacity = float(cfg.params.get("opacity", 0.9))
+        prim_path = cfg.params.get("prim_path", "/Visuals/ChoicePatches")
+        markers, centers, quats, choice_of = {}, [], [], []
+        proto = 0
+        for ci, patches in enumerate(patches_per_choice):
+            for (c, qq, size) in patches:
+                markers[f"p_{proto}"] = sim_utils.CuboidCfg(
+                    size=tuple(float(v) for v in size),
+                    visual_material=sim_utils.PreviewSurfaceCfg(diffuse_color=color, emissive_color=tuple(0.35 * v for v in color), opacity=opacity),
+                )
+                centers.append(c); quats.append(qq); choice_of.append(ci); proto += 1
+        markers["off"] = sim_utils.CuboidCfg(size=(0.001, 0.001, 0.001), visual_material=sim_utils.PreviewSurfaceCfg(diffuse_color=(0.0, 0.0, 0.0), opacity=0.0))
+        self._off_index = proto
+        self._vis = VisualizationMarkers(VisualizationMarkersCfg(prim_path=prim_path, markers=markers))
+        if cfg.params.get("hide_from_cameras", False):
+            hide_marker_from_cameras(self._vis)
+        self._centers = torch.tensor(centers, device=env.device, dtype=torch.float32).reshape(-1, 3)
+        self._quats = torch.tensor(quats, device=env.device, dtype=torch.float32).reshape(-1, 4)
+        self._choice_of = torch.tensor(choice_of, device=env.device, dtype=torch.long)
+
+    def __call__(
+        self,
+        env: ManagerBasedRLEnv,
+        patches_per_choice: list,
+        buffer_name: str,
+        object_cfg: SceneEntityCfg | None = None,
+        color: tuple[float, float, float] | None = None,
+        opacity: float | None = None,
+        prim_path: str | None = None,
+        hide_from_cameras: bool = False,
+    ) -> torch.Tensor:
+        obj: RigidObject = env.scene[self.object_cfg.name]
+        E, P = env.num_envs, self._centers.shape[0]
+        if P == 0:
+            return torch.zeros(E, 0, device=env.device)
+        pos = obj.data.root_pos_w.unsqueeze(1).expand(-1, P, -1)
+        quat = obj.data.root_quat_w.unsqueeze(1).expand(-1, P, -1).reshape(-1, 4)
+        centers_w = pos.reshape(-1, 3) + quat_apply(quat, self._centers.unsqueeze(0).expand(E, -1, -1).reshape(-1, 3))
+        quats_w = quat_mul(quat, self._quats.unsqueeze(0).expand(E, -1, -1).reshape(-1, 4))
+        choice = getattr(env, self.buffer_name, None)
+        idx = torch.full((E, P), self._off_index, dtype=torch.int32, device=env.device)
+        if choice is not None and choice.shape[0] == E:
+            show = self._choice_of.unsqueeze(0) == choice.unsqueeze(1)
+            proto_idx = torch.arange(P, device=env.device).unsqueeze(0).expand(E, -1).to(torch.int32)
+            idx = torch.where(show, proto_idx, idx)
+        self._vis.visualize(translations=centers_w, orientations=quats_w, marker_indices=idx.reshape(-1))
+        return torch.zeros(E, 0, device=env.device)
+
+
+class required_faces_vis(ManagerTermBase):
+    """Draw the per-episode required hold faces (and, optionally, the forbidden ones).
+
+    ``face_patches``: list of 6 entries (ordered ``[+x,-x,+y,-y,+z,-z]``), each a
+    list of patches ``(center_local(3), quat_local(4), size(3))`` -- the face quad
+    plus any wrap-band strips on the adjacent faces. ``forbidden_patches``: one
+    patch per face drawn (red) when that face is not part of the required pair
+    (``None`` disables). The axis index comes from ``env.<buffer_name>`` (see
+    ``mdp.sample_env_choice``). This is task information (a marking on the box), so
+    by default the patches stay visible to cameras (``hide_from_cameras=False``).
+    """
+
+    def __init__(self, cfg, env: ManagerBasedRLEnv):
+        super().__init__(cfg, env)
+        import isaaclab.sim as sim_utils
+        from isaaclab.markers import VisualizationMarkers, VisualizationMarkersCfg
+
+        face_patches = cfg.params["face_patches"] if cfg.params.get("show_required", True) else [[] for _ in cfg.params["face_patches"]]
+        forbidden_patches = cfg.params.get("forbidden_patches") if cfg.params.get("show_forbidden", True) else None
+        self.buffer_name = cfg.params.get("buffer_name", "hold_axis")
+        self.object_cfg = cfg.params.get("object_cfg", SceneEntityCfg("object"))
+        color = tuple(cfg.params.get("color", (0.95, 0.75, 0.10)))
+        fcolor = cfg.params.get("forbidden_color", (0.85, 0.15, 0.15))
+        prim_path = cfg.params.get("prim_path", "/Visuals/RequiredFaces")
+
+        markers = {}
+        centers, quats, face_of, kind = [], [], [], []  # kind: 0 required, 1 forbidden
+        proto = 0
+        for fi, patches in enumerate(face_patches):
+            for (c, qq, size) in patches:
+                markers[f"req_{proto}"] = sim_utils.CuboidCfg(
+                    size=tuple(float(v) for v in size),
+                    visual_material=sim_utils.PreviewSurfaceCfg(diffuse_color=color, emissive_color=tuple(0.35 * v for v in color), opacity=0.9),
+                )
+                centers.append(c); quats.append(qq); face_of.append(fi); kind.append(0); proto += 1
+        self._n_req = proto
+        if forbidden_patches is not None and fcolor is not None:
+            for fi, (c, qq, size) in enumerate(forbidden_patches):
+                markers[f"forb_{proto}"] = sim_utils.CuboidCfg(
+                    size=tuple(float(v) for v in size),
+                    visual_material=sim_utils.PreviewSurfaceCfg(diffuse_color=tuple(fcolor), emissive_color=tuple(0.25 * v for v in fcolor), opacity=0.55),
+                )
+                centers.append(c); quats.append(qq); face_of.append(fi); kind.append(1); proto += 1
+        markers["off"] = sim_utils.CuboidCfg(size=(0.001, 0.001, 0.001), visual_material=sim_utils.PreviewSurfaceCfg(diffuse_color=(0.0, 0.0, 0.0), opacity=0.0))
+        self._off_index = proto
+        self._vis = VisualizationMarkers(VisualizationMarkersCfg(prim_path=prim_path, markers=markers))
+        if cfg.params.get("hide_from_cameras", False):
+            hide_marker_from_cameras(self._vis)
+        self._centers = torch.tensor(centers, device=env.device, dtype=torch.float32)  # (P,3)
+        self._quats = torch.tensor(quats, device=env.device, dtype=torch.float32)  # (P,4)
+        self._face_of = torch.tensor(face_of, device=env.device, dtype=torch.long)  # (P,)
+        self._kind = torch.tensor(kind, device=env.device, dtype=torch.long)  # (P,)
+
+    def __call__(
+        self,
+        env: ManagerBasedRLEnv,
+        face_patches: list,
+        forbidden_patches: list | None = None,
+        buffer_name: str = "hold_axis",
+        object_cfg: SceneEntityCfg | None = None,
+        color: tuple[float, float, float] | None = None,
+        forbidden_color: tuple[float, float, float] | None = None,
+        prim_path: str | None = None,
+        hide_from_cameras: bool = False,
+        show_required: bool = True,
+        show_forbidden: bool = True,
+    ) -> torch.Tensor:
+        obj: RigidObject = env.scene[self.object_cfg.name]
+        E, P = env.num_envs, self._centers.shape[0]
+        if P == 0:
+            return torch.zeros(E, 0, device=env.device)
+        pos = obj.data.root_pos_w.unsqueeze(1).expand(-1, P, -1)
+        quat = obj.data.root_quat_w.unsqueeze(1).expand(-1, P, -1).reshape(-1, 4)
+        centers_w = pos.reshape(-1, 3) + quat_apply(quat, self._centers.unsqueeze(0).expand(E, -1, -1).reshape(-1, 3))
+        quats_w = quat_mul(quat, self._quats.unsqueeze(0).expand(E, -1, -1).reshape(-1, 4))
+        axis = getattr(env, self.buffer_name, None)
+        idx = torch.full((E, P), self._off_index, dtype=torch.int32, device=env.device)
+        if axis is not None and axis.shape[0] == E:
+            required = (self._face_of.unsqueeze(0) // 2) == axis.unsqueeze(1)  # (E,P)
+            proto_idx = torch.arange(P, device=env.device).unsqueeze(0).expand(E, -1).to(torch.int32)
+            show = (required & (self._kind == 0).unsqueeze(0)) | (~required & (self._kind == 1).unsqueeze(0))
+            idx = torch.where(show, proto_idx, idx)
+        self._vis.visualize(translations=centers_w, orientations=quats_w, marker_indices=idx.reshape(-1))
+        return torch.zeros(E, 0, device=env.device)
+
+
+class local_points_vis(ManagerTermBase):
+    """Draw small spheres at fixed local offsets of an asset's root -- e.g. the
+    8 corners of a goal region -- as a *vision-policy cue*: camera-visible by
+    default (``hide_from_cameras=False``), so wire it as an always-on
+    ``scene_vis`` term rather than behind ``enable_debug_vis``.
+
+    Args (from ``cfg.params``): ``asset_cfg``, ``local_points`` (list of
+    (x, y, z) in the asset root frame), ``radius`` (default 0.01), ``color``,
+    ``opacity`` (default 1.0), ``prim_path``, ``hide_from_cameras``.
+    """
+
+    def __init__(self, cfg, env: ManagerBasedRLEnv):
+        super().__init__(cfg, env)
+        import isaaclab.sim as sim_utils
+        from isaaclab.markers import VisualizationMarkers, VisualizationMarkersCfg
+
+        self.asset_cfg: SceneEntityCfg = cfg.params["asset_cfg"]
+        color = tuple(cfg.params.get("color", (0.15, 0.75, 0.25)))
+        self._vis = VisualizationMarkers(
+            VisualizationMarkersCfg(
+                prim_path=cfg.params.get("prim_path", "/Visuals/LocalPoints"),
+                markers={
+                    "pt": sim_utils.SphereCfg(
+                        radius=float(cfg.params.get("radius", 0.01)),
+                        visual_material=sim_utils.PreviewSurfaceCfg(diffuse_color=color, opacity=float(cfg.params.get("opacity", 1.0))),
+                    )
+                },
+            )
+        )
+        if cfg.params.get("hide_from_cameras", False):
+            hide_marker_from_cameras(self._vis)
+        self._points = torch.tensor(cfg.params["local_points"], device=env.device, dtype=torch.float32)  # (K, 3)
+
+    def __call__(
+        self,
+        env: ManagerBasedRLEnv,
+        asset_cfg: SceneEntityCfg,
+        local_points: list[tuple[float, float, float]],
+        radius: float = 0.01,
+        color: tuple[float, float, float] | None = None,
+        opacity: float | None = None,
+        prim_path: str | None = None,
+        hide_from_cameras: bool = False,
+    ) -> torch.Tensor:
+        asset = env.scene[self.asset_cfg.name]
+        pos, quat = asset.data.root_pos_w, asset.data.root_quat_w  # (E, 3), (E, 4)
+        E, K = pos.shape[0], self._points.shape[0]
+        pts = quat_apply(
+            quat.unsqueeze(1).expand(-1, K, -1).reshape(-1, 4),
+            self._points.unsqueeze(0).expand(E, -1, -1).reshape(-1, 3),
+        ).reshape(E, K, 3) + pos.unsqueeze(1)
+        self._vis.visualize(translations=pts.reshape(-1, 3))
+        return torch.zeros(env.num_envs, 0, device=env.device)
+
+
+class body_point_zone_vis(ManagerTermBase):
+    """Draw a sphere attached to a body of an articulation / rigid object (root when
+    no ``body_names``), offset by ``local_offset`` in that body's frame -- e.g. the
+    no-touch zone around a nail head that moves with the nail. Camera-hidden by
+    default (an operator cue)."""
+
+    def __init__(self, cfg, env: ManagerBasedRLEnv):
+        super().__init__(cfg, env)
+        import isaaclab.sim as sim_utils
+        from isaaclab.markers import VisualizationMarkers, VisualizationMarkersCfg
+
+        self.target_cfg: SceneEntityCfg = cfg.params["target_cfg"]
+        color = tuple(cfg.params.get("color", (0.9, 0.1, 0.1)))
+        self._vis = VisualizationMarkers(
+            VisualizationMarkersCfg(
+                prim_path=cfg.params.get("prim_path", "/Visuals/BodyPointZone"),
+                markers={
+                    "zone": sim_utils.SphereCfg(
+                        radius=float(cfg.params["radius"]),
+                        visual_material=sim_utils.PreviewSurfaceCfg(diffuse_color=color, opacity=float(cfg.params.get("opacity", 0.4))),
+                    )
+                },
+            )
+        )
+        if cfg.params.get("hide_from_cameras", True):
+            hide_marker_from_cameras(self._vis)
+        self._offset = torch.tensor(cfg.params.get("local_offset", (0.0, 0.0, 0.0)), device=env.device, dtype=torch.float32)
+
+    def __call__(
+        self,
+        env: ManagerBasedRLEnv,
+        target_cfg: SceneEntityCfg,
+        radius: float,
+        local_offset: tuple[float, float, float] = (0.0, 0.0, 0.0),
+        color: tuple[float, float, float] | None = None,
+        opacity: float | None = None,
+        prim_path: str | None = None,
+        hide_from_cameras: bool = True,
+    ) -> torch.Tensor:
+        target = env.scene[self.target_cfg.name]
+        ids = self.target_cfg.body_ids
+        if isinstance(target, Articulation) and ids is not None and ids != slice(None):
+            tid = ids[0] if isinstance(ids, (list, tuple)) else ids
+            pos, quat = target.data.body_pos_w[:, tid, :], target.data.body_quat_w[:, tid, :]
+        else:
+            pos, quat = target.data.root_pos_w, target.data.root_quat_w
+        point = pos + quat_apply(quat, self._offset.unsqueeze(0).expand(env.num_envs, -1))
+        self._vis.visualize(translations=point, orientations=quat)
+        return torch.zeros(env.num_envs, 0, device=env.device)
+
+
+class body_box_zone_vis(ManagerTermBase):
+    """Draw an oriented rectangular zone attached to an articulation body.
+
+    Unlike :class:`body_point_zone_vis`, this cue exposes the complete
+    functional area rather than implying that one exact point must make
+    contact. ``local_offset`` and ``size`` use the body's local frame.
+    """
+
+    def __init__(self, cfg, env: ManagerBasedRLEnv):
+        super().__init__(cfg, env)
+        import isaaclab.sim as sim_utils
+        from isaaclab.markers import VisualizationMarkers, VisualizationMarkersCfg
+
+        self.target_cfg: SceneEntityCfg = cfg.params["target_cfg"]
+        color = tuple(cfg.params.get("color", (0.15, 0.45, 0.85)))
+        self._vis = VisualizationMarkers(
+            VisualizationMarkersCfg(
+                prim_path=cfg.params.get("prim_path", "/Visuals/BodyBoxZone"),
+                markers={
+                    "zone": sim_utils.CuboidCfg(
+                        size=tuple(float(v) for v in cfg.params["size"]),
+                        visual_material=sim_utils.PreviewSurfaceCfg(
+                            diffuse_color=color,
+                            emissive_color=tuple(0.25 * v for v in color),
+                            opacity=float(cfg.params.get("opacity", 0.5)),
+                        ),
+                    )
+                },
+            )
+        )
+        if cfg.params.get("hide_from_cameras", True):
+            hide_marker_from_cameras(self._vis)
+        self._offset = torch.tensor(
+            cfg.params.get("local_offset", (0.0, 0.0, 0.0)), device=env.device, dtype=torch.float32
+        )
+
+    def __call__(
+        self,
+        env: ManagerBasedRLEnv,
+        target_cfg: SceneEntityCfg,
+        size: tuple[float, float, float],
+        local_offset: tuple[float, float, float] = (0.0, 0.0, 0.0),
+        color: tuple[float, float, float] | None = None,
+        opacity: float | None = None,
+        prim_path: str | None = None,
+        hide_from_cameras: bool = True,
+    ) -> torch.Tensor:
+        target = env.scene[self.target_cfg.name]
+        ids = self.target_cfg.body_ids
+        if isinstance(target, Articulation) and ids is not None and ids != slice(None):
+            tid = ids[0] if isinstance(ids, (list, tuple)) else ids
+            pos, quat = target.data.body_pos_w[:, tid, :], target.data.body_quat_w[:, tid, :]
+        else:
+            pos, quat = target.data.root_pos_w, target.data.root_quat_w
+        center = pos + quat_apply(quat, self._offset.unsqueeze(0).expand(env.num_envs, -1))
+        self._vis.visualize(translations=center, orientations=quat)
+        return torch.zeros(env.num_envs, 0, device=env.device)

--- a/source/dexverse/dexverse/baseline_v1/mdp/pusht_obstacles.py
+++ b/source/dexverse/dexverse/baseline_v1/mdp/pusht_obstacles.py
@@ -1,0 +1,289 @@
+"""Seeded goal-local Push-T rods with a collision-checked XY/yaw path witness.
+
+No Isaac imports: tests use the actual two-bar footprint, not a bounding disk.
+"""
+
+from functools import lru_cache
+import heapq
+import math
+
+import numpy as np
+import torch
+
+# tee.usda: x=[-.1,.1], y=[-.0625,.1375], relative to the recorded root.
+TEE_XY_BOUNDS = ((-0.10, 0.10), (-0.0625, 0.1375))
+TEE_RECT_CENTERS = np.array([[0., -.0375], [0., .0625]])
+TEE_RECT_HALF_SIZES = np.array([[.10, .025], [.025, .075]])
+TEE_CORNERS = np.concatenate([
+    center + half * np.array([[-1, -1], [-1, 1], [1, -1], [1, 1]])
+    for center, half in zip(TEE_RECT_CENTERS, TEE_RECT_HALF_SIZES)
+])
+TEE_BOUNDING_BOX_DIAGONAL = math.hypot(0.20, 0.20)
+TEE_ROOT_RADIUS = math.hypot(0.10, 0.1375)
+PATH_MARGIN = 0.015
+TEE_CLEARANCE_RADIUS = TEE_ROOT_RADIUS + PATH_MARGIN
+ROD_RADIUS = 0.018
+ROD_HEIGHT = 0.04
+ROD_COUNT = 10
+ROD_NAMES = tuple(f"push_t_rod_{i}" for i in range(ROD_COUNT))
+ROD_COLOR = (1.0, 0.32, 0.015)
+SEPARATION_SLACK = 0.01
+ROD_MIN_SURFACE_GAP = 0.15
+ROD_MIN_SPACING = ROD_MIN_SURFACE_GAP + 2 * ROD_RADIUS
+GOAL_ROD_RADII = (0.20, 0.40)
+# Require rods on all sides, without prescribing a ring/grid or a fixed entry.
+MAX_ROD_ANGULAR_GAP = 2 * math.pi / 3
+ROD_EDGE_INSET = ROD_RADIUS + 0.02
+START_GOAL_MIN_DISTANCE = 2 * TEE_ROOT_RADIUS + SEPARATION_SLACK
+PATH_GRID_STEP = 0.03
+PATH_YAW_BINS = 24
+PATH_SWEEP_STEP = 0.006
+DIRECT_BLOCK_DISTANCE = ROD_RADIUS - 0.003
+
+
+def segment_distances(start, end, points):
+    """Distances from points (..., K, 2) to segments (..., 2), with projection."""
+    delta = end - start
+    t = ((points - start[..., None, :]) * delta[..., None, :]).sum(-1) / np.maximum((delta * delta).sum(-1)[..., None], 1e-12)
+    nearest = start[..., None, :] + np.clip(t, 0, 1)[..., None] * delta[..., None, :]
+    return np.linalg.norm(points - nearest, axis=-1), t
+
+
+def direct_path_blocked(start, goal, rods):
+    """A rod intersects the root trajectory itself, not just an inflated bound.
+
+    The root lies inside the T at every yaw. Requiring its straight XY segment
+    to penetrate a rod blocks straight translation even with in-place rotation.
+    """
+    distance, t = segment_distances(np.asarray(start), np.asarray(goal), np.asarray(rods))
+    return np.any((distance < DIRECT_BLOCK_DISTANCE) & (t > .2) & (t < .8), axis=-1)
+
+
+def angle_delta(start, end):
+    """Shortest signed angle, including connections across the 0/2pi seam."""
+    return (end - start + math.pi) % (2 * math.pi) - math.pi
+
+
+def pose_clearance(poses, rods, *, table_size=(1.5, 1.5), table_center=(0., 0.)):
+    """Minimum T-to-rod surface / T-to-table-edge clearance for (..., 3) poses.
+
+    Transform rod centres into the T frame, then use exact point-to-rectangle
+    distance for each of the two USD collision boxes. All box corners determine
+    table containment. Negative clearance means collision or overhang.
+    """
+    poses, rods = np.asarray(poses), np.asarray(rods).reshape(-1, 2)
+    c, s = np.cos(poses[..., 2]), np.sin(poses[..., 2])
+    rotation = np.stack((c, -s, s, c), axis=-1).reshape(*c.shape, 2, 2)
+    corners = np.einsum("...ij,kj->...ki", rotation, TEE_CORNERS) + poses[..., None, :2]
+    edge = (np.asarray(table_size) / 2 - np.abs(corners - table_center)).min(axis=(-1, -2))
+    if not len(rods):
+        return edge
+    local = np.einsum("...ji,...kj->...ki", rotation, rods - poses[..., None, :2])
+    outside = np.maximum(np.abs(local[..., :, None, :] - TEE_RECT_CENTERS) - TEE_RECT_HALF_SIZES, 0.)
+    obstacle = np.linalg.norm(outside, axis=-1).min(axis=(-1, -2)) - ROD_RADIUS
+    return np.minimum(edge, obstacle)
+
+
+def motion_samples(start, end):
+    """Sample XY / shortest-yaw interpolation and bound inter-sample motion."""
+    delta = np.asarray(end) - start
+    delta[2] = angle_delta(start[2], end[2])
+    travel = np.linalg.norm(delta[:2]) + TEE_ROOT_RADIUS * abs(delta[2])
+    steps = max(1, int(np.ceil(travel / PATH_SWEEP_STEP)))
+    return np.asarray(start) + np.linspace(0., 1., steps + 1)[:, None] * delta, travel / (2 * steps)
+
+
+def motion_is_clear(start, end, rods, *, table_size=(1.5, 1.5), table_center=(0., 0.)):
+    """Certify the full swept footprint, not only endpoint/sample collisions.
+
+    Distance changes by at most translation + root radius * yaw change. An
+    extra half-sample travel margin bounds every point between sample poses.
+    """
+    poses, sweep_margin = motion_samples(start, end)
+    return bool(np.all(pose_clearance(poses, rods, table_size=table_size, table_center=table_center)
+                       >= PATH_MARGIN + sweep_margin))
+
+
+@lru_cache(maxsize=8)
+def _pose_grid(table_size, table_center):
+    half = np.asarray(table_size) / 2 - PATH_MARGIN
+    axes = [np.linspace(table_center[i] - half[i], table_center[i] + half[i],
+                        int(np.ceil(2 * half[i] / PATH_GRID_STEP)) + 1) for i in range(2)]
+    angles = np.arange(PATH_YAW_BINS) * (2 * math.pi / PATH_YAW_BINS)
+    nodes = np.stack(np.meshgrid(*axes, angles, indexing="ij"), axis=-1)
+    return nodes.reshape(-1, 3), nodes.shape[:3]
+
+
+def find_clear_path(start, goal, rods, *, table_size=(1.5, 1.5), table_center=(0., 0.)):
+    """A* over XY/yaw using the actual T, returning (N, 3) poses or None.
+
+    Translation and in-place turning edges are swept-collision checked, as are
+    exact endpoint connectors. A failed finite-grid search rejects a layout;
+    it does not prove that the continuous problem is impossible.
+    """
+    start, goal, rods = map(np.asarray, (start, goal, rods))
+    geometry = dict(table_size=table_size, table_center=table_center)
+    if np.any(np.asarray(table_size) <= 2 * PATH_MARGIN):
+        return None
+    if np.any(pose_clearance(np.stack((start, goal)), rods, **geometry) < PATH_MARGIN):
+        return None
+    flat, (nx, ny, na) = _pose_grid(tuple(table_size), tuple(table_center))
+    clearances = np.concatenate([pose_clearance(chunk, rods, **geometry) for chunk in np.array_split(flat, 16)])
+    safe = clearances >= PATH_MARGIN
+
+    def cost(poses, point):
+        return np.linalg.norm(poses[..., :2] - point[:2], axis=-1) + TEE_ROOT_RADIUS * np.abs(angle_delta(poses[..., 2], point[2]))
+
+    def connectors(point):
+        near = np.flatnonzero(safe & (np.linalg.norm(flat[:, :2] - point[:2], axis=-1) <= 1.5 * PATH_GRID_STEP)
+                              & (np.abs(angle_delta(flat[:, 2], point[2])) <= 2 * math.pi / na))
+        return [node for node in near if motion_is_clear(point, flat[node], rods, **geometry)]
+
+    source, target = connectors(start), set(connectors(goal))
+    if not source or not target:
+        return None
+    heuristic = cost(flat, goal)
+    parents = np.full(len(flat), -1, dtype=np.int32)
+    best = np.full(len(flat), np.inf)
+    closed = np.zeros(len(flat), dtype=bool)
+    queue = []
+    for node in source:
+        best[node] = cost(flat[node], start)
+        heapq.heappush(queue, (best[node] + heuristic[node], int(node)))
+    while queue:
+        _, node = heapq.heappop(queue)
+        if closed[node]:
+            continue
+        closed[node] = True
+        if node in target:
+            chain = []
+            while node != -1:
+                chain.append(flat[node])
+                node = parents[node]
+            return np.vstack((start, chain[::-1], goal))
+        xy, a = divmod(node, na)
+        x, y = divmod(xy, ny)
+        neighbors = [(x, y, (a + da) % na) for da in (-1, 1)]
+        neighbors.extend((x + dx, y + dy, a) for dx, dy in
+                         ((1, 0), (-1, 0), (0, 1), (0, -1), (1, 1), (-1, -1), (1, -1), (-1, 1)))
+        for ix, iy, ia in neighbors:
+            if not (0 <= ix < nx and 0 <= iy < ny):
+                continue
+            other = (ix * ny + iy) * na + ia
+            if closed[other] or not safe[other]:
+                continue
+            travel = cost(flat[other], flat[node])
+            candidate = best[node] + travel
+            if candidate >= best[other]:
+                continue
+            # Endpoint clearance can certify an entire edge without sampling.
+            if min(clearances[node], clearances[other]) < PATH_MARGIN + travel / 2:
+                if not motion_is_clear(flat[node], flat[other], rods, **geometry):
+                    continue
+            best[other], parents[other] = candidate, node
+            heapq.heappush(queue, (candidate + heuristic[other], other))
+    return None
+
+
+def sample_layouts(count, *, device="cpu", table_size=(1.5, 1.5), table_center=(0., 0.),
+                   spawn_x=(-0.406, 0.094), spawn_y=(-0.35, 0.15), max_rounds=256):
+    """Return [start x,y,yaw; goal x,y,yaw; ten rod x,y] for each env.
+
+    Uniform-area annulus proposals surround the goal, with 15 cm surface gaps.
+    Uses Torch's seeded RNG; geometry is deterministic NumPy. Failed bounded
+    rejection raises explicitly, never relaxing spacing or reachability.
+    """
+    if count < 0 or max_rounds < 1 or any(hi <= lo for lo, hi in (spawn_x, spawn_y)):
+        raise ValueError("Invalid Push-T layout sampling arguments")
+    half = np.asarray(table_size) / 2
+    if np.any(half <= 2 * TEE_CLEARANCE_RADIUS):
+        raise ValueError("Table too small for T-sized obstacle/edge clearance")
+    center = np.asarray(table_center)
+    low = np.array([spawn_x[0], spawn_y[0]]) + center
+    high = np.array([spawn_x[1], spawn_y[1]]) + center
+    safe_half = half - TEE_CLEARANCE_RADIUS
+    rod_half = half - ROD_EDGE_INSET
+    geometry = dict(table_size=table_size, table_center=table_center)
+    result = np.empty((count, 6 + 2 * ROD_COUNT), dtype=np.float32)
+    for row in range(count):
+        for _ in range(max_rounds):
+            rand_goal = torch.rand(3, device=device).cpu().numpy()
+            goal = np.r_[low + rand_goal[:2] * (high - low), rand_goal[2] * 2 * math.pi]
+            if np.any(np.abs(goal[:2] - center) > safe_half):
+                continue
+            rand_rods = torch.rand(ROD_COUNT, 256, 2, device=device).cpu().numpy()
+            radius = np.sqrt(GOAL_ROD_RADII[0]**2 + rand_rods[..., 0] * (GOAL_ROD_RADII[1]**2 - GOAL_ROD_RADII[0]**2))
+            angle = rand_rods[..., 1] * 2 * math.pi
+            proposals = goal[:2] + radius[..., None] * np.stack((np.cos(angle), np.sin(angle)), axis=-1)
+            rods = []
+            for candidates in proposals:
+                valid = (np.abs(candidates - center) <= rod_half).all(-1)
+                if rods:
+                    valid &= (np.linalg.norm(candidates[:, None, :] - np.asarray(rods)[None, :, :], axis=-1) >= ROD_MIN_SPACING).all(-1)
+                available = np.flatnonzero(valid)
+                if not len(available):
+                    break
+                rods.append(candidates[available[0]])
+            if len(rods) != ROD_COUNT:
+                continue
+            rods = np.asarray(rods)
+            bearings = np.sort(np.arctan2(rods[:, 1] - goal[1], rods[:, 0] - goal[0]))
+            if np.diff(np.r_[bearings, bearings[0] + 2 * math.pi]).max() > MAX_ROD_ANGULAR_GAP:
+                continue
+            if pose_clearance(goal, rods, **geometry) < PATH_MARGIN:
+                continue
+            rand = torch.rand(256, 3, device=device).cpu().numpy()
+            starts = np.column_stack((low + rand[:, :2] * (high - low), rand[:, 2] * 2 * math.pi))
+            valid = (np.abs(starts[:, :2] - center) <= safe_half).all(-1)
+            valid &= np.linalg.norm(starts[:, :2] - goal[:2], axis=-1) >= START_GOAL_MIN_DISTANCE
+            valid &= pose_clearance(starts, rods, **geometry) >= PATH_MARGIN + SEPARATION_SLACK
+            valid &= direct_path_blocked(starts[:, :2], goal[:2], rods)
+            chosen = None
+            for index in np.flatnonzero(valid):
+                if find_clear_path(starts[index], goal, rods, **geometry) is not None:
+                    chosen = index
+                    break
+            if chosen is not None:
+                result[row] = np.concatenate((starts[chosen], goal, rods.ravel()))
+                break
+        else:
+            raise RuntimeError("Could not sample collision-free Push-T layout within budget; enlarge table/spawn region, never weaken clearance")
+    return torch.as_tensor(result, device=device)
+
+
+def reset_push_t_with_rods(env, env_ids, *, table_size=(1.5, 1.5), table_center=(0., 0.),
+                         spawn_x=(-0.406, 0.094), spawn_y=(-0.35, 0.15)):
+    """Jointly reset tee, goal, rods; their poses are ordinary recorded scene state."""
+    if env_ids is None:
+        ids = torch.arange(env.num_envs, device=env.device)
+    elif isinstance(env_ids, slice):
+        ids = torch.arange(env.num_envs, device=env.device)[env_ids]
+    else:
+        ids = torch.as_tensor(env_ids, dtype=torch.long, device=env.device)
+    if not len(ids):
+        return
+    samples = sample_layouts(len(ids), device=env.device, table_size=table_size,
+                             table_center=table_center, spawn_x=spawn_x, spawn_y=spawn_y)
+    origins = env.scene.env_origins[ids]
+    for name, xy, yaw, dynamic in [
+        ("object", samples[:, :2], samples[:, 2], True),
+        ("goal_tee", samples[:, 3:5], samples[:, 5], False),
+        *[(name, samples[:, 6 + i*2:8 + i*2], torch.zeros(len(ids), device=env.device), False)
+          for i, name in enumerate(ROD_NAMES)],
+    ]:
+        asset = env.scene[name]
+        pose = asset.data.default_root_state[ids, :7].clone()
+        pose[:, :2] = xy
+        pose[:, :3] += origins
+        pose[:, 3:] = 0
+        pose[:, 3] = torch.cos(yaw / 2)
+        pose[:, 6] = torch.sin(yaw / 2)
+        asset.write_root_pose_to_sim(pose, env_ids=ids)
+        if dynamic:
+            asset.write_root_velocity_to_sim(torch.zeros(len(ids), 6, device=env.device), env_ids=ids)
+
+
+def rod_positions_in_table(env):
+    """Three coordinates per rod for state policies; also visible in RGB."""
+    table = env.scene["table"].data.root_pos_w
+    return torch.cat([env.scene[name].data.root_pos_w - table for name in ROD_NAMES], dim=-1)

--- a/source/dexverse/dexverse/baseline_v1/mdp/resets.py
+++ b/source/dexverse/dexverse/baseline_v1/mdp/resets.py
@@ -1,0 +1,1890 @@
+# Copyright (c) 2025-2026, The DexVerse Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+from __future__ import annotations
+
+import itertools
+import math
+import os
+import pickle
+
+import numpy as np
+import torch
+from dexverse.assets import DEBUG_HDR_PATH as DEBUG_HDR_ASSET_PATH
+from dexverse.baseline_v1.visual_purpose import hide_marker_from_cameras
+from isaaclab.controllers.differential_ik import DifferentialIKController
+from isaaclab.controllers.differential_ik_cfg import DifferentialIKControllerCfg
+from isaaclab.managers import SceneEntityCfg
+from isaaclab.markers import VisualizationMarkers
+from isaaclab.markers.config import FRAME_MARKER_CFG
+from isaaclab.utils.math import (
+    euler_xyz_from_quat,
+    quat_apply,
+    quat_from_euler_xyz,
+    quat_from_matrix,
+    quat_mul,
+    subtract_frame_transforms,
+)
+
+from .utils import get_init_joint_pos, resolve_env_ids, resolve_joint_ids
+
+
+def _get_or_create_frame_marker(env, key: str, frame_scale: tuple[float, float, float], prim_path: str):
+    if not hasattr(env, "_reset_vis_markers"):
+        env._reset_vis_markers = {}
+    markers = env._reset_vis_markers
+    if key not in markers:
+        frame_marker_cfg = FRAME_MARKER_CFG.copy()
+        frame_marker_cfg.markers["frame"].scale = frame_scale
+        markers[key] = VisualizationMarkers(frame_marker_cfg.replace(prim_path=prim_path))
+        hide_marker_from_cameras(markers[key])
+    return markers[key]
+
+
+def _get_hand_joint_defaults(robot, env_ids_t: torch.Tensor, arm_joint_ids, device: torch.device):
+    """Get non-arm joint ids and their default state for selected envs."""
+    if isinstance(arm_joint_ids, slice):
+        return [], None, None
+
+    num_total_joints = robot.data.joint_pos.shape[1]
+    all_indices = torch.arange(num_total_joints, device=device, dtype=torch.long)
+    arm_mask = torch.zeros(num_total_joints, dtype=torch.bool, device=device)
+    if torch.is_tensor(arm_joint_ids):
+        arm_mask[arm_joint_ids.to(device=device, dtype=torch.long)] = True
+    else:
+        arm_mask[arm_joint_ids] = True
+    hand_joint_ids_list = all_indices[~arm_mask].tolist()
+    if len(hand_joint_ids_list) == 0:
+        return hand_joint_ids_list, None, None
+
+    default_hand_pos = robot.data.default_joint_pos[env_ids_t][:, hand_joint_ids_list].clone()
+    default_hand_vel = torch.zeros_like(default_hand_pos)
+    return hand_joint_ids_list, default_hand_pos, default_hand_vel
+
+
+def reset_root_pose_uniform(
+    env,
+    env_ids: torch.Tensor,
+    asset_cfg: SceneEntityCfg,
+    pose_range: dict,
+    velocity_range: dict | None = None,
+    yaw_choices: tuple[float, ...] | list[float] | None = None,
+):
+    """Reset root pose and root velocity from uniform ranges.
+
+    ``pose_range`` values are treated as offsets from ``default_root_state``.
+    When ``yaw_choices`` is provided, one yaw centre is sampled uniformly per
+    environment and the ``pose_range['yaw']`` draw is added as local variance.
+    ``velocity_range`` is absolute world-frame velocity; when omitted, all
+    linear/angular components are reset to zero.
+    """
+    asset = env.scene[asset_cfg.name]
+
+    env_ids_t = resolve_env_ids(env, env_ids)
+
+    root_state = asset.data.default_root_state[env_ids_t].clone()  # (N, 13)
+    num = env_ids_t.shape[0]
+
+    # Translation offsets
+    offsets = torch.zeros((num, 3), device=env.device)
+    x_range = pose_range.get("x", (0.0, 0.0))
+    y_range = pose_range.get("y", (0.0, 0.0))
+    z_range = pose_range.get("z", (0.0, 0.0))
+    offsets[:, 0].uniform_(x_range[0], x_range[1])
+    offsets[:, 1].uniform_(y_range[0], y_range[1])
+    offsets[:, 2].uniform_(z_range[0], z_range[1])
+    root_state[:, 0:3] = root_state[:, 0:3] + env.scene.env_origins[env_ids_t] + offsets
+
+    # Orientation offsets (roll/pitch/yaw)
+    roll_range = pose_range.get("roll", (0.0, 0.0))
+    pitch_range = pose_range.get("pitch", (0.0, 0.0))
+    yaw_range = pose_range.get("yaw", (0.0, 0.0))
+    euler = torch.zeros((num, 3), device=env.device)
+    euler[:, 0].uniform_(roll_range[0], roll_range[1])
+    euler[:, 1].uniform_(pitch_range[0], pitch_range[1])
+    euler[:, 2].uniform_(yaw_range[0], yaw_range[1])
+    if yaw_choices is not None:
+        if len(yaw_choices) == 0:
+            raise ValueError("reset_root_pose_uniform: yaw_choices must not be empty")
+        yaw_centers = torch.as_tensor(yaw_choices, device=env.device, dtype=euler.dtype)
+        choice_ids = torch.randint(yaw_centers.numel(), (num,), device=env.device)
+        euler[:, 2] += yaw_centers[choice_ids]
+    delta_quat = quat_from_euler_xyz(euler[:, 0], euler[:, 1], euler[:, 2])
+    root_state[:, 3:7] = quat_mul(root_state[:, 3:7], delta_quat)
+
+    # Root linear / angular velocity. Keep deterministic zero defaults.
+    if velocity_range is None:
+        velocity_range = {}
+
+    lin_x_range = velocity_range.get("x", (0.0, 0.0))
+    lin_y_range = velocity_range.get("y", (0.0, 0.0))
+    lin_z_range = velocity_range.get("z", (0.0, 0.0))
+    ang_x_range = velocity_range.get("roll", velocity_range.get("wx", (0.0, 0.0)))
+    ang_y_range = velocity_range.get("pitch", velocity_range.get("wy", (0.0, 0.0)))
+    ang_z_range = velocity_range.get("yaw", velocity_range.get("wz", (0.0, 0.0)))
+
+    root_state[:, 7].uniform_(lin_x_range[0], lin_x_range[1])
+    root_state[:, 8].uniform_(lin_y_range[0], lin_y_range[1])
+    root_state[:, 9].uniform_(lin_z_range[0], lin_z_range[1])
+    root_state[:, 10].uniform_(ang_x_range[0], ang_x_range[1])
+    root_state[:, 11].uniform_(ang_y_range[0], ang_y_range[1])
+    root_state[:, 12].uniform_(ang_z_range[0], ang_z_range[1])
+
+    # Kinematic rigid bodies cannot accept velocity writes in PhysX.
+    asset.write_root_pose_to_sim(root_state[:, 0:7], env_ids=env_ids_t)
+    spawn_cfg = getattr(asset.cfg, "spawn", None)
+    rigid_props = getattr(spawn_cfg, "rigid_props", None)
+    is_kinematic = bool(getattr(rigid_props, "kinematic_enabled", False))
+    if not is_kinematic:
+        asset.write_root_velocity_to_sim(root_state[:, 7:13], env_ids=env_ids_t)
+
+
+def reset_random_support_and_goal(
+    env,
+    env_ids: torch.Tensor,
+    support_cfgs: tuple[SceneEntityCfg, ...] | list[SceneEntityCfg],
+    support_heights: tuple[float, ...] | list[float],
+    goal_cfg: SceneEntityCfg,
+    goal_xy_range: dict[str, tuple[float, float] | list[float]],
+    support_base_z: float,
+    goal_z_clearance: float = 0.0,
+    yaw_range: tuple[float, float] | list[float] = (0.0, 0.0),
+    inactive_z: float = -2.0,
+):
+    """Choose one raised support per environment and align a goal to its top.
+
+    Each entry in ``support_cfgs`` is a separately-authored, bottom-origin
+    support with the corresponding height in ``support_heights``. One support
+    is sampled per reset; it is placed at the sampled goal xy/yaw with its feet
+    at ``support_base_z``, while the other supports are parked at
+    ``inactive_z``. The goal receives the same xy/yaw and sits at the selected
+    top height plus ``goal_z_clearance``.
+
+    Discrete support assets are used instead of translating one table upward:
+    changing the latter's root z would leave its legs floating above the main
+    table.
+    """
+    if len(support_cfgs) == 0:
+        raise ValueError("reset_random_support_and_goal: support_cfgs must not be empty")
+    if len(support_cfgs) != len(support_heights):
+        raise ValueError("reset_random_support_and_goal: support_cfgs and support_heights must have equal length")
+
+    env_ids_t = resolve_env_ids(env, env_ids)
+    num = env_ids_t.shape[0]
+    dtype = env.scene[goal_cfg.name].data.root_pos_w.dtype
+
+    x_range = goal_xy_range.get("x", (0.0, 0.0))
+    y_range = goal_xy_range.get("y", (0.0, 0.0))
+    x = torch.empty(num, device=env.device, dtype=dtype).uniform_(x_range[0], x_range[1])
+    y = torch.empty(num, device=env.device, dtype=dtype).uniform_(y_range[0], y_range[1])
+    yaw = torch.empty(num, device=env.device, dtype=dtype).uniform_(yaw_range[0], yaw_range[1])
+    selected = torch.randint(len(support_cfgs), (num,), device=env.device)
+    heights = torch.as_tensor(support_heights, device=env.device, dtype=dtype)
+
+    # The sampled ranges are offsets from each entity's authored default pose,
+    # matching reset_root_pose_uniform's convention.
+    goal = env.scene[goal_cfg.name]
+    goal_pose = goal.data.default_root_state[env_ids_t, :7].clone()
+    goal_pose[:, 0] += env.scene.env_origins[env_ids_t, 0] + x
+    goal_pose[:, 1] += env.scene.env_origins[env_ids_t, 1] + y
+    goal_pose[:, 2] = float(support_base_z) + heights[selected] + float(goal_z_clearance)
+    goal_pose[:, 2] += env.scene.env_origins[env_ids_t, 2]
+    yaw_quat = quat_from_euler_xyz(torch.zeros_like(yaw), torch.zeros_like(yaw), yaw)
+    goal_pose[:, 3:7] = quat_mul(goal_pose[:, 3:7], yaw_quat)
+    goal.write_root_pose_to_sim(goal_pose, env_ids=env_ids_t)
+
+    for support_index, support_cfg in enumerate(support_cfgs):
+        support = env.scene[support_cfg.name]
+        support_pose = support.data.default_root_state[env_ids_t, :7].clone()
+        active = selected == support_index
+        support_pose[:, 0] = goal_pose[:, 0]
+        support_pose[:, 1] = goal_pose[:, 1]
+        support_pose[:, 2] = torch.where(
+            active,
+            torch.full_like(x, float(support_base_z)) + env.scene.env_origins[env_ids_t, 2],
+            torch.full_like(x, float(inactive_z)) + env.scene.env_origins[env_ids_t, 2],
+        )
+        support_pose[:, 3:7] = goal_pose[:, 3:7]
+        support.write_root_pose_to_sim(support_pose, env_ids=env_ids_t)
+
+
+def reset_root_pose_uniform_excluding(
+    env,
+    env_ids: torch.Tensor,
+    asset_cfg: SceneEntityCfg,
+    pose_range: dict,
+    *,
+    reference_asset_cfg: SceneEntityCfg,
+    min_xy_distance: float = 0.0,
+    footprint_half_extents: tuple[float, float] | None = None,
+    footprint_center_local: tuple[float, float] = (0.0, 0.0),
+    reference_footprint_half_extents: tuple[float, float] | None = None,
+    reference_footprint_center_local: tuple[float, float] = (0.0, 0.0),
+    footprint_clearance: float = 0.0,
+    max_attempts: int = 20,
+    velocity_range: dict | None = None,
+):
+    """Like :func:`reset_root_pose_uniform`, with collision-safe xy sampling.
+
+    ``min_xy_distance`` retains the original root-to-root distance constraint.
+    For closer layouts, pass both ``footprint_half_extents`` and
+    ``reference_footprint_half_extents`` to reject overlap between the two
+    yaw-oriented rectangular footprints instead. ``footprint_center_local``
+    offsets a footprint whose centre is not at its asset root (for example, an
+    open folder whose cover extends to one side). ``footprint_clearance`` adds
+    a world-space gap around the rectangles. The distance and footprint tests
+    are combined when both are enabled.
+
+    The reference asset's pose is read at call time, so for the constraint to
+    be meaningful this event must run *after* the reference asset has been
+    reset (the existing ``reset_object`` event normally satisfies this).
+
+    The footprint test is planar: roll and pitch do not change its projected
+    extents. If the constraints cannot be satisfied within ``max_attempts``,
+    the last sampled pose is kept and a warning is printed -- usually a sign
+    the sampling box is too small for the requested clearance.
+    """
+    if (footprint_half_extents is None) != (reference_footprint_half_extents is None):
+        raise ValueError(
+            "footprint_half_extents and reference_footprint_half_extents "
+            "must either both be provided or both be omitted"
+        )
+
+    asset = env.scene[asset_cfg.name]
+    reference_asset = env.scene[reference_asset_cfg.name]
+
+    env_ids_t = resolve_env_ids(env, env_ids)
+    num = env_ids_t.shape[0]
+    device = env.device
+
+    root_state = asset.data.default_root_state[env_ids_t].clone()  # (N, 13)
+    base_xyz = root_state[:, 0:3] + env.scene.env_origins[env_ids_t]
+
+    # Reference pose in world frame (already includes env origin).
+    ref_xy = reference_asset.data.root_pos_w[env_ids_t, :2]
+    ref_quat = reference_asset.data.root_quat_w[env_ids_t]
+
+    x_range = pose_range.get("x", (0.0, 0.0))
+    y_range = pose_range.get("y", (0.0, 0.0))
+    z_range = pose_range.get("z", (0.0, 0.0))
+
+    offsets = torch.zeros((num, 3), device=device)
+    offsets[:, 0].uniform_(x_range[0], x_range[1])
+    offsets[:, 1].uniform_(y_range[0], y_range[1])
+    offsets[:, 2].uniform_(z_range[0], z_range[1])
+
+    # Sample orientation before rejection: rectangular footprint overlap
+    # depends on yaw, so every rejected draw must get a fresh xy *and* yaw.
+    roll_range = pose_range.get("roll", (0.0, 0.0))
+    pitch_range = pose_range.get("pitch", (0.0, 0.0))
+    yaw_range = pose_range.get("yaw", (0.0, 0.0))
+    euler = torch.zeros((num, 3), device=device)
+    euler[:, 0].uniform_(roll_range[0], roll_range[1])
+    euler[:, 1].uniform_(pitch_range[0], pitch_range[1])
+    euler[:, 2].uniform_(yaw_range[0], yaw_range[1])
+
+    def _resample(mask: torch.Tensor) -> None:
+        n_bad = int(mask.sum().item())
+        new_xy = torch.empty((n_bad, 2), device=device)
+        new_xy[:, 0].uniform_(x_range[0], x_range[1])
+        new_xy[:, 1].uniform_(y_range[0], y_range[1])
+        offsets[mask, 0:2] = new_xy
+        new_euler = torch.empty((n_bad, 3), device=device)
+        new_euler[:, 0].uniform_(roll_range[0], roll_range[1])
+        new_euler[:, 1].uniform_(pitch_range[0], pitch_range[1])
+        new_euler[:, 2].uniform_(yaw_range[0], yaw_range[1])
+        euler[mask] = new_euler
+
+    def _footprints_overlap(candidate_xy: torch.Tensor) -> torch.Tensor:
+        if footprint_half_extents is None or reference_footprint_half_extents is None:
+            return torch.zeros(num, dtype=torch.bool, device=device)
+
+        # The final orientation is default_quat * sampled_delta_quat, matching
+        # the pose written below. Reference yaw comes from its already-reset
+        # world quaternion.
+        delta_quat = quat_from_euler_xyz(euler[:, 0], euler[:, 1], euler[:, 2])
+        candidate_quat = quat_mul(root_state[:, 3:7], delta_quat)
+        _, _, candidate_yaw = euler_xyz_from_quat(candidate_quat)
+        _, _, reference_yaw = euler_xyz_from_quat(ref_quat)
+
+        def _axes(yaw: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+            c, s = torch.cos(yaw), torch.sin(yaw)
+            return torch.stack((c, s), dim=1), torch.stack((-s, c), dim=1)
+
+        cand_x, cand_y = _axes(candidate_yaw)
+        ref_x, ref_y = _axes(reference_yaw)
+        cand_center_offset = (
+            float(footprint_center_local[0]) * cand_x
+            + float(footprint_center_local[1]) * cand_y
+        )
+        ref_center_offset = (
+            float(reference_footprint_center_local[0]) * ref_x
+            + float(reference_footprint_center_local[1]) * ref_y
+        )
+        delta = (ref_xy + ref_center_offset) - (candidate_xy + cand_center_offset)
+
+        cand_half = torch.tensor(footprint_half_extents, device=device, dtype=delta.dtype)
+        ref_half = torch.tensor(reference_footprint_half_extents, device=device, dtype=delta.dtype)
+        clearance = float(footprint_clearance)
+        overlap = torch.ones(num, dtype=torch.bool, device=device)
+        for axis in (cand_x, cand_y, ref_x, ref_y):
+            center_distance = torch.abs(torch.sum(delta * axis, dim=1))
+            cand_radius = cand_half[0] * torch.abs(torch.sum(cand_x * axis, dim=1))
+            cand_radius += cand_half[1] * torch.abs(torch.sum(cand_y * axis, dim=1))
+            ref_radius = ref_half[0] * torch.abs(torch.sum(ref_x * axis, dim=1))
+            ref_radius += ref_half[1] * torch.abs(torch.sum(ref_y * axis, dim=1))
+            overlap &= center_distance < (cand_radius + ref_radius + clearance)
+        return overlap
+
+    def _invalid_draws() -> torch.Tensor:
+        candidate_xy = base_xyz[:, :2] + offsets[:, :2]
+        invalid = _footprints_overlap(candidate_xy)
+        if min_xy_distance > 0.0:
+            delta = candidate_xy - ref_xy
+            min_sq = float(min_xy_distance) * float(min_xy_distance)
+            invalid |= (delta[:, 0] * delta[:, 0] + delta[:, 1] * delta[:, 1]) < min_sq
+        return invalid
+
+    # Rejection-resample only the environments that violate either constraint.
+    for _ in range(max_attempts):
+        invalid = _invalid_draws()
+        if not torch.any(invalid):
+            break
+        _resample(invalid)
+
+    # Re-check after the loop so we don't warn when the last iteration's
+    # resample actually fixed the remaining envs.
+    n_remaining = int(_invalid_draws().sum().item())
+    if n_remaining > 0:
+        print(
+            f"[reset_root_pose_uniform_excluding] WARNING: {n_remaining}/{num} envs "
+            f"could not satisfy the reset collision constraints from "
+            f"'{reference_asset_cfg.name}' after {max_attempts} attempts; "
+            "falling back to last draw. Consider widening the sampling range "
+            "or shrinking the requested clearance."
+        )
+
+    root_state[:, 0:3] = base_xyz + offsets
+
+    # Orientation offsets are the same samples used for footprint rejection.
+    delta_quat = quat_from_euler_xyz(euler[:, 0], euler[:, 1], euler[:, 2])
+    root_state[:, 3:7] = quat_mul(root_state[:, 3:7], delta_quat)
+
+    if velocity_range is None:
+        velocity_range = {}
+    lin_x_range = velocity_range.get("x", (0.0, 0.0))
+    lin_y_range = velocity_range.get("y", (0.0, 0.0))
+    lin_z_range = velocity_range.get("z", (0.0, 0.0))
+    ang_x_range = velocity_range.get("roll", velocity_range.get("wx", (0.0, 0.0)))
+    ang_y_range = velocity_range.get("pitch", velocity_range.get("wy", (0.0, 0.0)))
+    ang_z_range = velocity_range.get("yaw", velocity_range.get("wz", (0.0, 0.0)))
+
+    root_state[:, 7].uniform_(lin_x_range[0], lin_x_range[1])
+    root_state[:, 8].uniform_(lin_y_range[0], lin_y_range[1])
+    root_state[:, 9].uniform_(lin_z_range[0], lin_z_range[1])
+    root_state[:, 10].uniform_(ang_x_range[0], ang_x_range[1])
+    root_state[:, 11].uniform_(ang_y_range[0], ang_y_range[1])
+    root_state[:, 12].uniform_(ang_z_range[0], ang_z_range[1])
+
+    # Kinematic rigid bodies cannot accept velocity writes in PhysX
+    # (mirrors reset_root_pose_uniform).
+    asset.write_root_pose_to_sim(root_state[:, 0:7], env_ids=env_ids_t)
+    spawn_cfg = getattr(asset.cfg, "spawn", None)
+    rigid_props = getattr(spawn_cfg, "rigid_props", None)
+    is_kinematic = bool(getattr(rigid_props, "kinematic_enabled", False))
+    if not is_kinematic:
+        asset.write_root_velocity_to_sim(root_state[:, 7:13], env_ids=env_ids_t)
+
+
+def reset_articulation_with_supports_uniform(
+    env,
+    env_ids: torch.Tensor,
+    asset_cfg: SceneEntityCfg,
+    support_cfgs: list[SceneEntityCfg] | None,
+    pose_range: dict,
+    zero_support_velocity: bool = False,
+    reference_asset_cfg: SceneEntityCfg | None = None,
+    min_xy_distance: float = 0.0,
+    max_attempts: int = 20,
+    exclusion_points_local: list[tuple[float, float, float]] | None = None,
+):
+    """Reset an articulation and its (kinematic) support bodies as one rigid rig.
+
+    A single ``(x, y, z, roll, pitch, yaw)`` offset is sampled per env from
+    ``pose_range`` (offsets from each asset's ``default_root_state``) and applied
+    as one shared rigid transform pivoted at the articulation's default
+    position: the articulation is translated + rotated, and every support is
+    rotated about that same pivot and translated by the same offset.
+
+    This keeps supports (e.g. stands that a thin object rests on) in their
+    authored placement *under* the articulation at any sampled pose, instead of
+    sliding out from under it when each asset is randomized independently.
+
+    Supports are assumed kinematic, so only their pose is written (PhysX rejects
+    velocity writes on kinematic bodies); the articulation root velocity is
+    zeroed. Set ``zero_support_velocity=True`` when the supports are *dynamic*
+    (e.g. a movable tray carried by the robot) so their carried-over velocity is
+    cleared at reset too.
+
+    When ``reference_asset_cfg`` is given, the shared xy offset *and yaw* are
+    rejection-resampled (like :func:`reset_root_pose_uniform_excluding`) so
+    every rig check point stays at least ``min_xy_distance`` (m, world frame)
+    from the reference asset's root -- e.g. spawn a tool rig anywhere around a
+    centre-placed goal prop without overlapping it. ``exclusion_points_local``
+    lists the check points in the rig's pivot frame (rotated with the sampled
+    yaw; default: just the articulation root). Spacing a few points along an
+    elongated rig (tool + stands) with a margin of "rig half-width + prop
+    half-diagonal" lets the rig come much closer than a single circumscribing
+    radius around the root would, while still never overlapping. The
+    reference's pose is read at call time, so its own reset must run *before*
+    this event. If the constraint cannot be met within ``max_attempts``, the
+    last sample is kept and a warning is printed.
+    """
+    env_ids_t = resolve_env_ids(env, env_ids)
+    num = env_ids_t.shape[0]
+    device = env.device
+
+    asset = env.scene[asset_cfg.name]
+
+    # One shared translation offset + rotation per env.
+    offsets = torch.zeros((num, 3), device=device)
+    for i, key in enumerate(("x", "y", "z")):
+        lo, hi = pose_range.get(key, (0.0, 0.0))
+        offsets[:, i].uniform_(lo, hi)
+    euler = torch.zeros((num, 3), device=device)
+    for i, key in enumerate(("roll", "pitch", "yaw")):
+        lo, hi = pose_range.get(key, (0.0, 0.0))
+        euler[:, i].uniform_(lo, hi)
+    delta_quat = quat_from_euler_xyz(euler[:, 0], euler[:, 1], euler[:, 2])
+
+    env_origins = env.scene.env_origins[env_ids_t]
+
+    # Pivot of the shared transform = articulation default position (env-local).
+    asset_root = asset.data.default_root_state[env_ids_t].clone()
+    pivot_local = asset_root[:, 0:3]
+
+    if reference_asset_cfg is not None and min_xy_distance > 0.0:
+        ref_xy = env.scene[reference_asset_cfg.name].data.root_pos_w[env_ids_t, :2]
+        base_xy = pivot_local[:, :2] + env_origins[:, :2]
+        min_sq = float(min_xy_distance) * float(min_xy_distance)
+        x_range = pose_range.get("x", (0.0, 0.0))
+        y_range = pose_range.get("y", (0.0, 0.0))
+        yaw_range = pose_range.get("yaw", (0.0, 0.0))
+        check_pts = torch.tensor(
+            exclusion_points_local if exclusion_points_local else [(0.0, 0.0, 0.0)], device=device, dtype=offsets.dtype
+        )  # (K, 3) in the rig pivot frame
+        for _ in range(max_attempts):
+            too_close = torch.zeros(num, dtype=torch.bool, device=device)
+            for k in range(check_pts.shape[0]):
+                pt_rot = quat_apply(delta_quat, check_pts[k].unsqueeze(0).expand(num, -1))
+                delta = (base_xy + pt_rot[:, :2] + offsets[:, :2]) - ref_xy
+                too_close |= (delta * delta).sum(dim=1) < min_sq
+            if not torch.any(too_close):
+                break
+            n_bad = int(too_close.sum())
+            offsets[too_close, 0] = torch.empty(n_bad, device=device).uniform_(x_range[0], x_range[1])
+            offsets[too_close, 1] = torch.empty(n_bad, device=device).uniform_(y_range[0], y_range[1])
+            euler[too_close, 2] = torch.empty(n_bad, device=device).uniform_(yaw_range[0], yaw_range[1])
+            delta_quat = quat_from_euler_xyz(euler[:, 0], euler[:, 1], euler[:, 2])
+        else:
+            print(
+                f"[reset_articulation_with_supports_uniform] WARNING: could not keep "
+                f"'{asset_cfg.name}' {min_xy_distance} m from '{reference_asset_cfg.name}' "
+                f"within {max_attempts} attempts; keeping the last sample."
+            )
+
+    new_asset_pos = pivot_local + env_origins + offsets
+    new_asset_quat = quat_mul(delta_quat, asset_root[:, 3:7])
+    asset.write_root_pose_to_sim(torch.cat([new_asset_pos, new_asset_quat], dim=-1), env_ids=env_ids_t)
+    asset.write_root_velocity_to_sim(torch.zeros((num, 6), device=device), env_ids=env_ids_t)
+
+    for support_cfg in support_cfgs or []:
+        support = env.scene[support_cfg.name]
+        s_root = support.data.default_root_state[env_ids_t].clone()
+        # Offset from the pivot (env-local), co-rotated with the rig.
+        rel = s_root[:, 0:3] - pivot_local
+        new_s_pos = pivot_local + quat_apply(delta_quat, rel) + env_origins + offsets
+        new_s_quat = quat_mul(delta_quat, s_root[:, 3:7])
+        support.write_root_pose_to_sim(torch.cat([new_s_pos, new_s_quat], dim=-1), env_ids=env_ids_t)
+        if zero_support_velocity:
+            support.write_root_velocity_to_sim(torch.zeros((num, 6), device=device), env_ids=env_ids_t)
+
+
+def reset_object_from_place_annotations(
+    env,
+    env_ids: torch.Tensor,
+    asset_cfg: SceneEntityCfg,
+    per_env_positions,
+    per_env_quats,
+    support_z: float = 0.0,
+    pose_range: dict | None = None,
+):
+    """Reset a rigid object to a per-env upright placement.
+
+    The per-env placement is baked into ``per_env_positions`` / ``per_env_quats``
+    at config construction time (see
+    :func:`dexverse.tasks.object_annotations.collect_object_pool`). With
+    ``MultiAssetSpawnerCfg(random_choice=False)`` environment ``i`` spawns
+    ``usd_paths[i]`` so entry ``i`` of these lists corresponds to env ``i``.
+
+    Args:
+        env: Manager-based env.
+        env_ids: Environments to reset.
+        asset_cfg: Scene entity to reset (defaults to ``object``).
+        per_env_positions: Iterable of ``(dx, dy, dz)`` offsets (one per env).
+            ``dz`` is added to ``support_z`` so the annotated supporting point
+            lands on the support surface.
+        per_env_quats: Iterable of canonical upright quaternions as
+            ``(w, x, y, z)`` (one per env).
+        support_z: World-frame z-height of the supporting surface (e.g. table
+            top). Added to every ``dz``.
+        pose_range: Optional per-call uniform jitter applied on top of the
+            canonical placement. Supported keys: ``x``, ``y``, ``z`` (meters)
+            and ``roll``, ``pitch``, ``yaw`` (radians). All are offsets; yaw is
+            applied around the world +z axis after the canonical quaternion.
+    """
+    asset = env.scene[asset_cfg.name]
+    env_ids_t = resolve_env_ids(env, env_ids)
+    num = env_ids_t.shape[0]
+    device = env.device
+
+    cache = getattr(env, "_object_placement_cache", None)
+    if cache is None:
+        cache = {}
+        env._object_placement_cache = cache
+
+    cache_key = (asset_cfg.name, id(per_env_positions), id(per_env_quats))
+    cached = cache.get(cache_key)
+    if cached is None:
+        pos_t = torch.as_tensor(per_env_positions, device=device, dtype=torch.float32)
+        quat_t = torch.as_tensor(per_env_quats, device=device, dtype=torch.float32)
+        if pos_t.ndim != 2 or pos_t.shape[1] != 3:
+            raise ValueError(f"per_env_positions must be (N, 3); got shape {tuple(pos_t.shape)}")
+        if quat_t.ndim != 2 or quat_t.shape[1] != 4:
+            raise ValueError(f"per_env_quats must be (N, 4); got shape {tuple(quat_t.shape)}")
+        if pos_t.shape[0] == 0 or quat_t.shape[0] == 0:
+            raise ValueError("per_env_positions / per_env_quats must be non-empty")
+        if pos_t.shape[0] < env.num_envs or quat_t.shape[0] < env.num_envs:
+            reps = int(math.ceil(env.num_envs / max(pos_t.shape[0], 1)))
+            pos_t = pos_t.repeat(reps, 1)[: env.num_envs]
+            quat_t = quat_t.repeat(reps, 1)[: env.num_envs]
+        else:
+            pos_t = pos_t[: env.num_envs]
+            quat_t = quat_t[: env.num_envs]
+        # Normalize quats defensively.
+        quat_norm = torch.clamp(torch.linalg.norm(quat_t, dim=1, keepdim=True), min=1e-6)
+        quat_t = quat_t / quat_norm
+        cached = (pos_t.contiguous(), quat_t.contiguous())
+        cache[cache_key] = cached
+
+    pos_t, quat_t = cached
+
+    env_origins = env.scene.env_origins[env_ids_t]
+    base_pos = pos_t[env_ids_t].clone()
+    base_pos[:, 2] = base_pos[:, 2] + float(support_z)
+    target_pos = env_origins + base_pos
+
+    base_quat = quat_t[env_ids_t].clone()
+
+    if pose_range:
+        offsets = torch.zeros((num, 3), device=device, dtype=target_pos.dtype)
+        x_range = pose_range.get("x", (0.0, 0.0))
+        y_range = pose_range.get("y", (0.0, 0.0))
+        z_range = pose_range.get("z", (0.0, 0.0))
+        offsets[:, 0].uniform_(float(x_range[0]), float(x_range[1]))
+        offsets[:, 1].uniform_(float(y_range[0]), float(y_range[1]))
+        offsets[:, 2].uniform_(float(z_range[0]), float(z_range[1]))
+        target_pos = target_pos + offsets
+
+        has_rot = any(k in pose_range for k in ("roll", "pitch", "yaw"))
+        if has_rot:
+            roll_range = pose_range.get("roll", (0.0, 0.0))
+            pitch_range = pose_range.get("pitch", (0.0, 0.0))
+            yaw_range = pose_range.get("yaw", (0.0, 0.0))
+            euler = torch.zeros((num, 3), device=device, dtype=target_pos.dtype)
+            euler[:, 0].uniform_(float(roll_range[0]), float(roll_range[1]))
+            euler[:, 1].uniform_(float(pitch_range[0]), float(pitch_range[1]))
+            euler[:, 2].uniform_(float(yaw_range[0]), float(yaw_range[1]))
+            delta_quat = quat_from_euler_xyz(euler[:, 0], euler[:, 1], euler[:, 2])
+            # Apply delta in world frame: q_final = q_delta * q_base
+            base_quat = quat_mul(delta_quat, base_quat)
+
+    root_pose = torch.cat([target_pos, base_quat], dim=1)
+    asset.write_root_pose_to_sim(root_pose, env_ids=env_ids_t)
+    zero_vel = torch.zeros((num, 6), device=device, dtype=target_pos.dtype)
+    asset.write_root_velocity_to_sim(zero_vel, env_ids=env_ids_t)
+
+
+def reset_clutter_objects(
+    env,
+    env_ids: torch.Tensor,
+    asset_names: list[str] | tuple[str, ...],
+    slot_offsets: list[tuple[float, float]] | tuple[tuple[float, float], ...],
+    base_height: float,
+    slot_offsets_by_asset: list[tuple[float, float]] | tuple[tuple[float, float], ...] | None = None,
+    base_height_by_asset: list[float] | tuple[float, ...] | None = None,
+    position_jitter_x: float = 0.0,
+    position_jitter_y: float = 0.0,
+    position_jitter_z: tuple[float, float] = (0.0, 0.0),
+    roll_range: tuple[float, float] = (0.0, 0.0),
+    pitch_range: tuple[float, float] = (0.0, 0.0),
+    yaw_range: tuple[float, float] = (0.0, 0.0),
+    velocity_range: dict | None = None,
+    unique_slots: bool = True,
+):
+    """Reset clutter objects with optional per-asset XY slots and per-asset base heights.
+
+    Backward compatible:
+    - If ``slot_offsets_by_asset`` is None, XY slots are sampled from ``slot_offsets`` as before.
+    - If ``base_height_by_asset`` is None, ``base_height`` is used for all assets as before.
+    """
+    env_ids_t = resolve_env_ids(env, env_ids)
+    if len(asset_names) == 0:
+        return
+    if slot_offsets_by_asset is None and unique_slots and len(slot_offsets) < len(asset_names):
+        raise ValueError(
+            f"Need at least as many slot_offsets as asset_names, got {len(slot_offsets)} < {len(asset_names)}"
+        )
+    if slot_offsets_by_asset is not None and len(slot_offsets_by_asset) != len(asset_names):
+        raise ValueError(
+            f"slot_offsets_by_asset must match asset_names length, got {len(slot_offsets_by_asset)} !="
+            f" {len(asset_names)}"
+        )
+    if base_height_by_asset is not None and len(base_height_by_asset) != len(asset_names):
+        raise ValueError(
+            f"base_height_by_asset must match asset_names length, got {len(base_height_by_asset)} != {len(asset_names)}"
+        )
+
+    num_envs = env_ids_t.shape[0]
+    num_objects = len(asset_names)
+    device = env.device
+
+    if slot_offsets_by_asset is not None:
+        sampled_xy = (
+            torch.tensor(slot_offsets_by_asset, device=device, dtype=torch.float32).unsqueeze(0).repeat(num_envs, 1, 1)
+        )
+    else:
+        slot_xy = torch.tensor(slot_offsets, device=device, dtype=torch.float32)
+        if unique_slots:
+            slot_indices = torch.argsort(torch.rand((num_envs, len(slot_offsets)), device=device), dim=1)[
+                :, :num_objects
+            ]
+        else:
+            slot_indices = torch.randint(0, len(slot_offsets), (num_envs, num_objects), device=device)
+        sampled_xy = slot_xy[slot_indices]
+
+    sampled_xy[..., 0] += torch.empty((num_envs, num_objects), device=device).uniform_(
+        -position_jitter_x, position_jitter_x
+    )
+    sampled_xy[..., 1] += torch.empty((num_envs, num_objects), device=device).uniform_(
+        -position_jitter_y, position_jitter_y
+    )
+    sampled_z = torch.empty((num_envs, num_objects), device=device).uniform_(position_jitter_z[0], position_jitter_z[1])
+    sampled_roll = torch.empty((num_envs, num_objects), device=device).uniform_(roll_range[0], roll_range[1])
+    sampled_pitch = torch.empty((num_envs, num_objects), device=device).uniform_(pitch_range[0], pitch_range[1])
+    sampled_yaw = torch.empty((num_envs, num_objects), device=device).uniform_(yaw_range[0], yaw_range[1])
+
+    linear_velocity_range = velocity_range or {"x": (0.0, 0.0), "y": (0.0, 0.0), "z": (0.0, 0.0)}
+    env_origins = env.scene.env_origins[env_ids_t]
+    if base_height_by_asset is not None:
+        base_heights = (
+            torch.tensor(base_height_by_asset, device=device, dtype=torch.float32).unsqueeze(0).repeat(num_envs, 1)
+        )
+    else:
+        base_heights = torch.full((num_envs, num_objects), float(base_height), device=device, dtype=torch.float32)
+
+    for object_idx, asset_name in enumerate(asset_names):
+        asset = env.scene[asset_name]
+        root_state = asset.data.default_root_state[env_ids_t].clone()
+
+        root_state[:, 0] = env_origins[:, 0] + sampled_xy[:, object_idx, 0]
+        root_state[:, 1] = env_origins[:, 1] + sampled_xy[:, object_idx, 1]
+        root_state[:, 2] = env_origins[:, 2] + base_heights[:, object_idx] + sampled_z[:, object_idx]
+
+        delta_quat = quat_from_euler_xyz(
+            sampled_roll[:, object_idx],
+            sampled_pitch[:, object_idx],
+            sampled_yaw[:, object_idx],
+        )
+        root_state[:, 3:7] = quat_mul(root_state[:, 3:7], delta_quat)
+
+        root_state[:, 7].uniform_(
+            linear_velocity_range.get("x", (0.0, 0.0))[0], linear_velocity_range.get("x", (0.0, 0.0))[1]
+        )
+        root_state[:, 8].uniform_(
+            linear_velocity_range.get("y", (0.0, 0.0))[0], linear_velocity_range.get("y", (0.0, 0.0))[1]
+        )
+        root_state[:, 9].uniform_(
+            linear_velocity_range.get("z", (0.0, 0.0))[0], linear_velocity_range.get("z", (0.0, 0.0))[1]
+        )
+        root_state[:, 10:13] = 0.0
+
+        asset.write_root_pose_to_sim(root_state[:, 0:7], env_ids=env_ids_t)
+        asset.write_root_velocity_to_sim(root_state[:, 7:13], env_ids=env_ids_t)
+
+
+def reset_random_inverted_v_obstacles(
+    env,
+    env_ids: torch.Tensor,
+    obstacle_asset_cfgs: tuple[tuple[SceneEntityCfg, SceneEntityCfg], ...],
+    slope_center: tuple[float, float, float],
+    slope_quat: tuple[float, float, float, float],
+    active_count_range: tuple[int, int],
+    apex_tangent_range: tuple[float, float],
+    apex_tangent_jitter: float,
+    min_apex_tangent_spacing: float,
+    apex_lateral_range: tuple[float, float],
+    apex_normal_offset: float,
+    leg_length: float,
+    leg_yaw_angle_rad: float,
+    inactive_local_position: tuple[float, float, float] = (0.0, 0.0, -2.0),
+):
+    """Reset multiple small inverted-V obstacles, parking inactive ones below the ramp."""
+    env_ids_t = resolve_env_ids(env, env_ids)
+    num_envs = env_ids_t.shape[0]
+    device = env.device
+    num_obstacles = len(obstacle_asset_cfgs)
+    if num_obstacles == 0:
+        return
+
+    min_active, max_active = active_count_range
+    if min_active < 0 or min_active > max_active or max_active > num_obstacles:
+        raise ValueError(
+            "active_count_range must satisfy 0 <= min <= max <= number of obstacle asset pairs; "
+            f"got {active_count_range} for {num_obstacles} pairs"
+        )
+    valid_active_slot_orders: list[tuple[int, ...]] = [()]
+    if max_active > 0:
+        slot_spacing = (
+            (apex_tangent_range[1] - apex_tangent_range[0]) / (num_obstacles - 1) if num_obstacles > 1 else 0.0
+        )
+        valid_active_slot_orders = [
+            slot_order
+            for slot_order in itertools.permutations(range(num_obstacles), max_active)
+            if all(
+                abs(slot_order[first_idx] - slot_order[second_idx]) * slot_spacing
+                - 2.0 * apex_tangent_jitter
+                >= min_apex_tangent_spacing
+                for first_idx in range(max_active)
+                for second_idx in range(first_idx + 1, max_active)
+            )
+        ]
+        if not valid_active_slot_orders:
+            raise ValueError(
+                "No obstacle slot arrangement satisfies the requested tangent clearance; "
+                f"need {min_apex_tangent_spacing:.3f} m for {max_active} active obstacles"
+            )
+
+    env_origins = env.scene.env_origins[env_ids_t]
+    slope_quat_t = torch.tensor(slope_quat, device=device, dtype=torch.float32).unsqueeze(0).repeat(num_envs, 1)
+    slope_center_t = torch.tensor(slope_center, device=device, dtype=torch.float32).unsqueeze(0).repeat(num_envs, 1)
+    inactive_local = (
+        torch.tensor(inactive_local_position, device=device, dtype=torch.float32).unsqueeze(0).repeat(num_envs, 1)
+    )
+    inactive_pos = env_origins + slope_center_t + quat_apply(slope_quat_t, inactive_local)
+
+    active_counts = torch.randint(min_active, max_active + 1, (num_envs,), device=device)
+    slot_tangents = torch.linspace(
+        apex_tangent_range[0],
+        apex_tangent_range[1],
+        num_obstacles,
+        device=device,
+        dtype=torch.float32,
+    )
+    if max_active > 0:
+        valid_slot_orders_t = torch.tensor(valid_active_slot_orders, device=device, dtype=torch.long)
+        sampled_order_indices = torch.randint(valid_slot_orders_t.shape[0], (num_envs,), device=device)
+        active_slot_order = valid_slot_orders_t[sampled_order_indices]
+    else:
+        active_slot_order = torch.empty((num_envs, 0), device=device, dtype=torch.long)
+
+    left_dir_local = torch.tensor(
+        [math.cos(leg_yaw_angle_rad), math.sin(leg_yaw_angle_rad), 0.0], device=device, dtype=torch.float32
+    ).unsqueeze(0)
+    right_dir_local = torch.tensor(
+        [math.cos(-leg_yaw_angle_rad), math.sin(-leg_yaw_angle_rad), 0.0], device=device, dtype=torch.float32
+    ).unsqueeze(0)
+    half_leg = 0.5 * leg_length
+
+    left_yaw = torch.full((num_envs,), leg_yaw_angle_rad, device=device, dtype=torch.float32)
+    right_yaw = torch.full((num_envs,), -leg_yaw_angle_rad, device=device, dtype=torch.float32)
+    zero = torch.zeros_like(left_yaw)
+    left_local_quat = quat_from_euler_xyz(zero, zero, left_yaw)
+    right_local_quat = quat_from_euler_xyz(zero, zero, right_yaw)
+    left_quat = quat_mul(slope_quat_t, left_local_quat)
+    right_quat = quat_mul(slope_quat_t, right_local_quat)
+
+    for obstacle_idx, (left_asset_cfg, right_asset_cfg) in enumerate(obstacle_asset_cfgs):
+        active_mask = (obstacle_idx < active_counts).unsqueeze(1)
+        apex_local = torch.zeros((num_envs, 3), device=device, dtype=torch.float32)
+        if obstacle_idx < max_active:
+            apex_local[:, 0] = slot_tangents[active_slot_order[:, obstacle_idx]]
+        if apex_tangent_jitter > 0.0:
+            apex_local[:, 0] += torch.empty(num_envs, device=device, dtype=torch.float32).uniform_(
+                -apex_tangent_jitter, apex_tangent_jitter
+            )
+        apex_local[:, 1].uniform_(apex_lateral_range[0], apex_lateral_range[1])
+        apex_local[:, 2] = apex_normal_offset
+
+        # The apex is the downhill tip, so each leg extends uphill from it.
+        left_center_local = apex_local + half_leg * left_dir_local
+        right_center_local = apex_local + half_leg * right_dir_local
+        left_pos = env_origins + slope_center_t + quat_apply(slope_quat_t, left_center_local)
+        right_pos = env_origins + slope_center_t + quat_apply(slope_quat_t, right_center_local)
+        left_pos = torch.where(active_mask, left_pos, inactive_pos)
+        right_pos = torch.where(active_mask, right_pos, inactive_pos)
+
+        left_asset = env.scene[left_asset_cfg.name]
+        right_asset = env.scene[right_asset_cfg.name]
+        left_root_state = left_asset.data.default_root_state[env_ids_t].clone()
+        right_root_state = right_asset.data.default_root_state[env_ids_t].clone()
+        left_root_state[:, 0:3] = left_pos
+        left_root_state[:, 3:7] = left_quat
+        left_root_state[:, 7:13] = 0.0
+        right_root_state[:, 0:3] = right_pos
+        right_root_state[:, 3:7] = right_quat
+        right_root_state[:, 7:13] = 0.0
+
+        left_asset.write_root_pose_to_sim(left_root_state[:, 0:7], env_ids=env_ids_t)
+        left_asset.write_root_velocity_to_sim(left_root_state[:, 7:13], env_ids=env_ids_t)
+        right_asset.write_root_pose_to_sim(right_root_state[:, 0:7], env_ids=env_ids_t)
+        right_asset.write_root_velocity_to_sim(right_root_state[:, 7:13], env_ids=env_ids_t)
+
+
+def reset_inverted_v_obstacles_with_corridor(
+    env,
+    env_ids: torch.Tensor,
+    obstacle_asset_cfgs: tuple[tuple[SceneEntityCfg, SceneEntityCfg], ...],
+    slope_center: tuple[float, float, float],
+    slope_quat: tuple[float, float, float, float],
+    num_active: int,
+    apex_tangent_range: tuple[float, float],
+    min_apex_tangent_spacing: float,
+    apex_lateral_limit: float,
+    obstacle_lateral_half_extent: float,
+    corridor_width: float,
+    corridor_center_range: tuple[float, float],
+    apex_normal_offset: float,
+    leg_length: float,
+    leg_yaw_angle_rad: float,
+    inactive_local_position: tuple[float, float, float] = (0.0, 0.0, -2.0),
+):
+    """Randomly place inverted-V obstacles on a ramp while guaranteeing a free corridor.
+
+    "Well-behaved" obstacle randomization (Aug 2026): the first ``num_active``
+    obstacle pairs are placed, the rest are parked below the ramp.
+
+    * **Tangent (uphill) rows**: ``num_active`` apex tangents are drawn uniformly
+      over ``apex_tangent_range`` subject to a minimum apex spacing of
+      ``min_apex_tangent_spacing`` (sorted; obstacle ``i`` is row ``i`` from the
+      bottom), so chevrons never overlap along the slope.
+    * **Straight corridor**: one lateral corridor of width ``corridor_width``
+      (sphere diameter + margin) centred at a per-env draw from
+      ``corridor_center_range`` is kept free of every obstacle: each obstacle is
+      placed on a random feasible side of it, uniformly within the lateral room
+      left between the corridor edge and ``apex_lateral_limit`` (which already
+      encodes the side-guard clearance). The sphere can therefore always be
+      pushed straight up the ramp through the gaps, whatever the draw.
+
+    Positions are in the slope frame (x = tangent uphill, y = lateral,
+    z = normal). Raises at call time if the geometry cannot host the corridor
+    on at least one side of every obstacle for every corridor centre.
+    """
+    env_ids_t = resolve_env_ids(env, env_ids)
+    num_envs = env_ids_t.shape[0]
+    if num_envs == 0:
+        return
+    device = env.device
+    num_obstacles = len(obstacle_asset_cfgs)
+    if not 0 <= num_active <= num_obstacles:
+        raise ValueError(f"num_active must be within [0, {num_obstacles}]; got {num_active}")
+    t_lo, t_hi = float(apex_tangent_range[0]), float(apex_tangent_range[1])
+    spacing = float(min_apex_tangent_spacing)
+    if num_active > 1 and t_hi - t_lo < (num_active - 1) * spacing:
+        raise ValueError(
+            f"apex_tangent_range {apex_tangent_range} cannot host {num_active} obstacles "
+            f"with min spacing {spacing:.3f} m"
+        )
+    half_w = 0.5 * float(corridor_width)
+    h = float(obstacle_lateral_half_extent)
+    limit = float(apex_lateral_limit)
+    c_lo, c_hi = float(corridor_center_range[0]), float(corridor_center_range[1])
+    # For every corridor centre at least one side must have room for an obstacle.
+    if limit < half_w + h or max(abs(c_lo), abs(c_hi)) > limit:
+        raise ValueError(
+            "Corridor does not fit: need apex_lateral_limit >= corridor_width/2 + obstacle_lateral_half_extent "
+            f"({limit:.3f} vs {half_w + h:.3f}) and |corridor centre| <= apex_lateral_limit"
+        )
+
+    env_origins = env.scene.env_origins[env_ids_t]
+    slope_quat_t = torch.tensor(slope_quat, device=device, dtype=torch.float32).unsqueeze(0).repeat(num_envs, 1)
+    slope_center_t = torch.tensor(slope_center, device=device, dtype=torch.float32).unsqueeze(0).repeat(num_envs, 1)
+    inactive_local = (
+        torch.tensor(inactive_local_position, device=device, dtype=torch.float32).unsqueeze(0).repeat(num_envs, 1)
+    )
+    inactive_pos = env_origins + slope_center_t + quat_apply(slope_quat_t, inactive_local)
+
+    # Sorted tangents with guaranteed spacing: uniform draws in the compressed
+    # band, sorted, then spread back out by i * spacing.
+    if num_active > 0:
+        band = t_hi - t_lo - (num_active - 1) * spacing
+        draws = torch.rand((num_envs, num_active), device=device) * band + t_lo
+        tangents = torch.sort(draws, dim=1).values + spacing * torch.arange(num_active, device=device, dtype=torch.float32)
+    else:
+        tangents = torch.zeros((num_envs, 0), device=device)
+    corridor_c = torch.empty(num_envs, device=device).uniform_(c_lo, c_hi)
+    # Lateral room on each side of the corridor: y in [-limit, c - half_w - h] (left of
+    # the corridor, i.e. toward -y) or [c + half_w + h, limit].
+    left_hi = corridor_c - half_w - h
+    right_lo = corridor_c + half_w + h
+    left_ok = left_hi >= -limit
+    right_ok = right_lo <= limit
+
+    left_dir_local = torch.tensor(
+        [math.cos(leg_yaw_angle_rad), math.sin(leg_yaw_angle_rad), 0.0], device=device, dtype=torch.float32
+    ).unsqueeze(0)
+    right_dir_local = torch.tensor(
+        [math.cos(-leg_yaw_angle_rad), math.sin(-leg_yaw_angle_rad), 0.0], device=device, dtype=torch.float32
+    ).unsqueeze(0)
+    half_leg = 0.5 * leg_length
+    zero = torch.zeros(num_envs, device=device, dtype=torch.float32)
+    left_quat = quat_mul(slope_quat_t, quat_from_euler_xyz(zero, zero, zero + leg_yaw_angle_rad))
+    right_quat = quat_mul(slope_quat_t, quat_from_euler_xyz(zero, zero, zero - leg_yaw_angle_rad))
+
+    for obstacle_idx, (left_asset_cfg, right_asset_cfg) in enumerate(obstacle_asset_cfgs):
+        active = obstacle_idx < num_active
+        apex_local = torch.zeros((num_envs, 3), device=device, dtype=torch.float32)
+        if active:
+            apex_local[:, 0] = tangents[:, obstacle_idx]
+            # pick a side: both feasible -> coin flip; else the feasible one
+            go_left = torch.where(left_ok & right_ok, torch.rand(num_envs, device=device) < 0.5, left_ok)
+            u = torch.rand(num_envs, device=device)
+            y_left = -limit + u * (left_hi + limit)
+            y_right = right_lo + u * (limit - right_lo)
+            apex_local[:, 1] = torch.where(go_left, y_left, y_right)
+        apex_local[:, 2] = apex_normal_offset
+
+        # The apex is the downhill tip, so each leg extends uphill from it.
+        left_center_local = apex_local + half_leg * left_dir_local
+        right_center_local = apex_local + half_leg * right_dir_local
+        left_pos = env_origins + slope_center_t + quat_apply(slope_quat_t, left_center_local)
+        right_pos = env_origins + slope_center_t + quat_apply(slope_quat_t, right_center_local)
+        if not active:
+            left_pos, right_pos = inactive_pos, inactive_pos
+
+        for asset_cfg, pos, quat in ((left_asset_cfg, left_pos, left_quat), (right_asset_cfg, right_pos, right_quat)):
+            asset = env.scene[asset_cfg.name]
+            root_state = asset.data.default_root_state[env_ids_t].clone()
+            root_state[:, 0:3] = pos
+            root_state[:, 3:7] = quat
+            root_state[:, 7:13] = 0.0
+            asset.write_root_pose_to_sim(root_state[:, 0:7], env_ids=env_ids_t)
+            asset.write_root_velocity_to_sim(root_state[:, 7:13], env_ids=env_ids_t)
+
+
+def reset_rod_obstacles_sequential(
+    env,
+    env_ids: torch.Tensor,
+    obstacle_asset_cfgs: tuple[SceneEntityCfg, ...],
+    slope_center: tuple[float, float, float],
+    slope_quat: tuple[float, float, float, float],
+    tangent_range: tuple[float, float],
+    lateral_limit: float,
+    obstacle_radius: float,
+    normal_offset: float,
+    min_center_spacing: float,
+    max_attempts: int = 256,
+):
+    """Sample thin rods uniformly and sequentially over the usable slope.
+
+    Both uphill and lateral coordinates are independent uniform draws over the
+    full configured area. Each candidate is rejected against all earlier rods.
+    ``min_center_spacing`` should include both rod radii when its intended
+    meaning is a free surface-to-surface gap. No strata, corridor, or
+    deliberately safe route is reserved. If dense packing paints the greedy
+    sampler into a corner, a valid lattice seed is repeatedly randomized with
+    full-area uniform proposals, retaining the same inter-rod spacing without
+    leaving the fallback as a regular grid.
+    """
+    env_ids_t = resolve_env_ids(env, env_ids)
+    num_envs = env_ids_t.shape[0]
+    if num_envs == 0:
+        return
+    if len(obstacle_asset_cfgs) == 0:
+        return
+    if max_attempts <= 0:
+        raise ValueError("reset_rod_obstacles_sequential: max_attempts must be positive")
+
+    device = env.device
+    dtype = torch.float32
+    t_lo, t_hi = (float(v) for v in tangent_range)
+    limit = float(lateral_limit)
+    radius = float(obstacle_radius)
+    spacing_sq = float(min_center_spacing) ** 2
+    if t_lo >= t_hi:
+        raise ValueError(f"invalid tangent_range: {tangent_range}")
+    if limit <= radius:
+        raise ValueError("lateral_limit must exceed obstacle_radius")
+    # The rare fallback uses a uniform rectangular lattice. Verify that enough
+    # lattice positions fit while retaining the requested centre clearance.
+    tangent_slots = int(math.floor((t_hi - t_lo) / float(min_center_spacing))) + 1
+    lateral_slots = int(math.floor((2.0 * limit) / float(min_center_spacing))) + 1
+    if tangent_slots * lateral_slots < len(obstacle_asset_cfgs):
+        raise ValueError("Usable slope area is too small for the rod fallback at the requested spacing.")
+
+    num_rods = len(obstacle_asset_cfgs)
+    accepted: list[torch.Tensor] = []
+    fallback_envs = torch.zeros(num_envs, dtype=torch.bool, device=device)
+
+    def sample_candidate_batch() -> torch.Tensor:
+        centers = torch.empty((num_envs, max_attempts, 2), device=device, dtype=dtype)
+        centers[:, :, 0].uniform_(t_lo, t_hi)
+        centers[:, :, 1].uniform_(-limit, limit)
+        return centers
+
+    for _asset_cfg in obstacle_asset_cfgs:
+        candidates = sample_candidate_batch()
+        if accepted:
+            prior = torch.stack(accepted, dim=1)  # (E, previous, 2)
+            delta = candidates.unsqueeze(2) - prior.unsqueeze(1)
+            valid = (delta.square().sum(dim=-1) >= spacing_sq).all(dim=2)
+        else:
+            valid = torch.ones((num_envs, max_attempts), dtype=torch.bool, device=device)
+        has_valid = valid.any(dim=1)
+        # argmax returns the first True candidate; environments with no valid
+        # candidate temporarily receive candidate zero and are replaced by the
+        # randomized valid seed after all sequential samples are complete.
+        first_valid = valid.to(dtype=torch.int8).argmax(dim=1)
+        centers = candidates[torch.arange(num_envs, device=device), first_valid]
+        fallback_envs |= ~has_valid
+        accepted.append(centers)
+
+    if bool(fallback_envs.any()):
+        # Uniform lattice points are at least min_center_spacing apart along
+        # either axis. Shuffle their assignment so the fallback does not always
+        # associate the same rod index with the same area of the slope.
+        fallback_t = torch.linspace(t_lo, t_hi, tangent_slots, device=device, dtype=dtype)
+        fallback_y = torch.linspace(-limit, limit, lateral_slots, device=device, dtype=dtype)
+        lattice = torch.cartesian_prod(fallback_t, fallback_y)
+        lattice_ids = torch.randperm(lattice.shape[0], device=device)[: len(accepted)]
+        for obstacle_idx, centers in enumerate(accepted):
+            fallback_center = lattice[lattice_ids[obstacle_idx]].unsqueeze(0).expand(num_envs, -1)
+            centers[fallback_envs] = fallback_center[fallback_envs]
+
+        # Ten rods with a sphere-sized free gap form a dense hard-core point
+        # process. Greedy insertion can therefore exhaust its candidates even
+        # though valid layouts exist. Randomize the valid seed using repeated
+        # full-area proposals for each rod; accepted moves preserve all pairwise
+        # constraints and remove the seed lattice's regular appearance.
+        refinement_attempts = min(max_attempts, 64)
+        refinement_sweeps = 8
+        all_env_ids = torch.arange(num_envs, device=device)
+        for _ in range(refinement_sweeps):
+            for obstacle_idx in range(num_rods):
+                candidates = torch.empty((num_envs, refinement_attempts, 2), device=device, dtype=dtype)
+                candidates[:, :, 0].uniform_(t_lo, t_hi)
+                candidates[:, :, 1].uniform_(-limit, limit)
+                other_centers = torch.stack(
+                    [centers for other_idx, centers in enumerate(accepted) if other_idx != obstacle_idx], dim=1
+                )
+                delta = candidates.unsqueeze(2) - other_centers.unsqueeze(1)
+                valid = (delta.square().sum(dim=-1) >= spacing_sq).all(dim=2)
+                has_valid = valid.any(dim=1) & fallback_envs
+                first_valid = valid.to(dtype=torch.int8).argmax(dim=1)
+                proposed = candidates[all_env_ids, first_valid]
+                accepted[obstacle_idx][has_valid] = proposed[has_valid]
+
+    env_origins = env.scene.env_origins[env_ids_t]
+    slope_center_t = torch.tensor(slope_center, device=device, dtype=dtype).unsqueeze(0)
+    slope_quat_t = torch.tensor(slope_quat, device=device, dtype=dtype).unsqueeze(0).expand(num_envs, -1)
+    for asset_cfg, centers in zip(obstacle_asset_cfgs, accepted, strict=True):
+        local = torch.zeros((num_envs, 3), device=device, dtype=dtype)
+        local[:, :2] = centers
+        local[:, 2] = float(normal_offset)
+        pos = env_origins + slope_center_t + quat_apply(slope_quat_t, local)
+        asset = env.scene[asset_cfg.name]
+        root_state = asset.data.default_root_state[env_ids_t].clone()
+        root_state[:, 0:3] = pos
+        root_state[:, 3:7] = slope_quat_t
+        root_state[:, 7:13] = 0.0
+        asset.write_root_pose_to_sim(root_state[:, 0:7], env_ids=env_ids_t)
+        asset.write_root_velocity_to_sim(root_state[:, 7:13], env_ids=env_ids_t)
+
+
+def reset_root_pose_uniform_orientations(
+    env,
+    env_ids: torch.Tensor,
+    asset_cfg: SceneEntityCfg,
+    pose_range: dict,
+    orientations: list,
+    table_top_z: float,
+    weights: list[float] | None = None,
+    buffer_name: str | None = None,
+    reference_asset_cfg: SceneEntityCfg | None = None,
+    min_xy_distance: float = 0.0,
+    max_attempts: int = 30,
+):
+    """Reset a root to a uniform xy / yaw with one of several *rest orientations*.
+
+    ``orientations`` is a list of ``(quat_wxyz, z_offset)`` -- e.g. a cup lying
+    on its side, upside down, or upright -- with per-env categorical
+    ``weights``; the drawn index is stored in ``env.<buffer_name>`` (long, so it
+    can be recorded / observed). The final orientation is ``yaw * quat`` with
+    the yaw drawn from ``pose_range["yaw"]``, and the root sits at
+    ``table_top_z + z_offset`` above the env origin (each rest orientation has
+    its own resting height). ``pose_range["x"/"y"]`` are offsets from the
+    asset's default xy; when ``reference_asset_cfg`` is given the xy is
+    rejection-resampled to stay ``min_xy_distance`` from that asset's root.
+    """
+    asset = env.scene[asset_cfg.name]
+    env_ids_t = resolve_env_ids(env, env_ids)
+    num = env_ids_t.shape[0]
+    if num == 0:
+        return
+    device = env.device
+    root_state = asset.data.default_root_state[env_ids_t].clone()
+    origins = env.scene.env_origins[env_ids_t]
+    x_range = pose_range.get("x", (0.0, 0.0))
+    y_range = pose_range.get("y", (0.0, 0.0))
+    yaw_range = pose_range.get("yaw", (0.0, 0.0))
+    base_xy = root_state[:, 0:2] + origins[:, 0:2]
+    xy = base_xy.clone()
+    xy[:, 0] += torch.empty(num, device=device).uniform_(x_range[0], x_range[1])
+    xy[:, 1] += torch.empty(num, device=device).uniform_(y_range[0], y_range[1])
+    if reference_asset_cfg is not None and min_xy_distance > 0.0:
+        ref_xy = env.scene[reference_asset_cfg.name].data.root_pos_w[env_ids_t, 0:2]
+        for _ in range(max_attempts):
+            bad = torch.linalg.norm(xy - ref_xy, dim=-1) < min_xy_distance
+            if not bool(bad.any()):
+                break
+            n_bad = int(bad.sum())
+            xy[bad, 0] = base_xy[bad, 0] + torch.empty(n_bad, device=device).uniform_(x_range[0], x_range[1])
+            xy[bad, 1] = base_xy[bad, 1] + torch.empty(n_bad, device=device).uniform_(y_range[0], y_range[1])
+    quats = torch.tensor([list(q) for q, _ in orientations], device=device, dtype=torch.float32)
+    z_offsets = torch.tensor([float(z) for _, z in orientations], device=device, dtype=torch.float32)
+    w = torch.ones(len(orientations), device=device) if weights is None else torch.tensor(weights, device=device, dtype=torch.float32)
+    choice = torch.multinomial((w / w.sum()).expand(num, -1), 1).squeeze(1)
+    if buffer_name is not None:
+        buf = getattr(env, buffer_name, None)
+        if buf is None or buf.shape[0] != env.num_envs:
+            buf = torch.zeros(env.num_envs, device=device, dtype=torch.long)
+            setattr(env, buffer_name, buf)
+        buf[env_ids_t] = choice
+    yaw = torch.empty(num, device=device).uniform_(yaw_range[0], yaw_range[1])
+    zero = torch.zeros_like(yaw)
+    quat = quat_mul(quat_from_euler_xyz(zero, zero, yaw), quats[choice])
+    root_state[:, 0:2] = xy
+    root_state[:, 2] = origins[:, 2] + float(table_top_z) + z_offsets[choice]
+    root_state[:, 3:7] = quat
+    root_state[:, 7:13] = 0.0
+    asset.write_root_pose_to_sim(root_state[:, 0:7], env_ids=env_ids_t)
+    asset.write_root_velocity_to_sim(root_state[:, 7:13], env_ids=env_ids_t)
+
+
+def sync_object(
+    env,
+    env_ids: torch.Tensor,
+    target_cfg: SceneEntityCfg,
+    source_cfg: SceneEntityCfg,
+    z_offset: float = 0.0,
+    quat: tuple[float, float, float, float] | None = None,
+    source_local_offset: tuple[float, float, float] | None = None,
+    quat_local: tuple[float, float, float, float] | None = None,
+    xy_jitter_range: dict | None = None,
+):
+    """Align target to source's pose with optional offsets.
+
+    The target's world position is computed as
+    ``source.root_pos + R(source.root_quat) * source_local_offset``, then a
+    flat ``z_offset`` is added to z. ``source_local_offset`` defaults to
+    ``None`` (treated as zero) so the legacy "copy xy, offset z" behaviour
+    is preserved for existing call sites.
+
+    ``xy_jitter_range`` (e.g. ``{"x": (-0.04, 0.04), "y": (-0.04, 0.04)}``)
+    adds a per-env uniform *world-frame* xy offset on top. Shifting the
+    target while the source stays put randomizes the source's pose relative
+    to the target — e.g. where an object sits on the stand synced under it.
+
+    Orientation (pick at most one of ``quat`` / ``quat_local``):
+      - ``quat`` (default ``None``): absolute world-frame orientation. When
+        given it is written verbatim, so the target does *not* follow the
+        source's rotation. When ``None`` the target keeps its current quat.
+      - ``quat_local``: a quaternion expressed in the *source's* frame. The
+        target's world orientation becomes ``R(source.root_quat) * quat_local``
+        so the target rotates rigidly with the source. Use this when the
+        source is re-randomized (e.g. yaw jitter) and the target must follow.
+    """
+    target = env.scene[target_cfg.name]
+    source = env.scene[source_cfg.name]
+
+    if quat is not None and quat_local is not None:
+        raise ValueError("sync_object: pass at most one of `quat` / `quat_local`.")
+
+    env_ids_t = resolve_env_ids(env, env_ids)
+
+    pos = source.data.root_pos_w[env_ids_t].clone()
+    if source_local_offset is not None:
+        offset_local = torch.tensor(source_local_offset, device=env.device, dtype=pos.dtype)
+        offset_world = quat_apply(
+            source.data.root_quat_w[env_ids_t],
+            offset_local.unsqueeze(0).expand(env_ids_t.shape[0], -1),
+        )
+        pos = pos + offset_world
+    if xy_jitter_range is not None:
+        x_range = xy_jitter_range.get("x", (0.0, 0.0))
+        y_range = xy_jitter_range.get("y", (0.0, 0.0))
+        jitter = torch.zeros((env_ids_t.shape[0], 3), device=env.device, dtype=pos.dtype)
+        jitter[:, 0].uniform_(x_range[0], x_range[1])
+        jitter[:, 1].uniform_(y_range[0], y_range[1])
+        pos = pos + jitter
+    pos[:, 2] = pos[:, 2] + z_offset
+
+    if quat_local is not None:
+        quat_local_t = (
+            torch.tensor(quat_local, device=env.device, dtype=pos.dtype).unsqueeze(0).repeat(env_ids_t.shape[0], 1)
+        )
+        quat_t = quat_mul(source.data.root_quat_w[env_ids_t], quat_local_t)
+    elif quat is None:
+        quat_t = target.data.root_quat_w[env_ids_t]
+    else:
+        quat_t = torch.tensor(quat, device=env.device, dtype=pos.dtype).unsqueeze(0).repeat(env_ids_t.shape[0], 1)
+
+    target.write_root_pose_to_sim(torch.cat([pos, quat_t], dim=1), env_ids=env_ids_t)
+
+
+def reset_joints_to_init(
+    env,
+    env_ids: torch.Tensor,
+    asset_cfg: SceneEntityCfg = SceneEntityCfg("robot"),
+):
+    """Reset joints to init_state positions (fallback to default if not specified)."""
+    asset = env.scene[asset_cfg.name]
+
+    joint_ids = resolve_joint_ids(env, asset_cfg)
+    env_ids_t = resolve_env_ids(env, env_ids)
+
+    joint_pos = get_init_joint_pos(asset, joint_ids)[env_ids_t]
+    joint_vel = torch.zeros_like(joint_pos)
+    # Two-step indexing: advanced-indexing on dim 0 (env_ids), then basic
+    # slicing on dim 1 (joint_ids). The original ``[env_ids, joint_ids]``
+    # form requires PyTorch to broadcast the two index tensors, which fails
+    # when both are multi-element and their lengths differ — e.g. 50 envs
+    # × 2 articulation joints. This form returns ``[N_envs, N_joints, 2]``
+    # uniformly.
+    joint_pos_limits = asset.data.soft_joint_pos_limits[env_ids_t][:, joint_ids]
+    joint_pos = joint_pos.clamp_(joint_pos_limits[..., 0], joint_pos_limits[..., 1])
+    asset.write_joint_state_to_sim(joint_pos, joint_vel, joint_ids=joint_ids, env_ids=env_ids_t)
+
+
+def reset_robot_to_pose_ik(
+    env,
+    env_ids: torch.Tensor,
+    resolved_scene_cfg: SceneEntityCfg,
+    ik_method: str = "dls",
+    max_time: float = 1.0,
+    num_ik_iters: int = 10,
+    visualize: bool = True,
+    frame_scale: tuple[float, float, float] = (0.05, 0.05, 0.05),
+    instant_set: bool = False,
+    z_offset: float = 0.02,
+    override_xyz: tuple[float, float, float] | None = None,
+    override_quat: tuple[float, float, float, float] | None = None,
+):
+    # TODO: make this more efficient
+    robot = env.scene[resolved_scene_cfg.name]
+
+    # Ensure SceneEntityCfg is resolved (convert names to indices)
+    # Check if resolution is needed by seeing if joint_ids/body_ids are still slices
+    if (
+        isinstance(resolved_scene_cfg.joint_ids, slice)
+        and resolved_scene_cfg.joint_ids == slice(None)
+        and resolved_scene_cfg.joint_names is not None
+    ):
+        resolved_scene_cfg.resolve(env.scene)
+    if (
+        isinstance(resolved_scene_cfg.body_ids, slice)
+        and resolved_scene_cfg.body_ids == slice(None)
+        and resolved_scene_cfg.body_names is not None
+    ):
+        resolved_scene_cfg.resolve(env.scene)
+
+    # Handle body_ids which can be a list or slice
+    body_ids = resolved_scene_cfg.body_ids
+    if isinstance(body_ids, slice):
+        # Convert slice to list (slice(None) means all bodies, so use first body)
+        if body_ids == slice(None):
+            body_id = 0  # Use first body
+        else:
+            # For other slices, convert to list and take first
+            body_id = list(range(robot.num_bodies))[body_ids][0]
+    else:
+        # It's a list, take first element
+        body_id = body_ids[0]
+
+    # Resolve jacobian body index (see tutorial: fixed-base has one less body index)
+    # For fixed-base robots, the base body (index 0) is not included in the jacobian computation
+    # So we need to subtract 1 from the body index to get the correct jacobian index
+    if robot.is_fixed_base:
+        ee_jacobi_idx = body_id - 1
+    else:
+        ee_jacobi_idx = body_id
+
+    # Joints to control
+    joint_ids = resolved_scene_cfg.joint_ids
+
+    ik_controller = DifferentialIKController(
+        cfg=DifferentialIKControllerCfg(
+            command_type="pose",
+            use_relative_mode=False,
+            ik_method=ik_method,
+        ),
+        num_envs=env.num_envs,
+        device=env.device,
+    )
+    target_pos_w = torch.zeros(env.num_envs, 3, device=env.device, dtype=torch.float32)
+    target_quat_w = torch.zeros(env.num_envs, 4, device=env.device, dtype=torch.float32)
+    wrist_pos_rel: torch.Tensor = env._cached_wrist_pose_npz_simple["wrist_pos_rel"]  # (3,)
+    wrist_rot_rel: torch.Tensor = env._cached_wrist_pose_npz_simple["wrist_rot_rel"]  # (3,3)
+    obj = env.scene["object"]
+    obj_pos_w = obj.data.root_pos_w  # (N,3)
+    obj_quat_w = obj.data.root_quat_w  # (N,4)
+    wrist_pos_rel_expand = wrist_pos_rel.unsqueeze(0).repeat(env.num_envs, 1)  # (N,3)
+    wrist_quat_rel = wrist_rot_rel.unsqueeze(0).repeat(env.num_envs, 1)  # (N,4)
+    # Map demo wrist orientation to robot wrist orientation (orientation only)
+    demo2robot_R = torch.tensor(
+        [[[0.0, 0.0, 1.0], [0.0, -1.0, 0.0], [1.0, 0.0, 0.0]]], device=env.device, dtype=torch.float32
+    )  # (1,3,3)
+    q_map = quat_from_matrix(demo2robot_R).repeat(env.num_envs, 1)  # (N,4)
+    wrist_quat_rel = quat_mul(wrist_quat_rel, q_map)
+    wrist_pos_w = quat_apply(obj_quat_w, wrist_pos_rel_expand) + obj_pos_w
+    # apply a small lift along world z-axis
+    wrist_pos_w[:, 2] += float(z_offset)
+    wrist_quat_w = quat_mul(obj_quat_w, wrist_quat_rel)
+    target_pos_w[env_ids] = wrist_pos_w[env_ids]
+    target_quat_w[env_ids] = wrist_quat_w[env_ids]
+
+    root_pose_w = robot.data.root_pose_w  # [N, 7]
+    root_pos_w = root_pose_w[:, 0:3]
+    root_quat_w = root_pose_w[:, 3:7]
+    target_pos_b, target_quat_b = subtract_frame_transforms(root_pos_w, root_quat_w, target_pos_w, target_quat_w)
+
+    # Optional visualization markers (world-frame). Cache to avoid creating new prims every reset.
+    ee_marker = None
+    goal_marker = None
+    if visualize:
+        ee_marker = _get_or_create_frame_marker(env, "ee", frame_scale, "/Visuals/Reset/EE")
+        goal_marker = _get_or_create_frame_marker(env, "goal", frame_scale, "/Visuals/Reset/Goal")
+
+    # Prepare IK command buffer (7 for absolute pose: x y z qw qx qy qz)
+    ik_cmds = torch.zeros(env.num_envs, ik_controller.action_dim, device=env.device, dtype=torch.float)
+    # Fill only for env_ids; others remain zeros and will be set to no-op below each step
+    # target_pos_b[:, 0] = -0.5
+    # target_pos_b[:, 1] = 0.1
+    # target_pos_b[:, 2] = 0.5
+    ik_cmds[env_ids, 0:3] = target_pos_b[env_ids]
+    ik_cmds[env_ids, 3:7] = target_quat_b[env_ids]
+
+    # Normalize env ids tensor for consistent indexing and save object state before IK
+    env_ids_t = resolve_env_ids(env, env_ids)
+    saved_obj_pose = torch.cat(
+        [obj.data.root_pos_w[env_ids_t], obj.data.root_quat_w[env_ids_t]], dim=-1
+    ).clone()  # (K,7)
+    saved_obj_vel = torch.cat(
+        [obj.data.root_lin_vel_w[env_ids_t], obj.data.root_ang_vel_w[env_ids_t]], dim=-1
+    ).clone()  # (K,6)
+
+    # before IK, reset the robot joints to default state
+    default_joint_pos = robot.data.default_joint_pos[env_ids].clone()
+    default_joint_vel = robot.data.default_joint_vel[env_ids].clone()
+    robot.write_joint_state_to_sim(default_joint_pos, default_joint_vel, env_ids=env_ids)
+    env.scene.write_data_to_sim()
+    env.sim.step()
+    env.scene.update(dt=env.physics_dt)
+
+    if instant_set:
+        # Current EE pose and jacobian
+        # Optimized: reduce iterations (now 3 instead of 10) - most IK convergence happens in first few iterations
+        # NOTE: sim.step() steps ALL environments, not just env_ids. This is a simulator limitation.
+        # Non-resetting environments will advance in time, but their joint states are not modified.
+        for i in range(num_ik_iters):
+            jacobian = robot.root_physx_view.get_jacobians()[:, ee_jacobi_idx, :, joint_ids]
+            ee_pose_w = robot.data.body_pose_w[:, body_id]  # [N, 7]
+            root_pose_w = robot.data.root_pose_w
+            joint_pos = robot.data.joint_pos[:, joint_ids]
+            # EE pose in base frame
+            ee_pos_b, ee_quat_b = subtract_frame_transforms(
+                root_pose_w[:, 0:3], root_pose_w[:, 3:7], ee_pose_w[:, 0:3], ee_pose_w[:, 3:7]
+            )
+            # Compute single-shot IK and write state
+            ik_controller.set_command(ik_cmds)
+            joint_pos_des = ik_controller.compute(ee_pos_b, ee_quat_b, jacobian, joint_pos)
+            joint_vel_full = torch.zeros_like(joint_pos_des)
+            # Only modify joint states for environments being reset
+            joint_pos_des = joint_pos_des[env_ids, ...]
+            joint_vel_full = joint_vel_full[env_ids, ...]
+            robot.write_joint_state_to_sim(joint_pos_des, joint_vel_full, env_ids=env_ids, joint_ids=joint_ids)
+            env.scene.write_data_to_sim()
+            # WARNING: This steps ALL environments, not just env_ids. Non-resetting envs advance in time.
+            env.sim.step()
+            env.scene.update(dt=env.physics_dt)
+            if visualize and ee_marker is not None and goal_marker is not None:
+                ee_marker.visualize(ee_pose_w[:, 0:3], ee_pose_w[:, 3:7])
+                goal_marker.visualize(target_pos_w, target_quat_w)
+
+        # Restore object to its saved pose/velocity (preserve randomized placement)
+        obj.write_root_pose_to_sim(saved_obj_pose, env_ids=env_ids_t)
+        obj.write_root_velocity_to_sim(saved_obj_vel, env_ids=env_ids_t)
+
+        # Get final joint positions after IK (from last iteration)
+        final_joint_pos = robot.data.joint_pos[env_ids_t].clone()
+        final_joint_vel = torch.zeros_like(final_joint_pos)
+
+        # Reset finger joints to their default positions to remove IK disturbances
+        hand_joint_ids_list, default_hand_pos, default_hand_vel = _get_hand_joint_defaults(
+            robot, env_ids_t, joint_ids, env.device
+        )
+        if len(hand_joint_ids_list) > 0:
+            final_joint_pos[:, hand_joint_ids_list] = default_hand_pos
+            final_joint_vel[:, hand_joint_ids_list] = default_hand_vel
+
+        # Write final joint state (arm + hand) to ensure everything is set correctly
+        robot.write_joint_state_to_sim(final_joint_pos, final_joint_vel, env_ids=env_ids_t)
+
+        # Clear any residual joint targets and forces to prevent unwanted motion
+        # Reset actuators and clear external forces/torques
+        robot.reset(env_ids=env_ids_t)
+        # Set position targets to current positions (so PD controller holds them)
+        robot.set_joint_position_target(final_joint_pos, env_ids=env_ids_t)
+        # Set velocity targets to zero
+        robot.set_joint_velocity_target(final_joint_vel, env_ids=env_ids_t)
+        # Zero out any effort/torque targets
+        zero_efforts = torch.zeros_like(final_joint_pos)
+        robot.set_joint_effort_target(zero_efforts, env_ids=env_ids_t)
+
+        # Write all data to sim and do a final step to ensure physics is settled
+        # WARNING: This steps ALL environments, not just env_ids. Non-resetting envs advance in time.
+        env.scene.write_data_to_sim()
+        env.sim.step()
+        env.scene.update(dt=env.physics_dt)
+    else:
+        # Drive over time using joint position targets
+        physics_dt = env.physics_dt
+        sim_time = 0.0
+        while sim_time < max_time:
+            # Current EE pose and jacobian
+            jacobian = robot.root_physx_view.get_jacobians()[:, ee_jacobi_idx, :, joint_ids]
+            ee_pose_w = robot.data.body_pose_w[:, body_id]  # [N, 7]
+            root_pose_w = robot.data.root_pose_w
+            joint_pos = robot.data.joint_pos[:, joint_ids]
+            # EE pose in base frame
+            ee_pos_b, ee_quat_b = subtract_frame_transforms(
+                root_pose_w[:, 0:3], root_pose_w[:, 3:7], ee_pose_w[:, 0:3], ee_pose_w[:, 3:7]
+            )
+            # For non-target envs, set command to current so they no-op
+            not_env_mask = torch.ones(env.num_envs, dtype=torch.bool, device=env.device)
+            not_env_mask[env_ids] = False
+            if not_env_mask.any():
+                ik_cmds[not_env_mask, 0:3] = ee_pos_b[not_env_mask]
+                ik_cmds[not_env_mask, 3:7] = ee_quat_b[not_env_mask]
+            # Compute IK and set joint position targets for selected envs
+            ik_controller.set_command(ik_cmds)
+            joint_pos_des = ik_controller.compute(ee_pos_b, ee_quat_b, jacobian, joint_pos)
+            robot.set_joint_position_target(joint_pos_des[env_ids], joint_ids=joint_ids, env_ids=env_ids)
+            env.scene.write_data_to_sim()
+            env.sim.step()
+            env.scene.update(dt=physics_dt)
+            sim_time += physics_dt
+            # visualize frames (world)
+            if visualize and ee_marker is not None and goal_marker is not None:
+                ee_marker.visualize(ee_pose_w[:, 0:3], ee_pose_w[:, 3:7])
+                goal_marker.visualize(target_pos_w, target_quat_w)
+        # Zero velocities for affected envs to avoid residual motion
+        joint_pos_cur = robot.data.joint_pos[env_ids_t].clone()
+        joint_vel_cur = robot.data.joint_vel[env_ids_t].clone()
+        joint_vel_cur[:, :] = 0.0
+        robot.write_joint_state_to_sim(joint_pos_cur, joint_vel_cur, env_ids=env_ids_t)
+        # Restore object to its saved pose/velocity (preserve randomized placement)
+        obj.write_root_pose_to_sim(saved_obj_pose, env_ids=env_ids_t)
+        obj.write_root_velocity_to_sim(saved_obj_vel, env_ids=env_ids_t)
+        # Reset finger joints to their default positions to remove IK disturbances
+        hand_joint_ids_list, default_hand_pos, default_hand_vel = _get_hand_joint_defaults(
+            robot, env_ids_t, joint_ids, env.device
+        )
+        if len(hand_joint_ids_list) > 0:
+            robot.write_joint_state_to_sim(
+                default_hand_pos, default_hand_vel, env_ids=env_ids_t, joint_ids=hand_joint_ids_list
+            )
+
+
+def visualize_wrist_pose_from_file_simple(
+    env,
+    env_ids: torch.Tensor,
+    resolved_scene_cfg: SceneEntityCfg,
+    object_cfg: SceneEntityCfg = SceneEntityCfg("object"),
+    file_path: str = "",
+    points_key: str = "relative_points",
+    wrist_rot_key: str = "relative_wrist_rot",
+    visualize: bool = True,
+    frame_scale: tuple[float, float, float] = (0.1, 0.1, 0.1),
+):
+    """
+    Simple reset event: load wrist pose in object frame, transform to world via current object pose,
+    compute wrist pose in robot base frame, and visualize frame(s).
+    """
+    # load and cache file
+    if (
+        not hasattr(env, "_cached_wrist_pose_npz_simple")
+        or env._cached_wrist_pose_npz_simple.get("file", "") != file_path
+    ):
+        if not os.path.isfile(file_path):
+            raise FileNotFoundError(f"File not found: {file_path}")
+        if file_path.endswith(".npz"):
+            data = np.load(file_path)
+        elif file_path.endswith(".pkl"):
+            with open(file_path, "rb") as f:
+                data = pickle.load(f)
+        else:
+            raise ValueError(f"Unsupported file type: {file_path}")
+        if points_key not in data or wrist_rot_key not in data:
+            raise KeyError(
+                f"Required keys not in npz. Have: {list(data.keys())}, need: '{points_key}', '{wrist_rot_key}'"
+            )
+        env._cached_wrist_pose_npz_simple = {
+            "file": file_path,
+            "wrist_pos_rel": torch.tensor(data[points_key], dtype=torch.float32, device=env.device),  # (3,)
+            "wrist_rot_rel": torch.tensor(data[wrist_rot_key], dtype=torch.float32, device=env.device),  # (3,3)
+        }
+    wrist_pos_rel: torch.Tensor = env._cached_wrist_pose_npz_simple["wrist_pos_rel"]
+    wrist_rot_rel: torch.Tensor = env._cached_wrist_pose_npz_simple["wrist_rot_rel"]
+
+    # scene references
+    obj = env.scene[object_cfg.name]
+    robot = env.scene[resolved_scene_cfg.name]
+
+    # expand to all envs and compose to world
+    wrist_pos_rel_expand = wrist_pos_rel.unsqueeze(0).repeat(env.num_envs, 1)  # (N,3)
+    # Convert rotation matrix (3x3) to quaternion (4,)
+    # wrist_rot_rel is already a tensor from the cache, but check its shape
+    if isinstance(wrist_rot_rel, torch.Tensor):
+        wrist_rot_rel_shape = wrist_rot_rel.shape
+    else:
+        wrist_rot_rel_shape = np.array(wrist_rot_rel).shape
+        wrist_rot_rel = torch.tensor(wrist_rot_rel, dtype=torch.float32, device=env.device)
+
+    if wrist_rot_rel_shape == (3, 3):
+        # It's a rotation matrix, convert to quaternion
+        wrist_rot_rel_tensor = (
+            wrist_rot_rel.unsqueeze(0) if wrist_rot_rel.dim() == 2 else wrist_rot_rel
+        )  # (1, 3, 3) or (3, 3)
+        if wrist_rot_rel_tensor.dim() == 2:
+            wrist_rot_rel_tensor = wrist_rot_rel_tensor.unsqueeze(0)  # (1, 3, 3)
+        wrist_quat_rel = quat_from_matrix(wrist_rot_rel_tensor).repeat(env.num_envs, 1)  # (N, 4)
+    else:
+        # Already a quaternion or different format
+        if wrist_rot_rel.dim() == 1 or wrist_rot_rel.shape[0] != env.num_envs:
+            wrist_quat_rel = wrist_rot_rel.unsqueeze(0).repeat(env.num_envs, 1)  # (N, 4)
+        else:
+            wrist_quat_rel = wrist_rot_rel
+    obj_pos_w = obj.data.root_pos_w
+    obj_quat_w = obj.data.root_quat_w
+    wrist_pos_w = quat_apply(obj_quat_w, wrist_pos_rel_expand) + obj_pos_w
+    wrist_quat_w = quat_mul(obj_quat_w, wrist_quat_rel)
+    # convert to base frame (for logging / debug)
+    root_pose_w = robot.data.root_pose_w
+    root_pos_w = root_pose_w[:, 0:3]
+    root_quat_w = root_pose_w[:, 3:7]
+    wrist_pos_b, wrist_quat_b = subtract_frame_transforms(root_pos_w, root_quat_w, wrist_pos_w, wrist_quat_w)
+
+    # Get actual robot end-effector link pose for visualization
+    # Try common end-effector link names (order matters - try most specific first)
+    ee_link_body_ids = []
+    ee_body_candidates = ["palm_link", ".*ee.*", ".*wrist.*", ".*end.*effector.*"]
+
+    for candidate in ee_body_candidates:
+        try:
+            candidate_ids, _ = robot.find_bodies(candidate)
+            if len(candidate_ids) > 0:
+                ee_link_body_ids = candidate_ids
+                break
+        except ValueError:
+            # Pattern didn't match, try next candidate
+            continue
+
+    if len(ee_link_body_ids) > 0:
+        ee_body_id = ee_link_body_ids[0]
+        ee_pose_w = robot.data.body_pose_w[:, ee_body_id]  # [N, 7]
+        ee_pos_w = ee_pose_w[:, 0:3]
+        ee_quat_w = ee_pose_w[:, 3:7]
+        # Transform to base frame for visualization
+        ee_pos_b, ee_quat_b = subtract_frame_transforms(root_pos_w, root_quat_w, ee_pos_w, ee_quat_w)
+    else:
+        # Fallback: use root pose if no end-effector link found
+        ee_pos_b = root_pos_w
+        ee_quat_b = root_quat_w
+
+    # visualize one frame per env at the world pose and the object frame
+    if visualize:
+        wrist_marker = _get_or_create_frame_marker(env, "wrist_simple", frame_scale, "/Visuals/Reset/WristSimple")
+        wrist_marker.visualize(translations=wrist_pos_b, orientations=wrist_quat_b)
+        # Visualize actual robot ee_link pose
+        ee_marker = _get_or_create_frame_marker(env, "ee_link_actual", frame_scale, "/Visuals/Reset/EEActual")
+        ee_marker.visualize(translations=ee_pos_b, orientations=ee_quat_b)
+
+    # Store per-env wrist targets for later IK reset usage
+    env_ids_t = resolve_env_ids(env, env_ids)
+    if not hasattr(env, "_reset_targets"):
+        env._reset_targets = {}
+        env._reset_targets["wrist_pos_w"] = torch.zeros(env.num_envs, 3, device=env.device, dtype=torch.float32)
+        env._reset_targets["wrist_quat_w"] = torch.zeros(env.num_envs, 4, device=env.device, dtype=torch.float32)
+    if "wrist_pos_w" not in env._reset_targets or env._reset_targets["wrist_pos_w"].shape[0] != env.num_envs:
+        env._reset_targets["wrist_pos_w"] = torch.zeros(env.num_envs, 3, device=env.device, dtype=torch.float32)
+    if "wrist_quat_w" not in env._reset_targets or env._reset_targets["wrist_quat_w"].shape[0] != env.num_envs:
+        env._reset_targets["wrist_quat_w"] = torch.zeros(env.num_envs, 4, device=env.device, dtype=torch.float32)
+    env._reset_targets["wrist_pos_w"][env_ids_t] = wrist_pos_w[env_ids_t]
+    env._reset_targets["wrist_quat_w"][env_ids_t] = wrist_quat_w[env_ids_t]
+
+
+def reset_environment_background(
+    env,
+    env_ids: torch.Tensor,
+    hdr_paths: list[str] | None = None,
+    indoor_intensity_range: tuple[float, float] = (800.0, 3000.0),
+    outdoor_intensity_range: tuple[float, float] = (1500.0, 4000.0),
+    exposure_range: tuple[float, float] = (-1.0, 1.0),
+    color_temperature_mean_std: tuple[float, float] = (6500.0, 500.0),
+    light_prim_path: str = "/World/skyLight",
+):
+    """Randomize the dome light HDR texture and lighting parameters on reset.
+
+    The dome light is a single global prim shared across all envs, so this
+    samples one HDR per reset call and applies it scene-wide. Indoor vs
+    outdoor intensity is keyed off the substrings ``indoor`` / ``outdoor``
+    appearing (case-insensitively) in the HDR filename.
+    """
+    if hdr_paths is None or len(hdr_paths) == 0:
+        hdr_paths = [str(DEBUG_HDR_ASSET_PATH)]
+
+    hdr_path = str(np.random.choice(hdr_paths))
+
+    name_lower = os.path.basename(hdr_path).lower()
+    if "outdoor" in name_lower:
+        intensity = float(np.random.uniform(*outdoor_intensity_range))
+    else:
+        intensity = float(np.random.uniform(*indoor_intensity_range))
+
+    exposure = float(np.random.uniform(*exposure_range))
+    color_temp = float(np.random.normal(color_temperature_mean_std[0], color_temperature_mean_std[1]))
+
+    # Route writes through Kit's ChangeProperty command. Raw
+    # ``prim.GetAttribute(...).Set(...)`` does not always propagate through
+    # Fabric to the RTX renderer, so the dome light prim would update in USD
+    # but the camera kept rendering with the old intensity/texture.
+    # ChangeProperty fires the notifications Fabric listens to and RTX picks
+    # the change up on the next render.
+    import omni.kit.commands  # local import: Kit is only available post-AppLauncher.
+
+    omni.kit.commands.execute(
+        "ChangeProperty",
+        prop_path=f"{light_prim_path}.inputs:texture:file",
+        value=hdr_path,
+        prev=None,
+    )
+    omni.kit.commands.execute(
+        "ChangeProperty",
+        prop_path=f"{light_prim_path}.inputs:intensity",
+        value=intensity,
+        prev=None,
+    )
+    omni.kit.commands.execute(
+        "ChangeProperty",
+        prop_path=f"{light_prim_path}.inputs:exposure",
+        value=exposure,
+        prev=None,
+    )
+    omni.kit.commands.execute(
+        "ChangeProperty",
+        prop_path=f"{light_prim_path}.inputs:colorTemperature",
+        value=color_temp,
+        prev=None,
+    )
+
+
+def reset_object_on_rack_level(
+    env,
+    env_ids: torch.Tensor,
+    asset_cfg: SceneEntityCfg,
+    rack_cfg: SceneEntityCfg,
+    level_z_tops: list[float],
+    level_x_range: tuple[float, float] = (0.0, 0.0),
+    level_y_range: tuple[float, float] = (0.0, 0.0),
+    yaw_range: tuple[float, float] = (0.0, 0.0),
+    z_offset: float = 0.0,
+    level_weights: list[float] | None = None,
+):
+    """Place ``asset`` on a randomly chosen level of a rack.
+
+    The rack is any rigid body whose local frame matches the manifest written by
+    :mod:`dexverse.assets.rack_builder` (origin on the bottom face, +z up, level
+    ``k`` shelf top at ``level_z_tops[k]``). Reads the rack's *current* pose, so
+    schedule this after the rack's own reset event.
+
+    Per env: level ``k ~ Categorical(level_weights)``, then in the rack frame
+    ``xy ~ U(level_x_range) x U(level_y_range)``, ``z = level_z_tops[k] +
+    z_offset`` (``z_offset`` = the asset's root-to-bottom distance plus any
+    clearance), and orientation ``rack_quat * default_quat * Rz(yaw)`` so the
+    object keeps its rest orientation relative to the rack. Velocities are
+    zeroed. The chosen level index and shelf-top height are stored on the env
+    (``env.rack_level_index``, ``env.rack_level_z``, both ``(num_envs,)``) for
+    observations / logging.
+    """
+    asset = env.scene[asset_cfg.name]
+    rack = env.scene[rack_cfg.name]
+    env_ids_t = resolve_env_ids(env, env_ids)
+    num = env_ids_t.shape[0]
+    device = env.device
+    if num == 0:
+        return
+
+    z_tops = torch.tensor(level_z_tops, device=device, dtype=torch.float32)
+    n_levels = z_tops.shape[0]
+    if level_weights is None:
+        weights = torch.ones(n_levels, device=device)
+    else:
+        weights = torch.tensor(level_weights, device=device, dtype=torch.float32)
+    weights = weights / weights.sum()
+    level_idx = torch.multinomial(weights.expand(num, -1), 1).squeeze(1)
+
+    # buffers exposed to observations
+    if not hasattr(env, "rack_level_index") or env.rack_level_index.shape[0] != env.num_envs:
+        env.rack_level_index = torch.zeros(env.num_envs, device=device, dtype=torch.long)
+        env.rack_level_z = torch.zeros(env.num_envs, device=device, dtype=torch.float32)
+    env.rack_level_index[env_ids_t] = level_idx
+    env.rack_level_z[env_ids_t] = z_tops[level_idx]
+
+    # local offset in the rack frame
+    local = torch.zeros((num, 3), device=device)
+    local[:, 0].uniform_(float(level_x_range[0]), float(level_x_range[1]))
+    local[:, 1].uniform_(float(level_y_range[0]), float(level_y_range[1]))
+    local[:, 2] = z_tops[level_idx] + float(z_offset)
+
+    rack_pos = rack.data.root_pos_w[env_ids_t]
+    rack_quat = rack.data.root_quat_w[env_ids_t]
+    pos_w = rack_pos + quat_apply(rack_quat, local)
+
+    yaw = torch.zeros((num, 3), device=device)
+    yaw[:, 2].uniform_(float(yaw_range[0]), float(yaw_range[1]))
+    yaw_quat = quat_from_euler_xyz(yaw[:, 0], yaw[:, 1], yaw[:, 2])
+    default_quat = asset.data.default_root_state[env_ids_t, 3:7]
+    quat_w = quat_mul(rack_quat, quat_mul(default_quat, yaw_quat))
+
+    asset.write_root_pose_to_sim(torch.cat([pos_w, quat_w], dim=1), env_ids=env_ids_t)
+    asset.write_root_velocity_to_sim(torch.zeros((num, 6), device=device), env_ids=env_ids_t)
+
+
+def reset_root_pose_uniform_facing(
+    env,
+    env_ids: torch.Tensor,
+    asset_cfg: SceneEntityCfg,
+    pose_range: dict,
+    face_asset_cfg: SceneEntityCfg | None = SceneEntityCfg("robot"),
+    face_point: tuple[float, float] | None = None,
+    open_dir_local: tuple[float, float] = (-1.0, 0.0),
+    yaw_jitter: tuple[float, float] | tuple[tuple[float, float], ...] = (0.0, 0.0),
+):
+    """Sample the root position from ``pose_range`` (x/y/z offsets from the
+    default root state, like :func:`reset_root_pose_uniform`) and *aim* the asset
+    so that its local ``open_dir_local`` (xy, e.g. the open front of a rack) points
+    at a target: the ``face_asset_cfg`` root (default: the robot, i.e. its initial
+    location) or a fixed env-frame ``face_point`` (x, y). ``yaw_jitter`` adds a
+    yaw offset on top. Pass one ``(lo, hi)`` interval for uniform sampling, or
+    multiple intervals such as ``((-1.2, -0.8), (0.8, 1.2))`` to sample an
+    interval uniformly per environment and then sample within it. Roll/pitch
+    entries of ``pose_range`` are ignored (the asset stays upright); velocities
+    are zeroed for non-kinematic bodies.
+    """
+    asset = env.scene[asset_cfg.name]
+    env_ids_t = resolve_env_ids(env, env_ids)
+    num = env_ids_t.shape[0]
+    if num == 0:
+        return
+    device = env.device
+    origins = env.scene.env_origins[env_ids_t]
+    root_state = asset.data.default_root_state[env_ids_t].clone()
+
+    def _rng(key):
+        lo, hi = pose_range.get(key, (0.0, 0.0))
+        return torch.empty(num, device=device).uniform_(float(lo), float(hi))
+
+    pos = root_state[:, 0:3] + origins + torch.stack([_rng("x"), _rng("y"), _rng("z")], dim=1)
+
+    if face_point is not None:
+        target = torch.tensor(face_point, device=device, dtype=pos.dtype).unsqueeze(0).expand(num, -1) + origins[:, :2]
+    elif face_asset_cfg is not None:
+        target = env.scene[face_asset_cfg.name].data.root_pos_w[env_ids_t, :2]
+    else:
+        raise ValueError("reset_root_pose_uniform_facing: give face_asset_cfg or face_point")
+    d = target - pos[:, :2]
+    heading = torch.atan2(d[:, 1], d[:, 0])
+    open_local = math.atan2(float(open_dir_local[1]), float(open_dir_local[0]))
+    if isinstance(yaw_jitter[0], (tuple, list)):
+        ranges = torch.tensor(yaw_jitter, device=device, dtype=pos.dtype)
+        range_ids = torch.randint(ranges.shape[0], (num,), device=device)
+        selected = ranges[range_ids]
+        unit = torch.rand(num, device=device, dtype=pos.dtype)
+        jitter = selected[:, 0] + unit * (selected[:, 1] - selected[:, 0])
+    else:
+        jitter = torch.empty(num, device=device).uniform_(float(yaw_jitter[0]), float(yaw_jitter[1]))
+    yaw = heading - open_local + jitter
+    zeros = torch.zeros_like(yaw)
+    quat = quat_from_euler_xyz(zeros, zeros, yaw)
+
+    asset.write_root_pose_to_sim(torch.cat([pos, quat], dim=1), env_ids=env_ids_t)
+    spawn_cfg = getattr(asset.cfg, "spawn", None)
+    rigid_props = getattr(spawn_cfg, "rigid_props", None)
+    if not bool(getattr(rigid_props, "kinematic_enabled", False)):
+        asset.write_root_velocity_to_sim(torch.zeros((num, 6), device=device), env_ids=env_ids_t)
+
+
+def set_joint_position_target_to_init(
+    env,
+    env_ids: torch.Tensor,
+    asset_cfg: SceneEntityCfg = SceneEntityCfg("articulation"),
+):
+    """Point an articulation's position drive at its init/default joint angles.
+
+    Isaac Lab initialises ``joint_pos_target`` to zeros; for a passive articulation
+    driven by an implicit actuator with non-zero stiffness (a spring-loaded hinge)
+    the setpoint must be the rest angle instead. Use as a ``reset`` (and/or
+    ``startup``) event next to :func:`reset_joints_to_init`.
+    """
+    asset = env.scene[asset_cfg.name]
+    joint_ids = resolve_joint_ids(env, asset_cfg)
+    env_ids_t = resolve_env_ids(env, env_ids)
+    target = get_init_joint_pos(asset, joint_ids)[env_ids_t]
+    asset.set_joint_position_target(target, joint_ids=joint_ids, env_ids=env_ids_t)
+
+
+def sample_env_choice(
+    env,
+    env_ids: torch.Tensor,
+    buffer_name: str,
+    num_choices: int,
+    weights: list[float] | None = None,
+):
+    """Sample a categorical per-env choice into ``env.<buffer_name>`` (long, ``(num_envs,)``).
+
+    A generic "which variant this episode" event (which face pair to hold, which
+    slot to use, ...). Observations read the buffer via
+    :func:`~dexverse.tasks.mdp.observations.env_choice_one_hot`.
+    """
+    env_ids_t = resolve_env_ids(env, env_ids)
+    if env_ids_t.shape[0] == 0:
+        return
+    buf = getattr(env, buffer_name, None)
+    if buf is None or buf.shape[0] != env.num_envs:
+        buf = torch.zeros(env.num_envs, device=env.device, dtype=torch.long)
+        setattr(env, buffer_name, buf)
+    w = torch.ones(num_choices, device=env.device) if weights is None else torch.tensor(weights, device=env.device, dtype=torch.float32)
+    buf[env_ids_t] = torch.multinomial((w / w.sum()).expand(env_ids_t.shape[0], -1), 1).squeeze(1)

--- a/source/dexverse/dexverse/baseline_v1/mdp/rewards.py
+++ b/source/dexverse/dexverse/baseline_v1/mdp/rewards.py
@@ -1,0 +1,573 @@
+# Copyright (c) 2025-2026, The DexVerse Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# Copyright (c) 2022-2025, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+from __future__ import annotations
+
+import math
+from typing import TYPE_CHECKING, Literal
+
+import torch
+from isaaclab.assets import Articulation, RigidObject
+from isaaclab.envs.mdp.observations import last_action
+from isaaclab.managers import SceneEntityCfg
+from isaaclab.utils.math import euler_xyz_from_quat
+
+from .stage_machine import stage_success as stage_success_term
+from .utils import (
+    asset_axis_w,
+    axis_alignment_dot,
+    axis_tilt_angle,
+    command_axis_w,
+    factory_insert_success_mask,
+    get_init_joint_pos,
+    insert_peg_success_mask,
+    normalize_axis,
+    plug_charger_insertion_mask,
+    push_t_overlap_ratio,
+    resolve_joint_ids,
+    root_height_delta,
+    tracked_axis_rotation_step,
+    vector_projection_on_axis,
+    world_points_from_local,
+)
+
+if TYPE_CHECKING:
+    from isaaclab.envs import ManagerBasedRLEnv
+
+
+def action_rate_l2_clamped(env: ManagerBasedRLEnv) -> torch.Tensor:
+    """Penalize the rate of change of the actions using L2 squared kernel."""
+    return torch.sum(torch.square(env.action_manager.action - env.action_manager.prev_action), dim=1).clamp(-1000, 1000)
+
+
+def action_l2_clamped(env: ManagerBasedRLEnv) -> torch.Tensor:
+    """Penalize the actions using L2 squared kernel."""
+    return torch.sum(torch.square(env.action_manager.action), dim=1).clamp(-1000, 1000)
+
+
+def object_axis_alignment_dot(
+    env: ManagerBasedRLEnv,
+    command_name: str,
+    axis_local: tuple[float, float, float] = (0.0, 0.0, 1.0),
+    object_cfg: SceneEntityCfg = SceneEntityCfg("object"),
+    robot_cfg: SceneEntityCfg = SceneEntityCfg("robot"),
+) -> torch.Tensor:
+    """Signed cosine between object axis and commanded target axis in world frame."""
+    current_axis_w = asset_axis_w(env, asset_cfg=object_cfg, axis_local=axis_local)
+    target_axis_w = command_axis_w(env, command_name=command_name, axis_local=axis_local, robot_cfg=robot_cfg)
+    return axis_alignment_dot(current_axis_w, target_axis_w)
+
+
+def object_axis_ang_vel_projection(
+    env: ManagerBasedRLEnv,
+    command_name: str,
+    axis_local: tuple[float, float, float] = (0.0, 0.0, 1.0),
+    object_cfg: SceneEntityCfg = SceneEntityCfg("object"),
+    robot_cfg: SceneEntityCfg = SceneEntityCfg("robot"),
+) -> torch.Tensor:
+    """Object angular velocity projected onto commanded target axis."""
+    object: RigidObject = env.scene[object_cfg.name]
+    target_axis_w = command_axis_w(env, command_name=command_name, axis_local=axis_local, robot_cfg=robot_cfg)
+    return vector_projection_on_axis(object.data.root_ang_vel_w, target_axis_w)
+
+
+def root_lin_vel_norm(
+    env: ManagerBasedRLEnv,
+    asset_cfg: SceneEntityCfg = SceneEntityCfg("object"),
+    squared: bool = False,
+) -> torch.Tensor:
+    """Generic root linear-velocity magnitude penalty for rigid/articulated assets."""
+    asset: Articulation | RigidObject = env.scene[asset_cfg.name]
+    vel = asset.data.root_lin_vel_w
+    return torch.sum(torch.square(vel), dim=1) if squared else torch.norm(vel, dim=1)
+
+
+def root_ang_vel_norm(
+    env: ManagerBasedRLEnv,
+    asset_cfg: SceneEntityCfg = SceneEntityCfg("object"),
+    squared: bool = False,
+) -> torch.Tensor:
+    """Generic root angular-velocity magnitude penalty for rigid/articulated assets."""
+    asset: Articulation | RigidObject = env.scene[asset_cfg.name]
+    vel = asset.data.root_ang_vel_w
+    return torch.sum(torch.square(vel), dim=1) if squared else torch.norm(vel, dim=1)
+
+
+def cumulative_axis_rotation(
+    env: ManagerBasedRLEnv,
+    tracker_name: str = "default",
+    command_name: str | None = None,
+    axis_local: tuple[float, float, float] = (0.0, 0.0, 1.0),
+    world_axis: tuple[float, float, float] = (0.0, 0.0, -1.0),
+    object_cfg: SceneEntityCfg = SceneEntityCfg("object"),
+    robot_cfg: SceneEntityCfg = SceneEntityCfg("robot"),
+) -> torch.Tensor:
+    """Cumulative signed rotation (rad) around a selected axis."""
+    object: RigidObject = env.scene[object_cfg.name]
+    object_quat_w = object.data.root_quat_w
+    if command_name:
+        axis_w = command_axis_w(env, command_name=command_name, axis_local=axis_local, robot_cfg=robot_cfg)
+    else:
+        axis = normalize_axis(world_axis, device=env.device, dtype=object_quat_w.dtype)
+        axis_w = axis.unsqueeze(0).expand(env.num_envs, -1)
+    accumulated, _ = tracked_axis_rotation_step(env, object_quat_w, axis_w, tracker_name=tracker_name)
+    return accumulated
+
+
+def _reduce_body_distances(distances: torch.Tensor, reduce: str) -> torch.Tensor:
+    """Reduce a ``(num_envs, num_bodies)`` distance tensor over the body dim."""
+    if reduce == "sum":
+        return distances.sum(dim=-1)
+    if reduce == "mean":
+        return distances.mean(dim=-1)
+    if reduce == "min":
+        return distances.min(dim=-1).values
+    raise ValueError(f"Unknown reduce mode: {reduce!r}. Expected 'sum', 'mean' or 'min'.")
+
+
+def object_ee_distance(
+    env: ManagerBasedRLEnv,
+    std: float,
+    distance_gain: float = 10.0,
+    object_cfg: SceneEntityCfg = SceneEntityCfg("object"),
+    asset_cfg: SceneEntityCfg = SceneEntityCfg("robot"),
+    reduce: Literal["sum", "mean", "min"] = "sum",
+) -> torch.Tensor:
+    """Reward reaching the object using exponential distance decay.
+
+    The internal decay slope is controlled by ``distance_gain`` while the global
+    reward scale should be tuned with ``RewTerm.weight`` in task config.
+    ``std`` is kept for backward compatibility with existing configs.
+
+    ``reduce`` selects how per-fingertip distances combine before the exponential.
+    The legacy default ``"sum"`` collapses toward zero as fingertip count grows
+    (5-10 tips on Shadow hands); prefer ``"mean"`` for dense shaping there.
+    """
+    _ = std
+    asset: RigidObject = env.scene[asset_cfg.name]
+    object: RigidObject = env.scene[object_cfg.name]
+    asset_pos = asset.data.body_pos_w[:, asset_cfg.body_ids]
+    object_pos = object.data.root_pos_w
+    distances = torch.norm(asset_pos - object_pos[:, None, :], dim=-1)
+
+    return torch.exp(-distance_gain * _reduce_body_distances(distances, reduce))
+
+
+def fingertips_to_body_distance(
+    env: ManagerBasedRLEnv,
+    target_cfg: SceneEntityCfg,
+    asset_cfg: SceneEntityCfg = SceneEntityCfg("robot"),
+    distance_gain: float = 10.0,
+    reduce: Literal["sum", "mean", "min"] = "mean",
+) -> torch.Tensor:
+    """Exponential reach reward toward specific body link(s) of an asset.
+
+    Unlike :func:`object_ee_distance`, which reads the target's *root* position,
+    the target point here is the mean world position of ``target_cfg.body_ids``
+    — e.g. the moving link of an articulated object (lid, blade, handle).
+    """
+    asset: Articulation = env.scene[asset_cfg.name]
+    target: Articulation | RigidObject = env.scene[target_cfg.name]
+    finger_pos = asset.data.body_pos_w[:, asset_cfg.body_ids]
+    target_pos = target.data.body_pos_w[:, target_cfg.body_ids].mean(dim=1)
+    distances = torch.norm(finger_pos - target_pos[:, None, :], dim=-1)
+    return torch.exp(-distance_gain * _reduce_body_distances(distances, reduce))
+
+
+def point_to_point_distance_exp(
+    env: ManagerBasedRLEnv,
+    source_cfg: SceneEntityCfg,
+    target_cfg: SceneEntityCfg,
+    source_local_offset: tuple[float, float, float] = (0.0, 0.0, 0.0),
+    target_local_offset: tuple[float, float, float] = (0.0, 0.0, 0.0),
+    distance_gain: float = 10.0,
+) -> torch.Tensor:
+    """Exponential distance reward between offset points on two asset roots.
+
+    Suited for tool-use shaping where the working point is not the root — e.g.
+    hammer head to nail head, or a held part's tip to a receptacle opening.
+    """
+    source_point = world_points_from_local(
+        env, source_cfg, torch.tensor([source_local_offset], device=env.device)
+    ).squeeze(1)
+    target_point = world_points_from_local(
+        env, target_cfg, torch.tensor([target_local_offset], device=env.device)
+    ).squeeze(1)
+    distance = torch.norm(source_point - target_point, dim=-1)
+    return torch.exp(-distance_gain * distance)
+
+
+def lift_when_grasping_reward(
+    env: ManagerBasedRLEnv,
+    object_cfg: SceneEntityCfg = SceneEntityCfg("object"),
+    asset_cfg: SceneEntityCfg = SceneEntityCfg("robot"),
+    threshold: float = 0.07,
+) -> torch.Tensor:
+    """Reward lifting the object when grasping."""
+    asset: Articulation = env.scene[asset_cfg.name]
+    object: RigidObject = env.scene[object_cfg.name]
+    asset_pos = asset.data.body_pos_w[:, asset_cfg.body_ids]
+    object_pos = object.data.root_pos_w
+    asset_to_obj_distances = torch.norm(asset_pos - object_pos[:, None, :], dim=-1)
+    thumb_to_obj_distance = asset_to_obj_distances[:, 0]
+    index_to_obj_distance = asset_to_obj_distances[:, 1]
+    middle_to_obj_distance = asset_to_obj_distances[:, 2]
+    ring_to_obj_distance = asset_to_obj_distances[:, 3]
+
+    good_contact_cond1 = (thumb_to_obj_distance <= threshold) & (
+        (index_to_obj_distance <= threshold)
+        | (middle_to_obj_distance <= threshold)
+        | (ring_to_obj_distance <= threshold)
+    )
+    latest_action: torch.Tensor = last_action(env)
+    z_lift_action = latest_action[..., 2]
+    # clip to 0
+    z_lift_action = z_lift_action.clamp(0, 1)
+    reward = good_contact_cond1 * z_lift_action
+    return reward
+
+
+def grasp_lift_action_reward(
+    env: ManagerBasedRLEnv,
+    object_cfg: SceneEntityCfg = SceneEntityCfg("object"),
+    fingers_cfg: SceneEntityCfg = SceneEntityCfg("robot"),
+    thumb_cfg: SceneEntityCfg | None = None,
+    threshold: float = 0.07,
+    min_fingers: int = 2,
+    lift_action_index: int = 2,
+) -> torch.Tensor:
+    """Reward a positive lift action while the fingertips are grasping the object.
+
+    Name-scoped replacement for :func:`lift_when_grasping_reward`, whose
+    positional fingertip indexing is unreliable (``SceneEntityCfg`` resolves
+    body ids in articulation order, not list order, and breaks for hands with
+    more than four fingertips). ``fingers_cfg`` should select the non-thumb
+    fingertip bodies by name. When ``thumb_cfg`` is given, the grasp condition
+    is thumb plus at least one other fingertip within ``threshold``; otherwise
+    at least ``min_fingers`` fingertips within ``threshold``.
+    """
+    object: RigidObject = env.scene[object_cfg.name]
+    object_pos = object.data.root_pos_w
+
+    fingers: Articulation = env.scene[fingers_cfg.name]
+    finger_pos = fingers.data.body_pos_w[:, fingers_cfg.body_ids]
+    finger_dists = torch.norm(finger_pos - object_pos[:, None, :], dim=-1)
+
+    if thumb_cfg is not None:
+        thumb: Articulation = env.scene[thumb_cfg.name]
+        thumb_pos = thumb.data.body_pos_w[:, thumb_cfg.body_ids]
+        thumb_dist = torch.norm(thumb_pos - object_pos[:, None, :], dim=-1).min(dim=1).values
+        grasping = (thumb_dist <= threshold) & ((finger_dists <= threshold).sum(dim=1) >= 1)
+    else:
+        grasping = (finger_dists <= threshold).sum(dim=1) >= min_fingers
+
+    latest_action: torch.Tensor = last_action(env)
+    lift_action = latest_action[..., lift_action_index].clamp(0, 1)
+    return grasping * lift_action
+
+
+def object_lift_height(
+    env: ManagerBasedRLEnv,
+    asset_cfg: SceneEntityCfg = SceneEntityCfg("object"),
+    min_height: float = 0.05,
+) -> torch.Tensor:
+    """Reward lifting an asset above its default height.
+
+    Returns a [0,1] reward based on how much the object is lifted.
+    """
+    asset = env.scene[asset_cfg.name]
+    lift = root_height_delta(asset)
+    return torch.clamp(lift / max(min_height, 1e-6), 0.0, 1.0)
+
+
+def position_command_error(
+    env: ManagerBasedRLEnv,
+    std: float,
+    command_name: str,
+) -> torch.Tensor:
+    """Reward tracking of commanded position using command metrics (world-frame distance)."""
+    command_term = env.command_manager.get_term(command_name)
+    distance = command_term.metrics["position_error"]
+    return torch.exp(-distance / max(std, 1e-6))
+
+
+def success_reward(
+    env: ManagerBasedRLEnv,
+    command_name: str,
+    pos_std: float,
+    rot_std: float | None = None,
+) -> torch.Tensor:
+    """Reward success using command metrics (world-frame errors)."""
+    command_term = env.command_manager.get_term(command_name)
+    pos_dist = command_term.metrics["position_error"]
+    if not rot_std:
+        return (1 - torch.tanh(pos_dist / pos_std)) ** 2
+    rot_dist = command_term.metrics["orientation_error"]
+    return (1 - torch.tanh(pos_dist / pos_std)) * (1 - torch.tanh(rot_dist / rot_std))
+
+
+def stage_success_reward(
+    env: ManagerBasedRLEnv,
+    task_key: str,
+    terminal_stage: str | None = None,
+    persistent: bool = False,
+    success_mode: Literal["substage", "all"] | None = None,
+    ordering_mode: Literal["strict", "free"] | None = None,
+) -> torch.Tensor:
+    """Sparse reward from stage-machine terminal success."""
+    return stage_success_term(
+        env,
+        task_key=task_key,
+        terminal_stage=terminal_stage,
+        persistent=persistent,
+        success_mode=success_mode,
+        ordering_mode=ordering_mode,
+    ).float()
+
+
+def tilt_angle_reward(
+    env: ManagerBasedRLEnv,
+    threshold_rad: float = 2.35619449,
+    axis_local: tuple[float, float, float] = (0.0, 0.0, 1.0),
+    world_axis: tuple[float, float, float] = (0.0, 0.0, 1.0),
+    tilt_ge: bool = True,
+    object_cfg: SceneEntityCfg = SceneEntityCfg("object"),
+) -> torch.Tensor:
+    """Reward tilt progress relative to a threshold angle (in radians).
+
+    When ``tilt_ge`` is True, larger tilt is better and the reward rises from
+    0 at ``threshold_rad`` to 1 at ``pi``. When ``tilt_ge`` is False, smaller
+    tilt is better and the reward rises from 0 at ``threshold_rad`` to 1 at 0.
+    """
+    object: RigidObject = env.scene[object_cfg.name]
+    angle = axis_tilt_angle(object.data.root_quat_w, axis_local=axis_local, world_axis=world_axis)
+    if tilt_ge:
+        return torch.clamp((angle - threshold_rad) / (math.pi - threshold_rad), 0.0, 1.0)
+    return torch.clamp((threshold_rad - angle) / max(threshold_rad, 1e-6), 0.0, 1.0)
+
+
+def joint_open_reward(
+    env: ManagerBasedRLEnv,
+    threshold_rad: float,
+    asset_cfg: SceneEntityCfg = SceneEntityCfg("object"),
+) -> torch.Tensor:
+    """Reward opening a joint beyond a threshold (uses max abs joint position)."""
+    asset: Articulation = env.scene[asset_cfg.name]
+    joint_ids = resolve_joint_ids(env, asset_cfg)
+    joint_pos = asset.data.joint_pos[:, joint_ids]
+    max_abs = torch.abs(joint_pos).max(dim=1).values
+    return torch.clamp(max_abs / threshold_rad, 0.0, 1.0)
+
+
+def joint_displacement_reward(
+    env: ManagerBasedRLEnv,
+    threshold_m: float,
+    asset_cfg: SceneEntityCfg = SceneEntityCfg("object"),
+) -> torch.Tensor:
+    """Reward joint displacement magnitude from init beyond a threshold."""
+    asset: Articulation = env.scene[asset_cfg.name]
+    joint_ids = resolve_joint_ids(env, asset_cfg)
+
+    joint_pos = asset.data.joint_pos[:, joint_ids]
+    init_joint_pos = get_init_joint_pos(asset, joint_ids)
+
+    max_abs = torch.abs(joint_pos - init_joint_pos).max(dim=1).values
+    return torch.clamp(max_abs / threshold_m, 0.0, 1.0)
+
+
+def joint_open_fraction_reward(
+    env: ManagerBasedRLEnv,
+    close_angle_rad: float,
+    open_angle_rad: float,
+    asset_cfg: SceneEntityCfg = SceneEntityCfg("object"),
+) -> torch.Tensor:
+    """Reward joint opening as a normalized fraction between close and open angles."""
+    asset: Articulation = env.scene[asset_cfg.name]
+    joint_ids = resolve_joint_ids(env, asset_cfg)
+    joint_pos = asset.data.joint_pos[:, joint_ids]
+    max_pos = joint_pos.max(dim=1).values
+    denom = open_angle_rad - close_angle_rad
+    if abs(denom) < 1e-6:
+        return torch.zeros(env.num_envs, device=env.device)
+    fraction = (max_pos - close_angle_rad) / denom
+    return torch.clamp(fraction, 0.0, 1.0)
+
+
+def joint_range_progress(
+    env: ManagerBasedRLEnv,
+    asset_cfg: SceneEntityCfg = SceneEntityCfg("object"),
+) -> torch.Tensor:
+    """Reward progress of joint position from lower to upper limits (uses max joint pos)."""
+    asset: Articulation = env.scene[asset_cfg.name]
+    joint_ids = resolve_joint_ids(env, asset_cfg)
+    joint_pos = asset.data.joint_pos[:, joint_ids]
+    lower = asset.data.joint_pos_limits[:, joint_ids, 0]
+    upper = asset.data.joint_pos_limits[:, joint_ids, 1]
+    denom = torch.clamp(upper - lower, min=1e-6)
+    progress = (joint_pos - lower) / denom
+    max_progress = progress.max(dim=1).values
+    return torch.clamp(max_progress, 0.0, 1.0)
+
+
+def joint_range_progress_from_init(
+    env: ManagerBasedRLEnv,
+    asset_cfg: SceneEntityCfg = SceneEntityCfg("object"),
+) -> torch.Tensor:
+    """Reward progress of joint motion based on absolute delta from init over reachable range."""
+    asset: Articulation = env.scene[asset_cfg.name]
+    joint_ids = resolve_joint_ids(env, asset_cfg)
+
+    joint_pos = asset.data.joint_pos[:, joint_ids]
+    init_joint_pos = get_init_joint_pos(asset, joint_ids)
+
+    lower = asset.data.joint_pos_limits[:, joint_ids, 0]
+    upper = asset.data.joint_pos_limits[:, joint_ids, 1]
+    reachable = torch.maximum(init_joint_pos - lower, upper - init_joint_pos)
+    denom = torch.clamp(reachable, min=1e-6)
+    progress = torch.abs(joint_pos - init_joint_pos) / denom
+    max_progress = progress.max(dim=1).values
+    return torch.clamp(max_progress, 0.0, 1.0)
+
+
+def factory_insert_engaged_reward(
+    env: ManagerBasedRLEnv,
+    held_cfg: SceneEntityCfg,
+    fixed_cfg: SceneEntityCfg,
+    held_base_local_offset: tuple[float, float, float] = (0.0, 0.0, 0.0),
+    target_local_offset: tuple[float, float, float] = (0.0, 0.0, 0.0),
+    center_dist_thresh: float = 0.0025,
+    z_threshold: float = 0.01,
+    held_base_local_offset_2: tuple[float, float, float] | None = None,
+) -> torch.Tensor:
+    """Sparse engaged bonus for peg-insert / gear-mesh style tasks.
+
+    Pass ``held_base_local_offset_2`` to count *either* held reference point
+    (e.g. either end of a pen) as engaged.
+    """
+    return factory_insert_success_mask(
+        env=env,
+        held_cfg=held_cfg,
+        fixed_cfg=fixed_cfg,
+        held_base_local_offset=held_base_local_offset,
+        target_local_offset=target_local_offset,
+        center_dist_thresh=center_dist_thresh,
+        z_threshold=z_threshold,
+        held_base_local_offset_2=held_base_local_offset_2,
+    ).float()
+
+
+def factory_insert_success_reward(
+    env: ManagerBasedRLEnv,
+    held_cfg: SceneEntityCfg,
+    fixed_cfg: SceneEntityCfg,
+    held_base_local_offset: tuple[float, float, float] = (0.0, 0.0, 0.0),
+    target_local_offset: tuple[float, float, float] = (0.0, 0.0, 0.0),
+    center_dist_thresh: float = 0.0025,
+    z_threshold: float = 0.001,
+    held_base_local_offset_2: tuple[float, float, float] | None = None,
+) -> torch.Tensor:
+    """Sparse success bonus for peg-insert / gear-mesh style tasks.
+
+    Pass ``held_base_local_offset_2`` to count *either* held reference point
+    (e.g. either end of a pen) as success.
+    """
+    return factory_insert_success_mask(
+        env=env,
+        held_cfg=held_cfg,
+        fixed_cfg=fixed_cfg,
+        held_base_local_offset=held_base_local_offset,
+        target_local_offset=target_local_offset,
+        center_dist_thresh=center_dist_thresh,
+        z_threshold=z_threshold,
+        held_base_local_offset_2=held_base_local_offset_2,
+    ).float()
+
+
+def plug_charger_pose_success_reward(
+    env: ManagerBasedRLEnv,
+    held_cfg: SceneEntityCfg,
+    fixed_cfg: SceneEntityCfg,
+    insertion_x_threshold: float = 0.02,
+    insertion_y_threshold: float = 0.01,
+    insertion_z_threshold: float = 0.01,
+    held_local_offset: tuple[float, float, float] = (0.0, 0.0, 0.0),
+    fixed_local_offset: tuple[float, float, float] = (0.0, 0.0, 0.0),
+) -> torch.Tensor:
+    """Sparse success bonus using insertion geometry criteria in receptacle frame."""
+    return plug_charger_insertion_mask(
+        env=env,
+        held_cfg=held_cfg,
+        fixed_cfg=fixed_cfg,
+        held_local_offset=held_local_offset,
+        fixed_local_offset=fixed_local_offset,
+        insertion_x_threshold=insertion_x_threshold,
+        lateral_y_threshold=insertion_y_threshold,
+        vertical_z_threshold=insertion_z_threshold,
+    ).float()
+
+
+def insert_peg_success_reward(
+    env: ManagerBasedRLEnv,
+    peg_cfg: SceneEntityCfg,
+    hole_cfg: SceneEntityCfg,
+    peg_head_local_offset: tuple[float, float, float] = (0.10, 0.0, 0.0),
+    hole_center_local_offset: tuple[float, float, float] = (0.0, 0.0, 0.0),
+    hole_radius: float = 0.023,
+    insertion_x_threshold: float = 0.015,
+) -> torch.Tensor:
+    """Sparse reward using ManiSkill PegInsertionSide success condition."""
+    return insert_peg_success_mask(
+        env=env,
+        peg_cfg=peg_cfg,
+        hole_cfg=hole_cfg,
+        peg_head_local_offset=peg_head_local_offset,
+        hole_center_local_offset=hole_center_local_offset,
+        hole_radius=hole_radius,
+        insertion_x_threshold=insertion_x_threshold,
+    ).float()
+
+
+def push_t_pose_dense_reward(
+    env: ManagerBasedRLEnv,
+    object_cfg: SceneEntityCfg = SceneEntityCfg("object"),
+    goal_cfg: SceneEntityCfg = SceneEntityCfg("goal_tee"),
+    rotation_weight: float = 0.5,
+    translation_weight: float = 0.5,
+    translation_distance_gain: float = 5.0,
+    overlap_success_threshold: float = 0.90,
+    success_bonus: float = 3.0,
+    overlap_point_step: float = 0.005,
+) -> torch.Tensor:
+    """Pose-based dense reward for PushT, aligned with ManiSkill PushT-v1 behavior."""
+    tee: Articulation | RigidObject = env.scene[object_cfg.name]
+    goal_tee: Articulation | RigidObject = env.scene[goal_cfg.name]
+
+    _, _, tee_yaw = euler_xyz_from_quat(tee.data.root_quat_w)
+    _, _, goal_yaw = euler_xyz_from_quat(goal_tee.data.root_quat_w)
+    yaw_error = torch.atan2(torch.sin(tee_yaw - goal_yaw), torch.cos(tee_yaw - goal_yaw))
+
+    rot_score = ((torch.cos(yaw_error) + 1.0) * 0.5) ** 2
+
+    tee_to_goal_xy = tee.data.root_pos_w[:, :2] - goal_tee.data.root_pos_w[:, :2]
+    tee_to_goal_dist = torch.linalg.vector_norm(tee_to_goal_xy, dim=1)
+    trans_score = (1.0 - torch.tanh(translation_distance_gain * tee_to_goal_dist)) ** 2
+
+    reward = rotation_weight * rot_score + translation_weight * trans_score
+
+    overlap = push_t_overlap_ratio(
+        env=env,
+        object_cfg=object_cfg,
+        goal_cfg=goal_cfg,
+        point_step=overlap_point_step,
+    )
+    success = overlap >= float(overlap_success_threshold)
+    if success_bonus > 0.0:
+        reward = torch.where(success, torch.full_like(reward, float(success_bonus)), reward)
+    return reward

--- a/source/dexverse/dexverse/baseline_v1/mdp/stage_machine.py
+++ b/source/dexverse/dexverse/baseline_v1/mdp/stage_machine.py
@@ -1,0 +1,494 @@
+# Copyright (c) 2025-2026, The DexVerse Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+from __future__ import annotations
+
+import warnings
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+import torch
+from isaaclab.envs import ManagerBasedRLEnv
+
+
+@dataclass(frozen=True)
+class StageSpec:
+    """Single stage definition in a long-horizon state graph."""
+
+    name: str
+    func: Callable[..., torch.Tensor]
+    params: Mapping[str, Any] = field(default_factory=dict)
+    deps: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class StageGraphSpec:
+    """Ordered stage graph definition."""
+
+    stages: tuple[StageSpec, ...]
+    terminal_stage: str | None = None
+    ordering_mode: Literal["strict", "free"] = "strict"
+    success_mode: Literal["substage", "all"] = "substage"
+
+
+@dataclass
+class StageRuntimeState:
+    """Per-task runtime state cached on env for stage graph evaluation."""
+
+    raw_flags: dict[str, torch.Tensor] | None = None
+    raw_step_buf: torch.Tensor | None = None
+    raw_stage_names: tuple[str, ...] | None = None
+    latched_flags: dict[str, torch.Tensor] | None = None
+    latched_step_buf: torch.Tensor | None = None
+    latched_stage_names: tuple[str, ...] | None = None
+    eval_flags: dict[str, torch.Tensor] | None = None
+    eval_step_buf: torch.Tensor | None = None
+    eval_persistent: bool | None = None
+    eval_ordering_mode: Literal["strict", "free"] | None = None
+    eval_stage_names: tuple[str, ...] | None = None
+
+
+_STAGE_GRAPH_REGISTRY: dict[str, StageGraphSpec] = {}
+
+
+def _get_episode_length_buf(env: ManagerBasedRLEnv) -> torch.Tensor | None:
+    """Return episode-length buffer if the runtime exposes it."""
+    episode_length_buf = getattr(env, "episode_length_buf", None)
+    if isinstance(episode_length_buf, torch.Tensor) and episode_length_buf.ndim == 1:
+        return episode_length_buf
+    return None
+
+
+def _validate_stage_graph(graph: StageGraphSpec) -> None:
+    if len(graph.stages) == 0:
+        raise ValueError("StageGraphSpec.stages must not be empty.")
+
+    seen: set[str] = set()
+    for stage in graph.stages:
+        if stage.name in seen:
+            raise ValueError(f"Duplicate stage name: {stage.name}")
+        for dep in stage.deps:
+            if dep not in seen:
+                raise ValueError(f"Stage '{stage.name}' depends on unknown or later stage '{dep}'")
+        seen.add(stage.name)
+
+    if graph.terminal_stage is not None and graph.terminal_stage not in seen:
+        raise ValueError(f"Unknown terminal_stage: {graph.terminal_stage}")
+    if graph.ordering_mode not in ("strict", "free"):
+        raise ValueError(f"Unsupported ordering_mode: {graph.ordering_mode}")
+    if graph.success_mode not in ("substage", "all"):
+        raise ValueError(f"Unsupported success_mode: {graph.success_mode}")
+    if graph.ordering_mode == "free" and any(stage.deps for stage in graph.stages):
+        warnings.warn(
+            "StageGraphSpec has deps but ordering_mode='free': deps are ignored during stage gating.",
+            stacklevel=2,
+        )
+    if graph.success_mode == "all" and graph.terminal_stage is not None:
+        warnings.warn(
+            "StageGraphSpec has terminal_stage but success_mode='all': terminal_stage is ignored for success.",
+            stacklevel=2,
+        )
+
+
+def register_stage_graph(task_key: str, graph: StageGraphSpec, *, override: bool = False) -> None:
+    """Register stage graph by task key."""
+    if not task_key:
+        raise ValueError("task_key must be non-empty.")
+    _validate_stage_graph(graph)
+    if not override and task_key in _STAGE_GRAPH_REGISTRY:
+        raise ValueError(f"Stage graph already registered for task_key='{task_key}'")
+    _STAGE_GRAPH_REGISTRY[task_key] = graph
+
+
+def get_stage_graph(task_key: str) -> StageGraphSpec:
+    """Fetch a registered stage graph by key."""
+    if task_key not in _STAGE_GRAPH_REGISTRY:
+        raise KeyError(f"No stage graph registered for task_key='{task_key}'")
+    return _STAGE_GRAPH_REGISTRY[task_key]
+
+
+def _to_stage_flag(value: torch.Tensor, stage_name: str) -> torch.Tensor:
+    if not isinstance(value, torch.Tensor):
+        raise TypeError(f"Stage '{stage_name}' must return torch.Tensor, got {type(value)}")
+    stage_flag = value.bool()
+    if stage_flag.ndim == 2 and stage_flag.shape[1] == 1:
+        stage_flag = stage_flag[:, 0]
+    if stage_flag.ndim != 1:
+        raise ValueError(
+            f"Stage '{stage_name}' must return shape [num_envs] or [num_envs,1], got {tuple(stage_flag.shape)}"
+        )
+    return stage_flag
+
+
+def _evaluate_stage_raw(env: ManagerBasedRLEnv, graph: StageGraphSpec) -> dict[str, torch.Tensor]:
+    """Evaluate stage predicates without dependency gating."""
+    raw_flags: dict[str, torch.Tensor] = {}
+    for stage in graph.stages:
+        raw_flags[stage.name] = _to_stage_flag(stage.func(env, **dict(stage.params)), stage.name)
+    return raw_flags
+
+
+def _stage_names(graph: StageGraphSpec) -> tuple[str, ...]:
+    return tuple(stage.name for stage in graph.stages)
+
+
+def _get_or_create_task_runtime_state(env: ManagerBasedRLEnv, task_key: str) -> StageRuntimeState:
+    cache = getattr(env, "_stage_graph_runtime_cache", None)
+    if cache is None:
+        cache = {}
+        setattr(env, "_stage_graph_runtime_cache", cache)
+    state = cache.get(task_key)
+    if isinstance(state, StageRuntimeState):
+        return state
+    if isinstance(state, dict):
+        state = StageRuntimeState(
+            raw_flags=state.get("raw_flags"),
+            raw_step_buf=state.get("raw_step_buf"),
+            latched_flags=state.get("latched_flags"),
+            latched_step_buf=state.get("latched_step_buf"),
+            eval_flags=state.get("eval_flags"),
+            eval_step_buf=state.get("eval_step_buf"),
+            eval_persistent=state.get("eval_persistent"),
+            eval_ordering_mode=state.get("eval_ordering_mode"),
+            eval_stage_names=state.get("eval_stage_names"),
+        )
+    else:
+        state = StageRuntimeState()
+    cache[task_key] = state
+    return state
+
+
+def _get_raw_flags_cached(
+    env: ManagerBasedRLEnv, graph: StageGraphSpec, state: StageRuntimeState
+) -> dict[str, torch.Tensor]:
+    """Reuse raw stage predicates inside the same environment step."""
+    episode_length_buf = _get_episode_length_buf(env)
+    stage_names = _stage_names(graph)
+    if (
+        state.raw_flags is not None
+        and state.raw_stage_names == stage_names
+        and episode_length_buf is not None
+        and isinstance(state.raw_step_buf, torch.Tensor)
+        and torch.equal(state.raw_step_buf, episode_length_buf)
+    ):
+        return state.raw_flags
+
+    raw_flags = _evaluate_stage_raw(env, graph)
+    state.raw_flags = raw_flags
+    state.raw_stage_names = stage_names
+    state.raw_step_buf = episode_length_buf.clone() if episode_length_buf is not None else None
+    return raw_flags
+
+
+def _compute_reset_mask(
+    episode_length_buf: torch.Tensor | None,
+    previous_step_buf: torch.Tensor | None,
+) -> torch.Tensor | None:
+    if episode_length_buf is None:
+        return None
+    if isinstance(previous_step_buf, torch.Tensor) and previous_step_buf.shape == episode_length_buf.shape:
+        # A counter that went *backwards* is an unambiguous new episode. Relying on
+        # ``== 0`` alone only works if this state happens to be evaluated at the
+        # very first step -- lazy consumers (a strict stage graph only evaluates
+        # its first pending stage's predicate; obs presets can drop the terms
+        # that would touch it) otherwise inherit the previous episode's progress
+        # (Aug 2026: the cut frontier stayed at 1.0 into the next replayed demo,
+        # so success fired as soon as the blade extended).
+        return ((episode_length_buf == 0) & (previous_step_buf != 0)) | (episode_length_buf < previous_step_buf)
+    return episode_length_buf == 0
+
+
+def _initialize_latched_flags(
+    graph: StageGraphSpec,
+    num_envs: int,
+    device: torch.device | str,
+) -> dict[str, torch.Tensor]:
+    return {stage.name: torch.zeros(num_envs, dtype=torch.bool, device=device) for stage in graph.stages}
+
+
+def _get_persistent_base_flags(
+    env: ManagerBasedRLEnv,
+    graph: StageGraphSpec,
+    state: StageRuntimeState,
+) -> dict[str, torch.Tensor]:
+    episode_length_buf = _get_episode_length_buf(env)
+    stage_names = _stage_names(graph)
+    latched_flags = state.latched_flags
+    num_envs = env.num_envs
+    device = env.device
+    needs_init = (
+        latched_flags is None
+        or state.latched_stage_names != stage_names
+        or any(latched_flags[name].shape != (num_envs,) for name in stage_names)
+    )
+    if needs_init:
+        latched_flags = _initialize_latched_flags(graph, num_envs, device)
+        state.latched_flags = latched_flags
+        state.latched_stage_names = stage_names
+
+    reset_mask = _compute_reset_mask(episode_length_buf, state.latched_step_buf)
+    if episode_length_buf is not None:
+        state.latched_step_buf = episode_length_buf.clone()
+
+    has_reset = reset_mask is not None and bool(torch.any(reset_mask))
+    if not has_reset:
+        return latched_flags
+
+    reset_base_flags: dict[str, torch.Tensor] = {}
+    for stage in graph.stages:
+        base_done = latched_flags[stage.name].clone()
+        base_done[reset_mask] = False
+        reset_base_flags[stage.name] = base_done
+    return reset_base_flags
+
+
+def _evaluate_flags(
+    graph: StageGraphSpec,
+    raw_flags: dict[str, torch.Tensor],
+    ordering_mode: Literal["strict", "free"],
+    base_flags: dict[str, torch.Tensor] | None = None,
+) -> dict[str, torch.Tensor]:
+    if ordering_mode not in ("strict", "free"):
+        raise ValueError(f"Unsupported ordering_mode: {ordering_mode}")
+
+    flags: dict[str, torch.Tensor] = {}
+    for stage in graph.stages:
+        stage_flag = raw_flags[stage.name]
+        if ordering_mode == "strict" and stage.deps:
+            dep_ok = torch.ones_like(stage_flag)
+            for dep in stage.deps:
+                dep_ok &= flags[dep]
+            stage_flag &= dep_ok
+        if base_flags is not None:
+            stage_flag = base_flags[stage.name] | stage_flag
+        flags[stage.name] = stage_flag
+    return flags
+
+
+def _is_linear_chain(graph: StageGraphSpec) -> bool:
+    """Whether stages form a simple linear dependency chain."""
+    for idx, stage in enumerate(graph.stages):
+        if idx == 0:
+            if stage.deps:
+                return False
+            continue
+        if stage.deps != (graph.stages[idx - 1].name,):
+            return False
+    return True
+
+
+def _evaluate_strict_persistent_active_stage(
+    env: ManagerBasedRLEnv,
+    graph: StageGraphSpec,
+    state: StageRuntimeState,
+) -> dict[str, torch.Tensor]:
+    """Incremental strict+persistent evaluation: only evaluate current active stage."""
+    base_flags = _get_persistent_base_flags(env, graph, state)
+    flags = {name: value.clone() for name, value in base_flags.items()}
+
+    ordered_done = torch.stack([base_flags[stage.name] for stage in graph.stages], dim=-1)
+    pending = ~ordered_done
+    has_pending = pending.any(dim=-1)
+    if not bool(torch.any(has_pending)):
+        state.latched_flags = flags
+        return flags
+
+    pending_idx = pending.to(dtype=torch.int64).argmax(dim=-1)
+    for stage_idx, stage in enumerate(graph.stages):
+        env_mask = has_pending & (pending_idx == stage_idx)
+        if not bool(torch.any(env_mask)):
+            continue
+
+        stage_raw = _to_stage_flag(stage.func(env, **dict(stage.params)), stage.name)
+        if stage.deps:
+            dep_ok = torch.ones_like(stage_raw)
+            for dep in stage.deps:
+                dep_ok &= flags[dep]
+            stage_raw &= dep_ok
+        updated = flags[stage.name] | stage_raw
+        flags[stage.name] = torch.where(env_mask, updated, flags[stage.name])
+
+    state.latched_flags = flags
+    return flags
+
+
+def _get_cached_eval_flags(
+    env: ManagerBasedRLEnv,
+    graph: StageGraphSpec,
+    state: StageRuntimeState,
+    persistent: bool,
+    ordering_mode: Literal["strict", "free"],
+) -> dict[str, torch.Tensor] | None:
+    stage_names = _stage_names(graph)
+    episode_length_buf = _get_episode_length_buf(env)
+    if (
+        state.eval_flags is not None
+        and episode_length_buf is not None
+        and isinstance(state.eval_step_buf, torch.Tensor)
+        and torch.equal(state.eval_step_buf, episode_length_buf)
+        and state.eval_persistent == persistent
+        and state.eval_ordering_mode == ordering_mode
+        and state.eval_stage_names == stage_names
+    ):
+        return state.eval_flags
+    return None
+
+
+def _set_cached_eval_flags(
+    env: ManagerBasedRLEnv,
+    graph: StageGraphSpec,
+    state: StageRuntimeState,
+    flags: dict[str, torch.Tensor],
+    persistent: bool,
+    ordering_mode: Literal["strict", "free"],
+) -> None:
+    stage_names = _stage_names(graph)
+    episode_length_buf = _get_episode_length_buf(env)
+    if episode_length_buf is None:
+        state.eval_flags = None
+        state.eval_step_buf = None
+        state.eval_persistent = None
+        state.eval_ordering_mode = None
+        state.eval_stage_names = None
+        return
+    state.eval_flags = flags
+    state.eval_step_buf = episode_length_buf.clone()
+    state.eval_persistent = persistent
+    state.eval_ordering_mode = ordering_mode
+    state.eval_stage_names = stage_names
+
+
+def evaluate_stage_graph(
+    env: ManagerBasedRLEnv,
+    task_key: str,
+    persistent: bool = False,
+    ordering_mode: Literal["strict", "free"] | None = None,
+) -> dict[str, torch.Tensor]:
+    """Evaluate registered stage graph and return constrained stage flags.
+
+    Args:
+        env: RL environment.
+        task_key: Registered stage-graph key.
+        persistent: If True, stage completion is latched per env until reset.
+        ordering_mode: Optional runtime override, otherwise uses graph.ordering_mode.
+    """
+    graph = get_stage_graph(task_key)
+    state = _get_or_create_task_runtime_state(env, task_key)
+    mode = ordering_mode or graph.ordering_mode
+    cached_flags = _get_cached_eval_flags(env, graph, state, persistent=persistent, ordering_mode=mode)
+    if cached_flags is not None:
+        return cached_flags
+
+    if persistent and mode == "strict" and _is_linear_chain(graph):
+        flags = _evaluate_strict_persistent_active_stage(env, graph, state)
+        _set_cached_eval_flags(env, graph, state, flags, persistent=persistent, ordering_mode=mode)
+        return flags
+
+    raw_flags = _get_raw_flags_cached(env, graph, state)
+    if not persistent:
+        flags = _evaluate_flags(graph, raw_flags, mode)
+        _set_cached_eval_flags(env, graph, state, flags, persistent=persistent, ordering_mode=mode)
+        return flags
+
+    base_flags = _get_persistent_base_flags(env, graph, state)
+    flags = _evaluate_flags(graph, raw_flags, mode, base_flags=base_flags)
+    state.latched_flags = flags
+    _set_cached_eval_flags(env, graph, state, flags, persistent=persistent, ordering_mode=mode)
+    return flags
+
+
+def stage_signals(
+    env: ManagerBasedRLEnv,
+    task_key: str,
+    persistent: bool = False,
+    ordering_mode: Literal["strict", "free"] | None = None,
+) -> torch.Tensor:
+    """Return stage signals as [s1, s2, ..., psr]."""
+    graph = get_stage_graph(task_key)
+    flags = evaluate_stage_graph(env, task_key=task_key, persistent=persistent, ordering_mode=ordering_mode)
+    ordered = torch.stack([flags[stage.name].float() for stage in graph.stages], dim=-1)
+    psr = ordered.mean(dim=-1, keepdim=True)
+    return torch.cat((ordered, psr), dim=-1)
+
+
+def stage_progress(
+    env: ManagerBasedRLEnv,
+    task_key: str,
+    persistent: bool = False,
+    ordering_mode: Literal["strict", "free"] | None = None,
+) -> torch.Tensor:
+    """Return only PSR (stage completion ratio) as shape [num_envs, 1]."""
+    graph = get_stage_graph(task_key)
+    flags = evaluate_stage_graph(env, task_key=task_key, persistent=persistent, ordering_mode=ordering_mode)
+    ordered = torch.stack([flags[stage.name].float() for stage in graph.stages], dim=-1)
+    return ordered.mean(dim=-1, keepdim=True)
+
+
+def stage_success(
+    env: ManagerBasedRLEnv,
+    task_key: str,
+    terminal_stage: str | None = None,
+    persistent: bool = False,
+    success_mode: Literal["substage", "all"] | None = None,
+    ordering_mode: Literal["strict", "free"] | None = None,
+) -> torch.Tensor:
+    """Return success flag from substage or all-stage completion."""
+    graph = get_stage_graph(task_key)
+    flags = evaluate_stage_graph(env, task_key=task_key, persistent=persistent, ordering_mode=ordering_mode)
+    mode = success_mode or graph.success_mode
+    if mode == "all":
+        return torch.stack([flags[stage.name] for stage in graph.stages], dim=-1).all(dim=-1)
+    if mode == "substage":
+        stage_name = terminal_stage or graph.terminal_stage or graph.stages[-1].name
+        if stage_name not in flags:
+            raise KeyError(f"Unknown terminal stage '{stage_name}' for task_key='{task_key}'")
+        return flags[stage_name]
+    raise ValueError(f"Unsupported success_mode: {mode}")
+
+
+def reset_stage_graph_state(env: ManagerBasedRLEnv, env_ids, task_key: str | None = None) -> None:
+    """Reset event: clear a stage graph's latched flags and caches for ``env_ids``.
+
+    Register with ``mode="reset"`` (``params={"task_key": ...}``; ``None`` clears
+    every registered graph). The stage machine also infers resets from a
+    decreasing ``episode_length_buf``, but that misses the *first* reset: the
+    graph is first evaluated while the observation manager sizes its terms at
+    construction -- with the scene still at its init pose -- and
+    ``episode_length_buf`` is 0 both then and after the first reset, so a stage
+    the init pose happens to satisfy stays latched into episode 0.
+    """
+    cache = getattr(env, "_stage_graph_runtime_cache", None)
+    if not cache:
+        return
+    if env_ids is None:
+        ids = torch.arange(env.num_envs, device=env.device)
+    else:
+        ids = torch.as_tensor(env_ids, device=env.device, dtype=torch.long)
+    keys = [task_key] if task_key is not None else list(cache)
+    for key in keys:
+        state = cache.get(key)
+        if not isinstance(state, StageRuntimeState):
+            continue
+        for flags in (state.latched_flags, state.raw_flags, state.eval_flags):
+            if flags:
+                for tensor in flags.values():
+                    if isinstance(tensor, torch.Tensor) and tensor.shape[0] > int(ids.max()):
+                        tensor[ids] = False
+        state.raw_step_buf = None
+        state.eval_step_buf = None
+
+
+__all__ = [
+    "reset_stage_graph_state",
+    "StageSpec",
+    "StageGraphSpec",
+    "register_stage_graph",
+    "get_stage_graph",
+    "evaluate_stage_graph",
+    "stage_signals",
+    "stage_progress",
+    "stage_success",
+]

--- a/source/dexverse/dexverse/baseline_v1/mdp/terminations.py
+++ b/source/dexverse/dexverse/baseline_v1/mdp/terminations.py
@@ -1,0 +1,2327 @@
+# Copyright (c) 2025-2026, The DexVerse Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# Copyright (c) 2022-2025, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Common functions that can be used to activate certain terminations for the dexsuite task.
+
+The functions can be passed to the :class:`isaaclab.managers.TerminationTermCfg` object to enable
+the termination introduced by the function.
+"""
+
+from __future__ import annotations
+
+import os
+
+import torch
+from isaaclab.assets import Articulation, RigidObject
+from isaaclab.envs import ManagerBasedRLEnv
+from isaaclab.managers import ManagerTermBase, SceneEntityCfg
+from isaaclab.utils.math import quat_apply, quat_apply_inverse
+
+from .utils import (
+    asset_axis_w,
+    axis_alignment_dot,
+    axis_tilt_angle,
+    axis_to_plane_angle,
+    factory_insert_success_mask,
+    get_init_joint_pos,
+    insert_peg_success_mask,
+    plug_charger_insertion_mask,
+    push_t_overlap_ratio,
+    resolve_joint_ids,
+    root_height_delta,
+)
+
+
+def _normalize_in_bound_range(
+    in_bound_range: dict[str, tuple[float, float]] | None,
+) -> tuple[tuple[float, float], tuple[float, float], tuple[float, float]]:
+    """Convert optional range dict into canonical (x, y, z) bounds tuple."""
+    in_bound_range = in_bound_range or {}
+    x_bounds = tuple(float(v) for v in in_bound_range.get("x", (0.0, 0.0)))
+    y_bounds = tuple(float(v) for v in in_bound_range.get("y", (0.0, 0.0)))
+    z_bounds = tuple(float(v) for v in in_bound_range.get("z", (0.0, 0.0)))
+    return x_bounds, y_bounds, z_bounds
+
+
+def _get_cached_bounds_tensor(
+    env: ManagerBasedRLEnv,
+    cache_key: tuple[str, tuple[tuple[float, float], tuple[float, float], tuple[float, float]]],
+    dtype: torch.dtype,
+) -> torch.Tensor:
+    """Return cached bounds tensor on env.device/dtype to avoid per-step allocations."""
+    cache = getattr(env, "_out_of_bound_ranges_cache", None)
+    if cache is None:
+        cache = {}
+        setattr(env, "_out_of_bound_ranges_cache", cache)
+
+    ranges = cache.get(cache_key)
+    if ranges is None or ranges.device != env.device or ranges.dtype != dtype:
+        ranges = torch.tensor(cache_key[1], device=env.device, dtype=dtype)
+        cache[cache_key] = ranges
+    return ranges
+
+
+def out_of_bound(
+    env: ManagerBasedRLEnv,
+    asset_cfg: SceneEntityCfg = SceneEntityCfg("object"),
+    in_bound_range: dict[str, tuple[float, float]] | None = None,
+) -> torch.Tensor:
+    """Termination condition for the object falls out of bound.
+
+    Args:
+        env: The environment.
+        asset_cfg: The object configuration. Defaults to SceneEntityCfg("object").
+        in_bound_range: The range in x, y, z such that the object is considered in range
+    """
+    object: RigidObject = env.scene[asset_cfg.name]
+    object_pos_local = object.data.root_pos_w - env.scene.env_origins
+    bounds = _normalize_in_bound_range(in_bound_range)
+    cache_key = (asset_cfg.name, bounds)
+    ranges = _get_cached_bounds_tensor(env, cache_key, dtype=object_pos_local.dtype)
+
+    outside_bounds = ((object_pos_local < ranges[:, 0]) | (object_pos_local > ranges[:, 1])).any(dim=1)
+    return outside_bounds
+
+
+def object_at_goal_position(
+    env: ManagerBasedRLEnv,
+    command_name: str,
+    threshold: float = 0.02,
+) -> torch.Tensor:
+    """Termination condition for when the object is close enough to the goal position.
+
+    This checks if the object's position is within the specified threshold of the goal position.
+    Orientation is ignored - only position matters.
+
+    Args:
+        env: The environment.
+        command_name: The name of the command term that contains the goal position.
+        threshold: Distance threshold in meters. Defaults to 0.05.
+
+    Returns:
+        A boolean tensor indicating which environments have succeeded (object at goal position).
+    """
+    # Get the command term which has position_error metric
+    command_term = env.command_manager.get_term(command_name)
+
+    # Check if position error is below threshold
+    position_error = command_term.metrics["position_error"]
+    success = position_error < threshold
+
+    return success
+
+
+def object_at_goal_pose(
+    env: ManagerBasedRLEnv,
+    command_name: str,
+    position_threshold: float = 0.02,
+    orientation_threshold: float = 0.5,
+) -> torch.Tensor:
+    """Terminate when the commanded object pose is reached in position and orientation."""
+    command_term = env.command_manager.get_term(command_name)
+    position_error = command_term.metrics["position_error"]
+    orientation_error = command_term.metrics["orientation_error"]
+    return (position_error < position_threshold) & (orientation_error < orientation_threshold)
+
+
+def object_upright_at_goal(
+    env: ManagerBasedRLEnv,
+    command_name: str,
+    position_threshold: float = 0.05,
+    max_tilt_rad: float = 0.2617993878,  # 15 degrees
+    object_cfg: SceneEntityCfg = SceneEntityCfg("object"),
+) -> torch.Tensor:
+    """Terminate when the object reaches the goal *position* and is upright.
+
+    Position is read from the ``command_name`` term's ``position_error`` metric
+    (so the goal command can stay ``position_only``). Uprightness is the angle
+    between the object's local +Z and world +Z, which makes the check
+    yaw-agnostic: a cup set down at any heading still counts as upright, while a
+    tipped-over cup does not.
+    """
+    command_term = env.command_manager.get_term(command_name)
+    at_goal = command_term.metrics["position_error"] < position_threshold
+    obj: RigidObject = env.scene[object_cfg.name]
+    angle = axis_tilt_angle(obj.data.root_quat_w, axis_local=(0.0, 0.0, 1.0), world_axis=(0.0, 0.0, 1.0))
+    upright = angle <= max_tilt_rad
+    return at_goal & upright
+
+
+def lift_and_tilt(
+    env: ManagerBasedRLEnv,
+    min_height: float,
+    threshold_rad: float,
+    axis_local: tuple[float, float, float] = (0.0, 0.0, 1.0),
+    world_axis: tuple[float, float, float] = (0.0, 0.0, 1.0),
+    tilt_ge: bool = True,
+    object_cfg: SceneEntityCfg = SceneEntityCfg("object"),
+) -> torch.Tensor:
+    """Terminate when object is lifted above min_height and tilt angle meets threshold."""
+    object: RigidObject = env.scene[object_cfg.name]
+    angle = axis_tilt_angle(object.data.root_quat_w, axis_local=axis_local, world_axis=world_axis)
+    tilt_ok = angle >= threshold_rad if tilt_ge else angle <= threshold_rad
+    lifted = object_lifted(env, asset_cfg=object_cfg, min_height=min_height)
+    return lifted & tilt_ok
+
+
+def object_upright_and_lifted(
+    env: ManagerBasedRLEnv,
+    min_height: float = 0.10,
+    max_tilt_rad: float = 0.174532925,
+    object_cfg: SceneEntityCfg = SceneEntityCfg("object"),
+) -> torch.Tensor:
+    """Terminate when object is upright (tilt <= max_tilt_rad) and lifted above init height."""
+    object: RigidObject = env.scene[object_cfg.name]
+    angle = axis_tilt_angle(object.data.root_quat_w, axis_local=(0.0, 0.0, 1.0), world_axis=(0.0, 0.0, 1.0))
+    upright = angle <= max_tilt_rad
+
+    lifted = root_height_delta(object) >= min_height
+    return upright & lifted
+
+
+def _compare(value: torch.Tensor, target: torch.Tensor | float, op: str, tol: float) -> torch.Tensor:
+    if op == ">=":
+        return value >= (target - tol)
+    if op == ">":
+        return value > (target - tol)
+    if op == "<=":
+        return value <= (target + tol)
+    if op == "<":
+        return value < (target + tol)
+    raise ValueError(f"Unsupported op: {op}")
+
+
+def joint_reach_threshold(
+    env: ManagerBasedRLEnv,
+    threshold: float,
+    asset_cfg: SceneEntityCfg = SceneEntityCfg("object"),
+    op: str = ">=",
+    ref: str = "value",
+    tol: float = 0.0,
+    reduce: str = "any",
+) -> torch.Tensor:
+    """Terminate when joint values cross a threshold."""
+    asset: Articulation = env.scene[asset_cfg.name]
+    joint_ids = resolve_joint_ids(env, asset_cfg)
+    joint_pos = asset.data.joint_pos[:, joint_ids]
+
+    if ref == "value":
+        target = threshold
+    elif ref == "upper_limit":
+        target = asset.data.joint_pos_limits[:, joint_ids, 1] + threshold
+    elif ref == "lower_limit":
+        target = asset.data.joint_pos_limits[:, joint_ids, 0] + threshold
+    else:
+        raise ValueError(f"Unsupported ref: {ref}")
+
+    cmp = _compare(joint_pos, target, op, tol)
+    if reduce == "any":
+        return cmp.any(dim=1)
+    if reduce == "all":
+        return cmp.all(dim=1)
+    raise ValueError(f"Unsupported reduce: {reduce}")
+
+
+def joint_relative_move(
+    env: ManagerBasedRLEnv,
+    threshold: float,
+    asset_cfg: SceneEntityCfg = SceneEntityCfg("object"),
+    mode: str = "displacement",
+    op: str = ">=",
+    reduce: str = "any",
+) -> torch.Tensor:
+    """Terminate when joint displacement/progress crosses a threshold.
+
+    Supported modes:
+        - "displacement": abs(q - q_init)
+        - "progress": abs(q - q_init) / reachable_from_init
+        - "absolute_progress" (aliases: "range_progress", "ratio"): (q - lower) / (upper - lower)
+    """
+    asset: Articulation = env.scene[asset_cfg.name]
+    joint_ids = resolve_joint_ids(env, asset_cfg)
+    joint_pos = asset.data.joint_pos[:, joint_ids]
+
+    init_joint_pos = get_init_joint_pos(asset, joint_ids)
+    delta = torch.abs(joint_pos - init_joint_pos)
+
+    if mode == "displacement":
+        value = delta
+    elif mode == "progress":
+        lower = asset.data.joint_pos_limits[:, joint_ids, 0]
+        upper = asset.data.joint_pos_limits[:, joint_ids, 1]
+        reachable = torch.maximum(init_joint_pos - lower, upper - init_joint_pos)
+        denom = torch.clamp(reachable, min=1e-6)
+        value = delta / denom
+    elif mode == "ratio":
+        lower = asset.data.joint_pos_limits[:, joint_ids, 0]
+        upper = asset.data.joint_pos_limits[:, joint_ids, 1]
+        span = torch.clamp(upper - lower, min=1e-6)
+        value = (joint_pos - lower) / span
+    else:
+        raise ValueError(f"Unsupported mode: {mode}")
+
+    cmp = _compare(value, threshold, op, 0.0)
+    if reduce == "any":
+        return cmp.any(dim=1)
+    if reduce == "all":
+        return cmp.all(dim=1)
+    raise ValueError(f"Unsupported reduce: {reduce}")
+
+
+def object_lifted(
+    env: ManagerBasedRLEnv,
+    asset_cfg: SceneEntityCfg = SceneEntityCfg("object"),
+    object_cfg: SceneEntityCfg | None = None,
+    min_height: float = 0.05,
+) -> torch.Tensor:
+    """Terminate when an asset is lifted above its default height by min_height."""
+    # Backward-compatible alias: some task configs still pass `object_cfg`.
+    if object_cfg is not None:
+        asset_cfg = object_cfg
+    asset = env.scene[asset_cfg.name]
+    return root_height_delta(asset) >= min_height
+
+
+def joint_moved_and_object_lifted(
+    env: ManagerBasedRLEnv,
+    threshold: float,
+    min_height: float = 0.05,
+    asset_cfg: SceneEntityCfg = SceneEntityCfg("object"),
+    mode: str = "progress",
+    op: str = ">=",
+    reduce: str = "any",
+) -> torch.Tensor:
+    """Success when a joint has moved past ``threshold`` AND the asset is lifted.
+
+    Combines :func:`joint_relative_move` (the manipulation goal -- e.g. sliding a
+    blade out) with :func:`object_lifted` (the asset root must be at least
+    ``min_height`` above its spawn height). Requiring both prevents the policy
+    from "succeeding" while the object is still pinned to the table / its
+    supports; it must hold the object off the surface and drive the joint.
+
+    ``asset_cfg`` is used for both checks: its ``joint_names`` select the joint
+    for the move test, while the lift test only reads the asset root pose (joint
+    ids are ignored there).
+    """
+    moved = joint_relative_move(env, threshold=threshold, asset_cfg=asset_cfg, mode=mode, op=op, reduce=reduce)
+    lifted = object_lifted(env, asset_cfg=asset_cfg, min_height=min_height)
+    return moved & lifted
+
+
+class root_pose_displacement_exceeds(ManagerTermBase):
+    """Fail when an asset moves too far from its pose at the current reset.
+
+    The reference is captured after reset events have placed the asset, so
+    randomized initial positions are supported. ``max_upward_z`` is one-sided:
+    small downward settling into the support surface does not count as lifting.
+    """
+
+    def __init__(self, cfg, env: ManagerBasedRLEnv):
+        super().__init__(cfg, env)
+        self._env = env
+        self._reset_root_pos_w: torch.Tensor | None = None
+
+    def reset(self, env_ids=None):
+        asset_cfg = self.cfg.params.get("asset_cfg", SceneEntityCfg("articulation"))
+        asset: Articulation | RigidObject = self._env.scene[asset_cfg.name]
+        if self._reset_root_pos_w is None or self._reset_root_pos_w.shape != asset.data.root_pos_w.shape:
+            self._reset_root_pos_w = asset.data.root_pos_w.clone()
+        elif env_ids is None:
+            self._reset_root_pos_w.copy_(asset.data.root_pos_w)
+        else:
+            self._reset_root_pos_w[env_ids] = asset.data.root_pos_w[env_ids]
+        return {}
+
+    def reset_after_state_restore(self, env_ids=None):
+        """Rebase a new replay episode after its initial scene pose is restored."""
+        return self.reset(env_ids)
+
+    def __call__(
+        self,
+        env: ManagerBasedRLEnv,
+        asset_cfg: SceneEntityCfg = SceneEntityCfg("articulation"),
+        max_xy_displacement: float = 0.03,
+        max_upward_z: float = 0.01,
+    ) -> torch.Tensor:
+        asset: Articulation | RigidObject = env.scene[asset_cfg.name]
+        if self._reset_root_pos_w is None or self._reset_root_pos_w.shape != asset.data.root_pos_w.shape:
+            self._reset_root_pos_w = asset.data.root_pos_w.clone()
+        delta = asset.data.root_pos_w - self._reset_root_pos_w
+        moved_xy = torch.linalg.vector_norm(delta[:, :2], dim=1) > float(max_xy_displacement)
+        lifted = delta[:, 2] > float(max_upward_z)
+        return moved_xy | lifted
+
+
+def joint_moved_and_xy_region(
+    env: ManagerBasedRLEnv,
+    threshold: float,
+    x_bounds: tuple[float, float],
+    y_bounds: tuple[float, float],
+    asset_cfg: SceneEntityCfg = SceneEntityCfg("articulation"),
+    points_local: tuple[tuple[float, float, float], ...] | None = None,
+    require_inside: bool = True,
+    mode: str = "progress",
+    op: str = ">=",
+    reduce: str = "any",
+) -> torch.Tensor:
+    """Gate a joint target on a fixed, environment-frame tabletop region.
+
+    The joint must first satisfy :func:`joint_relative_move`. The asset root,
+    or every asset-local point in ``points_local``, must then be inside the
+    inclusive XY bounds when ``require_inside=True``. With
+    ``require_inside=False`` the term fires for the complementary case, which
+    allows a task to terminate immediately when the joint target is reached in
+    an invalid location. Bounds are relative to each environment origin.
+    """
+    if x_bounds[0] > x_bounds[1] or y_bounds[0] > y_bounds[1]:
+        raise ValueError(f"Invalid XY region bounds: x={x_bounds}, y={y_bounds}")
+
+    moved = joint_relative_move(
+        env,
+        threshold=threshold,
+        asset_cfg=asset_cfg,
+        mode=mode,
+        op=op,
+        reduce=reduce,
+    )
+    asset: Articulation = env.scene[asset_cfg.name]
+    if points_local:
+        local = torch.tensor(points_local, device=env.device, dtype=asset.data.root_pos_w.dtype)
+        count = local.shape[0]
+        asset_quat = asset.data.root_quat_w.unsqueeze(1).expand(-1, count, -1).reshape(-1, 4)
+        points_w = asset.data.root_pos_w.unsqueeze(1) + quat_apply(
+            asset_quat,
+            local.unsqueeze(0).expand(env.num_envs, -1, -1).reshape(-1, 3),
+        ).reshape(env.num_envs, count, 3)
+        points_e = points_w - env.scene.env_origins.unsqueeze(1)
+    else:
+        points_e = (asset.data.root_pos_w - env.scene.env_origins).unsqueeze(1)
+
+    inside = (
+        (points_e[:, :, 0] >= float(x_bounds[0]))
+        & (points_e[:, :, 0] <= float(x_bounds[1]))
+        & (points_e[:, :, 1] >= float(y_bounds[0]))
+        & (points_e[:, :, 1] <= float(y_bounds[1]))
+    ).all(dim=1)
+    region_ok = inside if require_inside else ~inside
+    return moved & region_ok
+
+
+
+def asset_at_goal_xy_yaw(
+    env: ManagerBasedRLEnv,
+    goal_cfg: SceneEntityCfg,
+    asset_cfg: SceneEntityCfg = SceneEntityCfg("articulation"),
+    center_local: tuple[float, float, float] = (0.0, 0.0, 0.0),
+    pos_tol: float = 0.05,
+    z_tol: float | None = None,
+    yaw_tol: float | None = 0.35,
+    bidirectional_yaw: bool = False,
+) -> torch.Tensor:
+    """True where an asset sits at a goal entity's pose (xy, optional yaw/z).
+
+    ``center_local`` is the asset-frame point that must coincide with the goal
+    root (e.g. a footprint centre when the asset root is off-centre). The yaw
+    error is the angle between the two frames' ``+y`` axes projected on the
+    table plane. Set ``bidirectional_yaw=True`` when the goal visualization
+    specifies an undirected long axis (for example, four symmetric footprint
+    corners), so headings separated by 180 degrees are equivalent. Both
+    entities may be rigid objects or articulations. When ``z_tol`` is set, the
+    asset centre must also match the goal height within that tolerance. Set
+    ``yaw_tol=None`` when orientation is unrestricted.
+    """
+    asset: Articulation | RigidObject = env.scene[asset_cfg.name]
+    goal: RigidObject | Articulation = env.scene[goal_cfg.name]
+    center = torch.tensor(center_local, device=env.device, dtype=asset.data.root_pos_w.dtype)
+    center_w = asset.data.root_pos_w + quat_apply(asset.data.root_quat_w, center.unsqueeze(0).expand(env.num_envs, -1))
+    d_xy = torch.linalg.norm((center_w - goal.data.root_pos_w)[:, :2], dim=-1)
+    e_y = torch.tensor([0.0, 1.0, 0.0], device=env.device, dtype=center.dtype).unsqueeze(0).expand(env.num_envs, -1)
+    heading_a = quat_apply(asset.data.root_quat_w, e_y)[:, :2]
+    heading_g = quat_apply(goal.data.root_quat_w, e_y)[:, :2]
+    cos = (heading_a * heading_g).sum(-1) / (heading_a.norm(dim=-1) * heading_g.norm(dim=-1)).clamp_min(1e-6)
+    if bidirectional_yaw:
+        cos = cos.abs()
+    yaw_err = torch.acos(cos.clamp(-1.0, 1.0))
+    at_goal = d_xy <= float(pos_tol)
+    if yaw_tol is not None:
+        at_goal &= yaw_err <= float(yaw_tol)
+    if z_tol is not None:
+        at_goal &= (center_w[:, 2] - goal.data.root_pos_w[:, 2]).abs() <= float(z_tol)
+    return at_goal
+
+
+def joint_moved_and_pose_near_goal(
+    env: ManagerBasedRLEnv,
+    threshold: float,
+    goal_cfg: SceneEntityCfg,
+    asset_cfg: SceneEntityCfg = SceneEntityCfg("articulation"),
+    center_local: tuple[float, float, float] = (0.0, 0.0, 0.0),
+    pos_tol: float = 0.05,
+    z_tol: float | None = None,
+    yaw_tol: float | None = 0.35,
+    bidirectional_yaw: bool = False,
+    require_at_goal: bool = True,
+    mode: str = "progress",
+    op: str = ">=",
+    reduce: str = "any",
+) -> torch.Tensor:
+    """Gate a joint target on the asset standing at a per-episode goal pose.
+
+    The pose-goal counterpart of :func:`joint_moved_and_xy_region`: the joint
+    must satisfy :func:`joint_relative_move` AND the asset must be at the goal
+    entity's planar pose per :func:`asset_at_goal_xy_yaw`. With
+    ``require_at_goal=False`` the term fires for the complementary case (joint
+    target reached while *off* the goal), for use as an explicit failure.
+    """
+    moved = joint_relative_move(env, threshold=threshold, asset_cfg=asset_cfg, mode=mode, op=op, reduce=reduce)
+    at_goal = asset_at_goal_xy_yaw(
+        env,
+        goal_cfg=goal_cfg,
+        asset_cfg=asset_cfg,
+        center_local=center_local,
+        pos_tol=pos_tol,
+        z_tol=z_tol,
+        yaw_tol=yaw_tol,
+        bidirectional_yaw=bidirectional_yaw,
+    )
+    return moved & (at_goal if require_at_goal else ~at_goal)
+
+
+class joint_pose_contact_release_hold_success(ManagerTermBase):
+    """Hold an opened articulation at a goal after releasing the robot.
+
+    Success requires, for ``hold_steps`` consecutive simulation steps: the
+    selected joint target, the goal pose, contact with the support, no robot
+    contact, and no configured robot body inside the articulation-local
+    forbidden zones. Any broken condition resets the per-environment dwell.
+    """
+
+    def __init__(self, cfg, env: ManagerBasedRLEnv):
+        super().__init__(cfg, env)
+        self._counter = torch.zeros(env.num_envs, dtype=torch.long, device=env.device)
+        self._last_step = torch.zeros(env.num_envs, dtype=torch.long, device=env.device)
+        (
+            self._forbidden_sphere_centers,
+            self._forbidden_sphere_r2,
+            self._forbidden_box_centers,
+            self._forbidden_box_half,
+            self._forbidden_cylinder_centers,
+            self._forbidden_cylinder_radius2_height,
+            self._forbidden_cylinder_quats,
+        ) = _build_zone_tensors(
+            cfg.params.get("forbidden_sphere_zones"),
+            cfg.params.get("forbidden_box_zones"),
+            cfg.params.get("forbidden_cylinder_zones"),
+            env.device,
+        )
+
+    def reset(self, env_ids=None):
+        if env_ids is None:
+            self._counter.zero_()
+            self._last_step.zero_()
+        else:
+            self._counter[env_ids] = 0
+            self._last_step[env_ids] = 0
+        return {}
+
+    @staticmethod
+    def _sensors_exceed_force(env: ManagerBasedRLEnv, sensor_names, threshold: float) -> torch.Tensor:
+        exceeded = torch.zeros(env.num_envs, dtype=torch.bool, device=env.device)
+        for sensor_name in sensor_names:
+            force_w = env.scene.sensors[sensor_name].data.force_matrix_w
+            if force_w is not None:
+                force_mag = force_w.reshape(env.num_envs, -1, 3).norm(dim=-1)
+                exceeded |= (force_mag >= float(threshold)).any(dim=1)
+        return exceeded
+
+    def __call__(
+        self,
+        env: ManagerBasedRLEnv,
+        threshold: float,
+        goal_cfg: SceneEntityCfg,
+        support_sensor_names: tuple[str, ...] | list[str],
+        robot_sensor_names: tuple[str, ...] | list[str],
+        forbidden_sphere_zones: list | None = None,
+        forbidden_box_zones: list | None = None,
+        forbidden_cylinder_zones: list | None = None,
+        forbidden_asset_cfg: SceneEntityCfg = SceneEntityCfg("robot"),
+        asset_cfg: SceneEntityCfg = SceneEntityCfg("articulation"),
+        center_local: tuple[float, float, float] = (0.0, 0.0, 0.0),
+        pos_tol: float = 0.05,
+        z_tol: float | None = None,
+        yaw_tol: float | None = 0.35,
+        bidirectional_yaw: bool = False,
+        mode: str = "progress",
+        op: str = ">=",
+        reduce: str = "any",
+        support_force_threshold: float = 0.25,
+        robot_force_threshold: float = 0.10,
+        hold_steps: int = 10,
+    ) -> torch.Tensor:
+        opened_and_placed = joint_moved_and_pose_near_goal(
+            env,
+            threshold=threshold,
+            goal_cfg=goal_cfg,
+            asset_cfg=asset_cfg,
+            center_local=center_local,
+            pos_tol=pos_tol,
+            z_tol=z_tol,
+            yaw_tol=yaw_tol,
+            bidirectional_yaw=bidirectional_yaw,
+            require_at_goal=True,
+            mode=mode,
+            op=op,
+            reduce=reduce,
+        )
+        on_support = self._sensors_exceed_force(env, support_sensor_names, support_force_threshold)
+        robot_touching = self._sensors_exceed_force(env, robot_sensor_names, robot_force_threshold)
+        robot_in_forbidden_zone = _eval_zone_violation(
+            env,
+            forbidden_asset_cfg,
+            SceneEntityCfg(asset_cfg.name),
+            self._forbidden_sphere_centers,
+            self._forbidden_sphere_r2,
+            self._forbidden_box_centers,
+            self._forbidden_box_half,
+            self._forbidden_cylinder_centers,
+            self._forbidden_cylinder_radius2_height,
+            self._forbidden_cylinder_quats,
+        )
+
+        current = env.episode_length_buf.to(dtype=torch.long)
+        reset_rows = current < self._last_step
+        if reset_rows.any():
+            self._counter[reset_rows] = 0
+        self._last_step = current.clone()
+
+        valid = opened_and_placed & on_support & ~robot_touching & ~robot_in_forbidden_zone
+        self._counter = torch.where(valid, self._counter + 1, torch.zeros_like(self._counter))
+        return self._counter >= max(int(hold_steps), 1)
+
+
+def joint_near_init_and_contact(
+    env: ManagerBasedRLEnv,
+    sensor_names: tuple[str, ...] | list[str],
+    asset_cfg: SceneEntityCfg = SceneEntityCfg("articulation"),
+    max_progress: float = 0.25,
+    force_threshold: float = 0.5,
+) -> torch.Tensor:
+    """Fail when a selected joint is near its reset pose during contact.
+
+    Contact is read only from the supplied filtered contact sensors. Joint
+    progress is the absolute displacement from the reset position divided by
+    the reachable range, matching :func:`joint_relative_move`'s ``progress``
+    mode. This is useful for a raised placement target that may be touched only
+    after an articulation (for example a stapler) has been opened safely.
+    """
+    asset: Articulation = env.scene[asset_cfg.name]
+    joint_ids = resolve_joint_ids(env, asset_cfg)
+    joint_pos = asset.data.joint_pos[:, joint_ids]
+    init_joint_pos = get_init_joint_pos(asset, joint_ids)
+    lower = asset.data.joint_pos_limits[:, joint_ids, 0]
+    upper = asset.data.joint_pos_limits[:, joint_ids, 1]
+    reachable = torch.maximum(init_joint_pos - lower, upper - init_joint_pos).clamp_min(1e-6)
+    near_init = (torch.abs(joint_pos - init_joint_pos) / reachable <= float(max_progress)).all(dim=1)
+
+    touching = torch.zeros(env.num_envs, dtype=torch.bool, device=env.device)
+    for sensor_name in sensor_names:
+        force_w = env.scene.sensors[sensor_name].data.force_matrix_w
+        if force_w is not None:
+            force_mag = force_w.reshape(env.num_envs, -1, 3).norm(dim=-1)
+            touching |= (force_mag >= float(force_threshold)).any(dim=1)
+    return near_init & touching
+
+
+def joint_velocity_exceeds(
+    env: ManagerBasedRLEnv,
+    asset_cfg: SceneEntityCfg,
+    max_speed: float,
+    direction: int = 0,
+) -> torch.Tensor:
+    """True where any selected joint moves faster than ``max_speed`` (rad/s or m/s).
+
+    ``direction`` = ``0`` tests ``|v|``; ``+1`` only positive velocity
+    (``v >= max_speed``); ``-1`` only negative (``v <= -max_speed``). Use as a
+    failure term to punish slamming a spring-loaded part (e.g. a stapler top
+    snapping shut on the loader's hand: closing is the positive direction of a
+    hinge whose open limit is negative).
+    """
+    asset: Articulation = env.scene[asset_cfg.name]
+    vel = asset.data.joint_vel[:, asset_cfg.joint_ids]
+    if direction > 0:
+        hit = vel >= float(max_speed)
+    elif direction < 0:
+        hit = vel <= -float(max_speed)
+    else:
+        hit = vel.abs() >= float(max_speed)
+    return hit.any(dim=1)
+
+
+def object_seated_in_body_channel(
+    env: ManagerBasedRLEnv,
+    object_cfg: SceneEntityCfg,
+    body_cfg: SceneEntityCfg,
+    channel_center_local: tuple[float, float, float],
+    channel_half_extents: tuple[float, float, float],
+    object_points_local: tuple[tuple[float, float, float], ...],
+    tolerance: tuple[float, float, float] = (0.0, 0.0, 0.0),
+    axis_alignments: tuple[tuple[tuple[float, float, float], tuple[float, float, float], float, bool], ...] = (),
+) -> torch.Tensor:
+    """True where an object sits inside a box channel attached to an articulation body.
+
+    Every ``object_points_local`` point (object frame) must fall inside the
+    box ``channel_center_local`` +- (``channel_half_extents`` + ``tolerance``)
+    expressed in the ``body_cfg`` body's frame, and each
+    ``axis_alignments`` entry ``(object_axis, body_axis, min_cos, use_abs)``
+    must hold (world-frame dot product of the two unit axes >= ``min_cos``,
+    optionally on ``|dot|``). Pose-only: no contact is involved, so the object
+    may be collision-filtered against the body (phantom insertion).
+    """
+    obj: RigidObject | Articulation = env.scene[object_cfg.name]
+    body: Articulation = env.scene[body_cfg.name]
+    if isinstance(body_cfg.body_ids, slice):
+        body_cfg.resolve(env.scene)
+    bidx = 0 if isinstance(body_cfg.body_ids, slice) else int(body_cfg.body_ids[0])
+    body_pos = body.data.body_pos_w[:, bidx]
+    body_quat = body.data.body_quat_w[:, bidx]
+    n = env.num_envs
+    dtype = body_pos.dtype
+    pts = torch.tensor(object_points_local, device=env.device, dtype=dtype)  # (K, 3)
+    k = pts.shape[0]
+    obj_quat = obj.data.root_quat_w.unsqueeze(1).expand(-1, k, -1).reshape(-1, 4)
+    pts_w = obj.data.root_pos_w.unsqueeze(1) + quat_apply(obj_quat, pts.unsqueeze(0).expand(n, -1, -1).reshape(-1, 3)).reshape(n, k, 3)
+    bq = body_quat.unsqueeze(1).expand(-1, k, -1).reshape(-1, 4)
+    pts_b = quat_apply_inverse(bq, (pts_w - body_pos.unsqueeze(1)).reshape(-1, 3)).reshape(n, k, 3)
+    center = torch.tensor(channel_center_local, device=env.device, dtype=dtype)
+    bound = torch.tensor(channel_half_extents, device=env.device, dtype=dtype) + torch.tensor(tolerance, device=env.device, dtype=dtype)
+    inside = ((pts_b - center).abs() <= bound).all(dim=-1).all(dim=-1)
+    for obj_axis, body_axis, min_cos, use_abs in axis_alignments:
+        a = quat_apply(obj.data.root_quat_w, torch.tensor(obj_axis, device=env.device, dtype=dtype).unsqueeze(0).expand(n, -1))
+        b = quat_apply(body_quat, torch.tensor(body_axis, device=env.device, dtype=dtype).unsqueeze(0).expand(n, -1))
+        dot = (a * b).sum(dim=-1) / (a.norm(dim=-1) * b.norm(dim=-1)).clamp_min(1e-6)
+        inside &= (dot.abs() if use_abs else dot) >= float(min_cos)
+    return inside
+
+def object_axis_upright(
+    env: ManagerBasedRLEnv,
+    object_cfg: SceneEntityCfg = SceneEntityCfg("object"),
+    axis_local: tuple[float, float, float] = (0.0, 0.0, 1.0),
+    min_cos: float = 0.966,
+) -> torch.Tensor:
+    """True where the object's local ``axis_local`` points up within ``acos(min_cos)``."""
+    obj: RigidObject | Articulation = env.scene[object_cfg.name]
+    axis = torch.tensor(axis_local, device=env.device, dtype=obj.data.root_quat_w.dtype).unsqueeze(0).expand(env.num_envs, -1)
+    up_w = quat_apply(obj.data.root_quat_w, axis)
+    return up_w[:, 2] >= float(min_cos)
+
+
+def robot_in_forbidden_zones(
+    env: ManagerBasedRLEnv,
+    asset_cfg: SceneEntityCfg,
+    object_cfg: SceneEntityCfg,
+    sphere_zones: list | None = None,
+    box_zones: list | None = None,
+    cylinder_zones: list | None = None,
+) -> torch.Tensor:
+    """True where any ``asset_cfg`` body is inside an object-local forbidden zone.
+
+    A plain-function wrapper over the zone machinery of
+    :class:`lift_and_tilt_with_contact_zones` (same zone list formats, e.g. from
+    ``split_zones``), usable as a failure term or a stage gate.
+    """
+    tensors = _build_zone_tensors(sphere_zones, box_zones, cylinder_zones, env.device)
+    return _eval_zone_violation(env, asset_cfg, object_cfg, *tensors)
+
+
+def _points_to_segment_distance(points: torch.Tensor, seg_a: torch.Tensor, seg_b: torch.Tensor) -> torch.Tensor:
+    """Distance from ``points`` (N, B, 3) to per-env segments ``seg_a``->``seg_b`` (N, 3)."""
+    ab = (seg_b - seg_a).unsqueeze(1)  # (N, 1, 3)
+    ap = points - seg_a.unsqueeze(1)
+    t = ((ap * ab).sum(-1) / (ab * ab).sum(-1).clamp_min(1e-9)).clamp(0.0, 1.0)
+    closest = seg_a.unsqueeze(1) + t.unsqueeze(-1) * ab
+    return torch.linalg.norm(points - closest, dim=-1)
+
+
+def object_placed_at_spot(
+    env: ManagerBasedRLEnv,
+    cache_key: str,
+    spot_cfg: SceneEntityCfg,
+    spot_local: tuple[float, float, float],
+    object_cfg: SceneEntityCfg = SceneEntityCfg("object"),
+    xy_tol: float = 0.03,
+    z_tol: float = 0.02,
+    axis_local: tuple[float, float, float] = (0.0, 0.0, 1.0),
+    upright_cos: float = 0.985,
+    max_lin_speed: float = 0.05,
+    hold_steps: int = 30,
+    robot_cfg: SceneEntityCfg | None = None,
+    object_radius: float = 0.04,
+    object_axis_length: float = 0.1,
+    release_clearance: float = 0.02,
+) -> torch.Tensor:
+    """True once an object has stood at a spot, upright and let go of, for ``hold_steps``.
+
+    The spot is ``spot_local`` in the ``spot_cfg`` root frame (e.g. a dispenser's
+    tray centre). Each step the object must have its root within ``xy_tol``
+    horizontally and ``z_tol`` vertically of the spot, its ``axis_local`` up
+    within ``acos(upright_cos)``, root speed <= ``max_lin_speed`` and -- when
+    ``robot_cfg`` is given -- every listed robot body farther than
+    ``object_radius + release_clearance`` from the object's axis segment (root
+    to root + ``object_axis_length`` * axis), i.e. the hand has released it.
+    A per-env counter (keyed by ``cache_key``, reset with the episode) must
+    reach ``hold_steps`` consecutive satisfied steps. Plain function, so it can
+    serve as a stage-graph stage.
+    """
+    obj: RigidObject | Articulation = env.scene[object_cfg.name]
+    spot: RigidObject | Articulation = env.scene[spot_cfg.name]
+    n = env.num_envs
+    dtype = obj.data.root_pos_w.dtype
+    offset = torch.tensor(spot_local, device=env.device, dtype=dtype).unsqueeze(0).expand(n, -1)
+    spot_w = spot.data.root_pos_w + quat_apply(spot.data.root_quat_w, offset)
+    pos = obj.data.root_pos_w
+    d_xy = torch.linalg.norm((pos - spot_w)[:, :2], dim=-1)
+    axis = torch.tensor(axis_local, device=env.device, dtype=dtype).unsqueeze(0).expand(n, -1)
+    up_w = quat_apply(obj.data.root_quat_w, axis)
+    ok = (d_xy <= float(xy_tol)) & ((pos[:, 2] - spot_w[:, 2]).abs() <= float(z_tol)) & (up_w[:, 2] >= float(upright_cos))
+    ok &= torch.linalg.norm(obj.data.root_lin_vel_w, dim=-1) <= float(max_lin_speed)
+    if robot_cfg is not None:
+        robot: Articulation = env.scene[robot_cfg.name]
+        if isinstance(robot_cfg.body_ids, slice):
+            robot_cfg.resolve(env.scene)
+        body_pos = robot.data.body_pos_w[:, robot_cfg.body_ids]  # (N, B, 3)
+        dist = _points_to_segment_distance(body_pos, pos, pos + float(object_axis_length) * up_w)
+        ok &= dist.min(dim=1).values >= float(object_radius) + float(release_clearance)
+    # consecutive-step counter, reset when the episode restarts
+    store = env.__dict__.setdefault("_placed_hold_state", {})
+    state = store.get(cache_key)
+    step_buf = getattr(env, "episode_length_buf", None)
+    if state is None or state["count"].shape[0] != n:
+        state = {"count": torch.zeros(n, device=env.device, dtype=torch.long), "step": None if step_buf is None else step_buf.clone()}
+        store[cache_key] = state
+    if step_buf is not None and state["step"] is not None:
+        restarted = (step_buf < state["step"]) | (step_buf == 0)
+        state["count"][restarted] = 0
+    state["count"] = torch.where(ok, state["count"] + 1, torch.zeros_like(state["count"]))
+    if step_buf is not None:
+        state["step"] = step_buf.clone()
+    return state["count"] >= int(hold_steps)
+
+class joint_co_completion(ManagerTermBase):
+    """Success when all selected joints reach the target within a shared time window.
+
+    Each step, the term records — per env and per selected joint — the first
+    episode step at which the joint entered the satisfied region. If a joint
+    drops back out, its first-entry step is cleared, so the window only counts
+    contiguous dwell.
+
+    ``mode="value"`` uses the same ``op``/``ref``/``tol`` semantics as
+    :func:`joint_reach_threshold`. ``mode="ratio"`` compares the absolute joint
+    range fraction ``(q - lower) / (upper - lower)`` against ``threshold``.
+
+    Success fires when every selected joint is currently satisfied AND the
+    spread between first-entry steps (``max - min``) is at most
+    ``window_steps``. Releasing one joint long before the others will not
+    trigger success.
+    """
+
+    def __init__(self, cfg, env):
+        super().__init__(cfg, env)
+        self._first_entry: torch.Tensor | None = None
+        self._last_step: torch.Tensor | None = None
+
+    def _ensure_buffer(self, shape: tuple[int, int], device) -> None:
+        if self._first_entry is None or tuple(self._first_entry.shape) != shape or self._first_entry.device != device:
+            self._first_entry = torch.full(shape, -1, dtype=torch.long, device=device)
+            self._last_step = torch.zeros(shape[0], dtype=torch.long, device=device)
+
+    def __call__(
+        self,
+        env: ManagerBasedRLEnv,
+        threshold: float,
+        asset_cfg: SceneEntityCfg = SceneEntityCfg("articulation"),
+        op: str = ">=",
+        ref: str = "value",
+        tol: float = 0.0,
+        window_steps: int = 30,
+        mode: str = "value",
+    ) -> torch.Tensor:
+        asset: Articulation = env.scene[asset_cfg.name]
+        joint_ids = resolve_joint_ids(env, asset_cfg)
+        joint_pos = asset.data.joint_pos[:, joint_ids]
+
+        if mode == "value":
+            if ref == "value":
+                target = threshold
+            elif ref == "upper_limit":
+                target = asset.data.joint_pos_limits[:, joint_ids, 1] + threshold
+            elif ref == "lower_limit":
+                target = asset.data.joint_pos_limits[:, joint_ids, 0] + threshold
+            else:
+                raise ValueError(f"Unsupported ref: {ref}")
+            value = joint_pos
+        elif mode == "ratio":
+            lower = asset.data.joint_pos_limits[:, joint_ids, 0]
+            upper = asset.data.joint_pos_limits[:, joint_ids, 1]
+            span = torch.clamp(upper - lower, min=1e-6)
+            value = (joint_pos - lower) / span
+            target = threshold
+        else:
+            raise ValueError(f"Unsupported mode: {mode}")
+
+        satisfied = _compare(value, target, op, tol)
+
+        self._ensure_buffer((env.num_envs, joint_pos.shape[1]), env.device)
+
+        # Detect per-env resets: episode_length_buf is monotone within an
+        # episode, so a drop means the env was reset since the last call.
+        current = env.episode_length_buf.to(dtype=self._first_entry.dtype)
+        reset_rows = current < self._last_step
+        if reset_rows.any():
+            self._first_entry[reset_rows] = -1
+        self._last_step = current.clone()
+
+        step = current
+        step = step.unsqueeze(1).expand_as(self._first_entry)
+        newly_entered = satisfied & (self._first_entry < 0)
+        self._first_entry = torch.where(newly_entered, step, self._first_entry)
+        self._first_entry = torch.where(satisfied, self._first_entry, torch.full_like(self._first_entry, -1))
+
+        all_satisfied = satisfied.all(dim=1)
+        entries = self._first_entry.clamp_min(0)
+        spread = entries.amax(dim=1) - entries.amin(dim=1)
+        return all_satisfied & (spread <= window_steps)
+
+
+def _build_zone_tensors(
+    sphere_zones: list | None,
+    box_zones: list | None,
+    cylinder_zones: list | None,
+    device,
+) -> tuple[
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+]:
+    """Convert flat zone lists to cached tensor parameters."""
+    sphere_zones = sphere_zones or []
+    box_zones = box_zones or []
+    cylinder_zones = cylinder_zones or []
+    if sphere_zones:
+        arr = torch.tensor(sphere_zones, device=device, dtype=torch.float32)
+        sphere_centers = arr[:, :3].contiguous()
+        sphere_r2 = (arr[:, 3] ** 2).contiguous()
+    else:
+        sphere_centers = torch.zeros(0, 3, device=device)
+        sphere_r2 = torch.zeros(0, device=device)
+    if box_zones:
+        arr = torch.tensor(box_zones, device=device, dtype=torch.float32)
+        box_centers = arr[:, :3].contiguous()
+        box_half = arr[:, 3:6].contiguous()
+    else:
+        box_centers = torch.zeros(0, 3, device=device)
+        box_half = torch.zeros(0, 3, device=device)
+    if cylinder_zones:
+        normalized_cylinder_zones = []
+        for zone in cylinder_zones:
+            if len(zone) == 5:
+                normalized_cylinder_zones.append([*zone, 1.0, 0.0, 0.0, 0.0])
+            elif len(zone) == 9:
+                normalized_cylinder_zones.append(zone)
+            else:
+                raise ValueError(
+                    "Cylinder zones must be (cx, cy, cz, radius, half_height) "
+                    "or (cx, cy, cz, radius, half_height, qw, qx, qy, qz)."
+                )
+        arr = torch.tensor(normalized_cylinder_zones, device=device, dtype=torch.float32)
+        cylinder_centers = arr[:, :3].contiguous()
+        cylinder_radius2_height = torch.stack((arr[:, 3] ** 2, arr[:, 4]), dim=-1).contiguous()
+        cylinder_quats = arr[:, 5:9]
+        quat_norm = torch.linalg.norm(cylinder_quats, dim=-1, keepdim=True)
+        identity = torch.tensor((1.0, 0.0, 0.0, 0.0), device=device, dtype=torch.float32)
+        cylinder_quats = torch.where(
+            quat_norm > 1.0e-8,
+            cylinder_quats / quat_norm.clamp_min(1.0e-8),
+            identity.expand_as(cylinder_quats),
+        ).contiguous()
+    else:
+        cylinder_centers = torch.zeros(0, 3, device=device)
+        cylinder_radius2_height = torch.zeros(0, 2, device=device)
+        cylinder_quats = torch.zeros(0, 4, device=device)
+    return (
+        sphere_centers,
+        sphere_r2,
+        box_centers,
+        box_half,
+        cylinder_centers,
+        cylinder_radius2_height,
+        cylinder_quats,
+    )
+
+
+def _eval_zone_violation(
+    env: ManagerBasedRLEnv,
+    asset_cfg: SceneEntityCfg,
+    object_cfg: SceneEntityCfg,
+    sphere_centers: torch.Tensor,
+    sphere_r2: torch.Tensor,
+    box_centers: torch.Tensor,
+    box_half: torch.Tensor,
+    cylinder_centers: torch.Tensor,
+    cylinder_radius2_height: torch.Tensor,
+    cylinder_quats: torch.Tensor,
+) -> torch.Tensor:
+    """Per-env bool: any body listed in ``asset_cfg`` is inside any forbidden zone."""
+    n_spheres = sphere_centers.shape[0]
+    n_boxes = box_centers.shape[0]
+    n_cylinders = cylinder_centers.shape[0]
+    if n_spheres == 0 and n_boxes == 0 and n_cylinders == 0:
+        return torch.zeros(env.num_envs, dtype=torch.bool, device=env.device)
+
+    body_pos_w = _asset_body_positions_w(env, asset_cfg)
+    body_pos_obj = _positions_in_object_frame(env, body_pos_w, object_cfg)
+
+    violated = torch.zeros(env.num_envs, dtype=torch.bool, device=env.device)
+    if n_spheres > 0:
+        d2 = ((body_pos_obj.unsqueeze(2) - sphere_centers) ** 2).sum(dim=-1)
+        violated |= (d2 < sphere_r2).any(dim=-1).any(dim=-1)
+    if n_boxes > 0:
+        d = (body_pos_obj.unsqueeze(2) - box_centers).abs()
+        inside = (d < box_half).all(dim=-1)
+        violated |= inside.any(dim=-1).any(dim=-1)
+    if n_cylinders > 0:
+        d = body_pos_obj.unsqueeze(2) - cylinder_centers
+        cylinder_quats = cylinder_quats.unsqueeze(0).unsqueeze(0).expand(*d.shape[:2], -1, -1)
+        d = quat_apply_inverse(cylinder_quats.reshape(-1, 4), d.reshape(-1, 3)).reshape(d.shape)
+        radial2 = (d[..., :2] ** 2).sum(dim=-1)
+        inside_radial = radial2 < cylinder_radius2_height[:, 0]
+        inside_height = d[..., 2].abs() < cylinder_radius2_height[:, 1]
+        violated |= (inside_radial & inside_height).any(dim=-1).any(dim=-1)
+    return violated
+
+
+def _asset_body_positions_w(
+    env: ManagerBasedRLEnv,
+    asset_cfg: SceneEntityCfg,
+) -> torch.Tensor:
+    """Return world positions for configured articulation bodies or a rigid root."""
+    asset = env.scene[asset_cfg.name]
+    if isinstance(asset, Articulation):
+        body_ids = asset_cfg.body_ids
+        if body_ids is None:
+            return asset.data.body_pos_w
+        return asset.data.body_pos_w[:, body_ids]
+    if isinstance(asset, RigidObject):
+        return asset.data.root_pos_w.unsqueeze(1)
+    raise TypeError(f"Unsupported asset type for contact-zone evaluation: {type(asset)!r}")
+
+
+def _positions_in_object_frame(
+    env: ManagerBasedRLEnv,
+    positions_w: torch.Tensor,
+    object_cfg: SceneEntityCfg,
+) -> torch.Tensor:
+    """Transform ``(E, B, 3)`` world positions into the object's root frame."""
+    obj: RigidObject = env.scene[object_cfg.name]
+    E, B, _ = positions_w.shape
+
+    rel_w = positions_w - obj.data.root_pos_w[:, None, :]
+    obj_quat = obj.data.root_quat_w[:, None, :].expand(-1, B, -1).reshape(-1, 4)
+    return quat_apply_inverse(obj_quat, rel_w.reshape(-1, 3)).reshape(E, B, 3)
+
+
+def _eval_zone_coverage(
+    env: ManagerBasedRLEnv,
+    asset_cfg: SceneEntityCfg,
+    object_cfg: SceneEntityCfg,
+    sphere_centers: torch.Tensor,
+    sphere_r2: torch.Tensor,
+    box_centers: torch.Tensor,
+    box_half: torch.Tensor,
+    cylinder_centers: torch.Tensor,
+    cylinder_radius2_height: torch.Tensor,
+    cylinder_quats: torch.Tensor,
+) -> torch.Tensor:
+    """Per-env bool: every required zone contains at least one configured body."""
+    n_spheres = sphere_centers.shape[0]
+    n_boxes = box_centers.shape[0]
+    n_cylinders = cylinder_centers.shape[0]
+    if n_spheres == 0 and n_boxes == 0 and n_cylinders == 0:
+        return torch.ones(env.num_envs, dtype=torch.bool, device=env.device)
+
+    body_pos_w = _asset_body_positions_w(env, asset_cfg)
+    body_pos_obj = _positions_in_object_frame(env, body_pos_w, object_cfg)
+
+    satisfied = []
+    if n_spheres > 0:
+        d2 = ((body_pos_obj.unsqueeze(2) - sphere_centers) ** 2).sum(dim=-1)
+        satisfied.append((d2 < sphere_r2).any(dim=1))
+    if n_boxes > 0:
+        d = (body_pos_obj.unsqueeze(2) - box_centers).abs()
+        satisfied.append((d < box_half).all(dim=-1).any(dim=1))
+    if n_cylinders > 0:
+        d = body_pos_obj.unsqueeze(2) - cylinder_centers
+        cylinder_quats = cylinder_quats.unsqueeze(0).unsqueeze(0).expand(*d.shape[:2], -1, -1)
+        d = quat_apply_inverse(cylinder_quats.reshape(-1, 4), d.reshape(-1, 3)).reshape(d.shape)
+        radial2 = (d[..., :2] ** 2).sum(dim=-1)
+        inside_radial = radial2 < cylinder_radius2_height[:, 0]
+        inside_height = d[..., 2].abs() < cylinder_radius2_height[:, 1]
+        satisfied.append((inside_radial & inside_height).any(dim=1))
+    return torch.cat(satisfied, dim=1).all(dim=1)
+
+
+class success_no_forbidden_contact(ManagerTermBase):
+    """Goal-position success gated by forbidden-zone clearance.
+
+    Fires only when the object is within ``threshold`` of the commanded goal
+    AND no body listed in ``asset_cfg.body_ids`` (e.g. fingertips) lies inside
+    any forbidden zone defined in the object's local frame.
+
+    ``sphere_zones``: list of ``(cx, cy, cz, radius)`` in object-local frame.
+    ``box_zones``: list of ``(cx, cy, cz, hx, hy, hz)`` (axis-aligned half-sizes
+    in object-local frame).
+    ``cylinder_zones``: list of ``(cx, cy, cz, radius, half_height)`` or
+    ``(cx, cy, cz, radius, half_height, qw, qx, qy, qz)`` in object-local frame.
+    """
+
+    def __init__(self, cfg, env: ManagerBasedRLEnv):
+        super().__init__(cfg, env)
+        (
+            self._sphere_centers,
+            self._sphere_r2,
+            self._box_centers,
+            self._box_half,
+            self._cylinder_centers,
+            self._cylinder_radius2_height,
+            self._cylinder_quats,
+        ) = _build_zone_tensors(
+            cfg.params.get("sphere_zones"),
+            cfg.params.get("box_zones"),
+            cfg.params.get("cylinder_zones"),
+            env.device,
+        )
+
+    def __call__(
+        self,
+        env: ManagerBasedRLEnv,
+        command_name: str,
+        threshold: float = 0.03,
+        sphere_zones: list | None = None,
+        box_zones: list | None = None,
+        cylinder_zones: list | None = None,
+        asset_cfg: SceneEntityCfg = SceneEntityCfg("robot"),
+        object_cfg: SceneEntityCfg = SceneEntityCfg("object"),
+    ) -> torch.Tensor:
+        command_term = env.command_manager.get_term(command_name)
+        at_goal = command_term.metrics["position_error"] < threshold
+
+        if (
+            self._sphere_centers.shape[0] == 0
+            and self._box_centers.shape[0] == 0
+            and self._cylinder_centers.shape[0] == 0
+        ):
+            return at_goal
+
+        violated = _eval_zone_violation(
+            env,
+            asset_cfg,
+            object_cfg,
+            self._sphere_centers,
+            self._sphere_r2,
+            self._box_centers,
+            self._box_half,
+            self._cylinder_centers,
+            self._cylinder_radius2_height,
+            self._cylinder_quats,
+        )
+        return at_goal & ~violated
+
+
+class success_with_contact_zones(ManagerTermBase):
+    """Goal-position success gated by forbidden and designated contact zones.
+
+    In addition to the forbidden-zone clearance supported by
+    :class:`success_no_forbidden_contact`, this term requires every designated
+    contact zone to contain at least one body from ``contact_asset_cfg``.
+    """
+
+    def __init__(self, cfg, env: ManagerBasedRLEnv):
+        super().__init__(cfg, env)
+        (
+            self._forbidden_sphere_centers,
+            self._forbidden_sphere_r2,
+            self._forbidden_box_centers,
+            self._forbidden_box_half,
+            self._forbidden_cylinder_centers,
+            self._forbidden_cylinder_radius2_height,
+            self._forbidden_cylinder_quats,
+        ) = _build_zone_tensors(
+            cfg.params.get("sphere_zones"),
+            cfg.params.get("box_zones"),
+            cfg.params.get("cylinder_zones"),
+            env.device,
+        )
+        (
+            self._contact_sphere_centers,
+            self._contact_sphere_r2,
+            self._contact_box_centers,
+            self._contact_box_half,
+            self._contact_cylinder_centers,
+            self._contact_cylinder_radius2_height,
+            self._contact_cylinder_quats,
+        ) = _build_zone_tensors(
+            cfg.params.get("contact_sphere_zones"),
+            cfg.params.get("contact_box_zones"),
+            cfg.params.get("contact_cylinder_zones"),
+            env.device,
+        )
+
+    def __call__(
+        self,
+        env: ManagerBasedRLEnv,
+        command_name: str,
+        threshold: float = 0.03,
+        sphere_zones: list | None = None,
+        box_zones: list | None = None,
+        cylinder_zones: list | None = None,
+        contact_sphere_zones: list | None = None,
+        contact_box_zones: list | None = None,
+        contact_cylinder_zones: list | None = None,
+        asset_cfg: SceneEntityCfg = SceneEntityCfg("robot"),
+        contact_asset_cfg: SceneEntityCfg | None = None,
+        object_cfg: SceneEntityCfg = SceneEntityCfg("object"),
+        contact_object_cfg: SceneEntityCfg | None = None,
+    ) -> torch.Tensor:
+        command_term = env.command_manager.get_term(command_name)
+        success = command_term.metrics["position_error"] < threshold
+
+        if (
+            self._forbidden_sphere_centers.shape[0] > 0
+            or self._forbidden_box_centers.shape[0] > 0
+            or self._forbidden_cylinder_centers.shape[0] > 0
+        ):
+            violated = _eval_zone_violation(
+                env,
+                asset_cfg,
+                object_cfg,
+                self._forbidden_sphere_centers,
+                self._forbidden_sphere_r2,
+                self._forbidden_box_centers,
+                self._forbidden_box_half,
+                self._forbidden_cylinder_centers,
+                self._forbidden_cylinder_radius2_height,
+                self._forbidden_cylinder_quats,
+            )
+            success &= ~violated
+
+        if (
+            self._contact_sphere_centers.shape[0] > 0
+            or self._contact_box_centers.shape[0] > 0
+            or self._contact_cylinder_centers.shape[0] > 0
+        ):
+            covered = _eval_zone_coverage(
+                env,
+                contact_asset_cfg or asset_cfg,
+                contact_object_cfg or object_cfg,
+                self._contact_sphere_centers,
+                self._contact_sphere_r2,
+                self._contact_box_centers,
+                self._contact_box_half,
+                self._contact_cylinder_centers,
+                self._contact_cylinder_radius2_height,
+                self._contact_cylinder_quats,
+            )
+            success &= covered
+
+        return success
+
+
+class lift_and_tilt_with_contact_zones(ManagerTermBase):
+    """Lift-and-tilt success gated by forbidden and designated contact zones."""
+
+    def __init__(self, cfg, env: ManagerBasedRLEnv):
+        super().__init__(cfg, env)
+        (
+            self._forbidden_sphere_centers,
+            self._forbidden_sphere_r2,
+            self._forbidden_box_centers,
+            self._forbidden_box_half,
+            self._forbidden_cylinder_centers,
+            self._forbidden_cylinder_radius2_height,
+            self._forbidden_cylinder_quats,
+        ) = _build_zone_tensors(
+            cfg.params.get("sphere_zones"),
+            cfg.params.get("box_zones"),
+            cfg.params.get("cylinder_zones"),
+            env.device,
+        )
+        (
+            self._contact_sphere_centers,
+            self._contact_sphere_r2,
+            self._contact_box_centers,
+            self._contact_box_half,
+            self._contact_cylinder_centers,
+            self._contact_cylinder_radius2_height,
+            self._contact_cylinder_quats,
+        ) = _build_zone_tensors(
+            cfg.params.get("contact_sphere_zones"),
+            cfg.params.get("contact_box_zones"),
+            cfg.params.get("contact_cylinder_zones"),
+            env.device,
+        )
+
+        # Optional object-local offset for the xy-distance check. When set,
+        # the xy distance is computed between
+        # ``obj.root_pos + R(obj.root_quat) * offset`` and the goal asset's
+        # root xy, which lets tasks anchor the gate at e.g. the bottle's
+        # spout instead of the bottle's mass centre.
+        offset = cfg.params.get("goal_object_local_offset")
+        if offset is None:
+            self._goal_object_local_offset = None
+        else:
+            self._goal_object_local_offset = torch.tensor(offset, device=env.device, dtype=torch.float32)
+
+    def __call__(
+        self,
+        env: ManagerBasedRLEnv,
+        min_height: float,
+        threshold_rad: float,
+        axis_local: tuple[float, float, float] = (0.0, 0.0, 1.0),
+        world_axis: tuple[float, float, float] = (0.0, 0.0, 1.0),
+        tilt_ge: bool = True,
+        sphere_zones: list | None = None,
+        box_zones: list | None = None,
+        cylinder_zones: list | None = None,
+        contact_sphere_zones: list | None = None,
+        contact_box_zones: list | None = None,
+        contact_cylinder_zones: list | None = None,
+        asset_cfg: SceneEntityCfg = SceneEntityCfg("robot"),
+        contact_asset_cfg: SceneEntityCfg | None = None,
+        object_cfg: SceneEntityCfg = SceneEntityCfg("object"),
+        contact_object_cfg: SceneEntityCfg | None = None,
+        goal_asset_cfg: SceneEntityCfg | None = None,
+        goal_xy_threshold: float | None = None,
+        goal_object_local_offset: tuple[float, float, float] | None = None,
+        plane_axis_local: tuple[float, float, float] | None = None,
+        plane_normal: tuple[float, float, float] = (0.0, 0.0, 1.0),
+        plane_angle_threshold_rad: float | None = None,
+    ) -> torch.Tensor:
+        # Lift gate (always required).
+        obj: RigidObject = env.scene[object_cfg.name]
+        lifted = object_lifted(env, asset_cfg=object_cfg, min_height=min_height)
+
+        # Primary tilt gate: angle between a local axis and a world axis.
+        primary_angle = axis_tilt_angle(obj.data.root_quat_w, axis_local=axis_local, world_axis=world_axis)
+        primary_tilt_ok = primary_angle >= threshold_rad if tilt_ge else primary_angle <= threshold_rad
+
+        # Optional secondary tilt gate: angle between a (possibly different)
+        # local axis and the ground plane (normal = ``plane_normal``). When
+        # supplied, satisfying *either* tilt criterion counts as enough tilt.
+        if plane_axis_local is not None and plane_angle_threshold_rad is not None:
+            plane_angle = axis_to_plane_angle(
+                obj.data.root_quat_w,
+                axis_local=plane_axis_local,
+                plane_normal=plane_normal,
+            )
+            plane_tilt_ok = plane_angle >= float(plane_angle_threshold_rad)
+            tilt_ok = primary_tilt_ok | plane_tilt_ok
+        else:
+            tilt_ok = primary_tilt_ok
+
+        success = lifted & tilt_ok
+        if goal_asset_cfg is not None and goal_xy_threshold is not None:
+            goal: RigidObject = env.scene[goal_asset_cfg.name]
+            if self._goal_object_local_offset is not None:
+                offset_e = self._goal_object_local_offset.unsqueeze(0).expand(env.num_envs, -1)
+                offset_w = quat_apply(obj.data.root_quat_w, offset_e)
+                zone_w = obj.data.root_pos_w + offset_w
+            else:
+                zone_w = obj.data.root_pos_w
+            dxy = zone_w[:, :2] - goal.data.root_pos_w[:, :2]
+            within_goal = dxy.pow(2).sum(dim=-1) <= float(goal_xy_threshold) ** 2
+            success &= within_goal
+
+        if (
+            self._forbidden_sphere_centers.shape[0] > 0
+            or self._forbidden_box_centers.shape[0] > 0
+            or self._forbidden_cylinder_centers.shape[0] > 0
+        ):
+            violated = _eval_zone_violation(
+                env,
+                asset_cfg,
+                object_cfg,
+                self._forbidden_sphere_centers,
+                self._forbidden_sphere_r2,
+                self._forbidden_box_centers,
+                self._forbidden_box_half,
+                self._forbidden_cylinder_centers,
+                self._forbidden_cylinder_radius2_height,
+                self._forbidden_cylinder_quats,
+            )
+            success &= ~violated
+
+        if (
+            self._contact_sphere_centers.shape[0] > 0
+            or self._contact_box_centers.shape[0] > 0
+            or self._contact_cylinder_centers.shape[0] > 0
+        ):
+            covered = _eval_zone_coverage(
+                env,
+                contact_asset_cfg or asset_cfg,
+                contact_object_cfg or object_cfg,
+                self._contact_sphere_centers,
+                self._contact_sphere_r2,
+                self._contact_box_centers,
+                self._contact_box_half,
+                self._contact_cylinder_centers,
+                self._contact_cylinder_radius2_height,
+                self._contact_cylinder_quats,
+            )
+            success &= covered
+
+        return success
+
+
+class lifted_no_forbidden_contact(ManagerTermBase):
+    """Height-based lift success gated by forbidden-zone clearance.
+
+    Fires when the object's world-frame z-coordinate exceeds ``min_height``
+    AND no body listed in ``asset_cfg.body_ids`` lies inside any forbidden
+    zone (object-local frame).
+
+    Mirrors :func:`object_lifted` for the success half so existing
+    bimanual-lift configs only need to swap the termination ``func``.
+    """
+
+    def __init__(self, cfg, env: ManagerBasedRLEnv):
+        super().__init__(cfg, env)
+        (
+            self._sphere_centers,
+            self._sphere_r2,
+            self._box_centers,
+            self._box_half,
+            self._cylinder_centers,
+            self._cylinder_radius2_height,
+            self._cylinder_quats,
+        ) = _build_zone_tensors(
+            cfg.params.get("sphere_zones"),
+            cfg.params.get("box_zones"),
+            cfg.params.get("cylinder_zones"),
+            env.device,
+        )
+
+    def __call__(
+        self,
+        env: ManagerBasedRLEnv,
+        min_height: float,
+        sphere_zones: list | None = None,
+        box_zones: list | None = None,
+        cylinder_zones: list | None = None,
+        asset_cfg: SceneEntityCfg = SceneEntityCfg("robot"),
+        object_cfg: SceneEntityCfg = SceneEntityCfg("object"),
+    ) -> torch.Tensor:
+        obj: RigidObject = env.scene[object_cfg.name]
+        lifted = root_height_delta(obj) >= min_height
+
+        if (
+            self._sphere_centers.shape[0] == 0
+            and self._box_centers.shape[0] == 0
+            and self._cylinder_centers.shape[0] == 0
+        ):
+            return lifted
+
+        violated = _eval_zone_violation(
+            env,
+            asset_cfg,
+            object_cfg,
+            self._sphere_centers,
+            self._sphere_r2,
+            self._box_centers,
+            self._box_half,
+            self._cylinder_centers,
+            self._cylinder_radius2_height,
+            self._cylinder_quats,
+        )
+        return lifted & ~violated
+
+
+def nutthread_success(
+    env: ManagerBasedRLEnv,
+    success_threshold_turns: float = 0.375,
+    center_dist_thresh: float = 0.0025,
+    thread_pitch: float = 0.002,
+    nut_cfg: SceneEntityCfg = SceneEntityCfg("nut"),
+    bolt_cfg: SceneEntityCfg = SceneEntityCfg("bolt"),
+    nut_base_height: float = 0.01,
+    bolt_head_height: float = 0.01,
+    bolt_shank_height: float = 0.025,
+    target_thread_turns: float = 1.5,
+) -> torch.Tensor:
+    """Factory-style NutThread success: centered in XY and deep enough in Z."""
+    nut: Articulation = env.scene[nut_cfg.name]
+    bolt: Articulation = env.scene[bolt_cfg.name]
+
+    nut_pos = nut.data.root_pos_w
+    nut_quat = nut.data.root_quat_w
+    bolt_pos = bolt.data.root_pos_w
+    bolt_quat = bolt.data.root_quat_w
+
+    nut_base_local = torch.zeros((env.num_envs, 3), device=env.device, dtype=nut_pos.dtype)
+    nut_base_local[:, 2] = float(nut_base_height)
+    nut_base_pos = nut_pos + quat_apply(nut_quat, nut_base_local)
+
+    target_local = torch.zeros((env.num_envs, 3), device=env.device, dtype=bolt_pos.dtype)
+    target_local[:, 2] = float(bolt_head_height + bolt_shank_height - thread_pitch * target_thread_turns)
+    target_pos = bolt_pos + quat_apply(bolt_quat, target_local)
+
+    xy_dist = torch.linalg.vector_norm(target_pos[:, 0:2] - nut_base_pos[:, 0:2], dim=1)
+    z_disp = nut_base_pos[:, 2] - target_pos[:, 2]
+    centered = xy_dist < float(center_dist_thresh)
+    close_or_below = z_disp < float(thread_pitch * success_threshold_turns)
+    success = torch.logical_and(centered, close_or_below)
+    return success
+
+
+def factory_insert_success(
+    env: ManagerBasedRLEnv,
+    held_cfg: SceneEntityCfg,
+    fixed_cfg: SceneEntityCfg,
+    held_base_local_offset: tuple[float, float, float] = (0.0, 0.0, 0.0),
+    target_local_offset: tuple[float, float, float] = (0.0, 0.0, 0.0),
+    center_dist_thresh: float = 0.0025,
+    z_threshold: float = 0.001,
+    held_base_local_offset_2: tuple[float, float, float] | None = None,
+) -> torch.Tensor:
+    """Terminate when held asset is centered and inserted below z-threshold.
+
+    Pass ``held_base_local_offset_2`` to terminate on *either* held reference
+    point (e.g. either end of a pen) being inserted.
+    """
+    return factory_insert_success_mask(
+        env=env,
+        held_cfg=held_cfg,
+        fixed_cfg=fixed_cfg,
+        held_base_local_offset=held_base_local_offset,
+        target_local_offset=target_local_offset,
+        center_dist_thresh=center_dist_thresh,
+        z_threshold=z_threshold,
+        held_base_local_offset_2=held_base_local_offset_2,
+    )
+
+
+def plug_charger_pose_success(
+    env: ManagerBasedRLEnv,
+    held_cfg: SceneEntityCfg,
+    fixed_cfg: SceneEntityCfg,
+    insertion_x_threshold: float = 0.02,
+    insertion_y_threshold: float = 0.01,
+    insertion_z_threshold: float = 0.01,
+    held_local_offset: tuple[float, float, float] = (0.0, 0.0, 0.0),
+    fixed_local_offset: tuple[float, float, float] = (0.0, 0.0, 0.0),
+) -> torch.Tensor:
+    """PlugCharger success using insertion geometry criteria in receptacle frame."""
+    return plug_charger_insertion_mask(
+        env=env,
+        held_cfg=held_cfg,
+        fixed_cfg=fixed_cfg,
+        held_local_offset=held_local_offset,
+        fixed_local_offset=fixed_local_offset,
+        insertion_x_threshold=insertion_x_threshold,
+        lateral_y_threshold=insertion_y_threshold,
+        vertical_z_threshold=insertion_z_threshold,
+    )
+
+
+def insert_peg_success(
+    env: ManagerBasedRLEnv,
+    peg_cfg: SceneEntityCfg,
+    hole_cfg: SceneEntityCfg,
+    peg_head_local_offset: tuple[float, float, float] = (0.10, 0.0, 0.0),
+    hole_center_local_offset: tuple[float, float, float] = (0.0, 0.0, 0.0),
+    hole_radius: float = 0.023,
+    insertion_x_threshold: float = 0.015,
+) -> torch.Tensor:
+    """Terminate on ManiSkill PegInsertionSide success condition."""
+    return insert_peg_success_mask(
+        env=env,
+        peg_cfg=peg_cfg,
+        hole_cfg=hole_cfg,
+        peg_head_local_offset=peg_head_local_offset,
+        hole_center_local_offset=hole_center_local_offset,
+        hole_radius=hole_radius,
+        insertion_x_threshold=insertion_x_threshold,
+    )
+
+
+def push_t_success(
+    env: ManagerBasedRLEnv,
+    object_cfg: SceneEntityCfg = SceneEntityCfg("object"),
+    goal_cfg: SceneEntityCfg = SceneEntityCfg("goal_tee"),
+    success_threshold: float = 0.90,
+    overlap_point_step: float = 0.005,
+) -> torch.Tensor:
+    """Terminate when the movable T overlaps the goal T above threshold."""
+    overlap = push_t_overlap_ratio(
+        env=env,
+        object_cfg=object_cfg,
+        goal_cfg=goal_cfg,
+        point_step=overlap_point_step,
+    )
+    return overlap >= float(success_threshold)
+
+
+def assets_axis_aligned(
+    env: ManagerBasedRLEnv,
+    source_asset_cfg: SceneEntityCfg = SceneEntityCfg("object"),
+    target_asset_cfg: SceneEntityCfg = SceneEntityCfg("target"),
+    source_axis_local: tuple[float, float, float] = (0.0, 0.0, 1.0),
+    target_axis_local: tuple[float, float, float] = (0.0, 0.0, 1.0),
+    threshold_cos: float = 0.95,
+    use_abs: bool = True,
+) -> torch.Tensor:
+    """Per-env bool: a chosen local axis of two assets aligns within a cosine threshold.
+
+    Both axes are rotated into world frame using each asset's root quaternion,
+    then compared via signed cosine similarity. ``use_abs=True`` treats the axes
+    as undirected so anti-parallel orientations also count as aligned.
+    """
+    src_axis_w = asset_axis_w(env, asset_cfg=source_asset_cfg, axis_local=source_axis_local)
+    tgt_axis_w = asset_axis_w(env, asset_cfg=target_asset_cfg, axis_local=target_axis_local)
+    cos = axis_alignment_dot(src_axis_w, tgt_axis_w)
+    if use_abs:
+        cos = torch.abs(cos)
+    return cos >= threshold_cos
+
+
+class hammer_strike_success(ManagerTermBase):
+    """Success when grasp is held, forbidden zones are clear, and target compresses.
+
+    Combines, per env:
+      - ``forbidden`` zone clearance for the hand on the source object,
+      - optional ``target_*_zones`` clearance for the hand on the target asset
+        (e.g. to forbid pressing the nail directly with a fingertip),
+      - target-articulation joint displacement past ``press_threshold_m``.
+
+    ``*_zones`` are interpreted in the source object's local frame;
+    ``target_*_zones`` are interpreted in the target asset's local frame.
+    """
+
+    def __init__(self, cfg, env: ManagerBasedRLEnv):
+        super().__init__(cfg, env)
+        (
+            self._forbidden_sphere_centers,
+            self._forbidden_sphere_r2,
+            self._forbidden_box_centers,
+            self._forbidden_box_half,
+            self._forbidden_cylinder_centers,
+            self._forbidden_cylinder_radius2_height,
+            self._forbidden_cylinder_quats,
+        ) = _build_zone_tensors(
+            cfg.params.get("sphere_zones"),
+            cfg.params.get("box_zones"),
+            cfg.params.get("cylinder_zones"),
+            env.device,
+        )
+        (
+            self._target_forbidden_sphere_centers,
+            self._target_forbidden_sphere_r2,
+            self._target_forbidden_box_centers,
+            self._target_forbidden_box_half,
+            self._target_forbidden_cylinder_centers,
+            self._target_forbidden_cylinder_radius2_height,
+            self._target_forbidden_cylinder_quats,
+        ) = _build_zone_tensors(
+            cfg.params.get("target_sphere_zones"),
+            cfg.params.get("target_box_zones"),
+            cfg.params.get("target_cylinder_zones"),
+            env.device,
+        )
+
+    def __call__(
+        self,
+        env: ManagerBasedRLEnv,
+        press_threshold_m: float,
+        sphere_zones: list | None = None,
+        box_zones: list | None = None,
+        cylinder_zones: list | None = None,
+        target_sphere_zones: list | None = None,
+        target_box_zones: list | None = None,
+        target_cylinder_zones: list | None = None,
+        asset_cfg: SceneEntityCfg = SceneEntityCfg("robot"),
+        object_cfg: SceneEntityCfg = SceneEntityCfg("object"),
+        target_asset_cfg: SceneEntityCfg = SceneEntityCfg("target"),
+        target_joint_cfg: SceneEntityCfg = SceneEntityCfg("target"),
+        press_mode: str = "displacement",
+    ) -> torch.Tensor:
+        success = torch.ones(env.num_envs, dtype=torch.bool, device=env.device)
+        if (
+            self._forbidden_sphere_centers.shape[0] > 0
+            or self._forbidden_box_centers.shape[0] > 0
+            or self._forbidden_cylinder_centers.shape[0] > 0
+        ):
+            violated = _eval_zone_violation(
+                env,
+                asset_cfg,
+                object_cfg,
+                self._forbidden_sphere_centers,
+                self._forbidden_sphere_r2,
+                self._forbidden_box_centers,
+                self._forbidden_box_half,
+                self._forbidden_cylinder_centers,
+                self._forbidden_cylinder_radius2_height,
+                self._forbidden_cylinder_quats,
+            )
+            success &= ~violated
+        if (
+            self._target_forbidden_sphere_centers.shape[0] > 0
+            or self._target_forbidden_box_centers.shape[0] > 0
+            or self._target_forbidden_cylinder_centers.shape[0] > 0
+        ):
+            target_violated = _eval_zone_violation(
+                env,
+                asset_cfg,
+                target_asset_cfg,
+                self._target_forbidden_sphere_centers,
+                self._target_forbidden_sphere_r2,
+                self._target_forbidden_box_centers,
+                self._target_forbidden_box_half,
+                self._target_forbidden_cylinder_centers,
+                self._target_forbidden_cylinder_radius2_height,
+                self._target_forbidden_cylinder_quats,
+            )
+            success &= ~target_violated
+        pressed = joint_relative_move(
+            env,
+            threshold=float(press_threshold_m),
+            asset_cfg=target_joint_cfg,
+            mode=press_mode,
+            op=">=",
+            reduce="any",
+        )
+        return success & pressed
+
+
+def _cargo_on_carrier(
+    env: ManagerBasedRLEnv,
+    cargo_cfg: SceneEntityCfg,
+    carrier_cfg: SceneEntityCfg,
+    carrier_half_extents_xy: tuple[float, float],
+    z_min: float,
+    z_max: float,
+) -> torch.Tensor:
+    """True where the cargo root sits within the carrier's top footprint (in the
+    carrier's frame) and within ``[z_min, z_max]`` above the carrier root."""
+    cargo: RigidObject = env.scene[cargo_cfg.name]
+    carrier: RigidObject = env.scene[carrier_cfg.name]
+    rel = quat_apply_inverse(carrier.data.root_quat_w, cargo.data.root_pos_w - carrier.data.root_pos_w)
+    inside_xy = (rel[:, 0].abs() <= carrier_half_extents_xy[0]) & (rel[:, 1].abs() <= carrier_half_extents_xy[1])
+    inside_z = (rel[:, 2] >= z_min) & (rel[:, 2] <= z_max)
+    return inside_xy & inside_z
+
+
+def cargo_off_carrier(
+    env: ManagerBasedRLEnv,
+    cargo_cfg: SceneEntityCfg = SceneEntityCfg("food"),
+    carrier_cfg: SceneEntityCfg = SceneEntityCfg("object"),
+    carrier_half_extents_xy: tuple[float, float] = (0.14, 0.11),
+    z_min: float = -0.03,
+    z_max: float = 0.20,
+) -> torch.Tensor:
+    """Failure: the cargo (e.g. food on a tray) has left the carrier -- slid past
+    its footprint or fallen below its surface."""
+    return ~_cargo_on_carrier(env, cargo_cfg, carrier_cfg, carrier_half_extents_xy, z_min, z_max)
+
+
+def carrier_delivered_with_cargo(
+    env: ManagerBasedRLEnv,
+    carrier_cfg: SceneEntityCfg = SceneEntityCfg("object"),
+    goal_cfg: SceneEntityCfg = SceneEntityCfg("goal_pad"),
+    cargo_cfg: SceneEntityCfg | None = SceneEntityCfg("food"),
+    xy_threshold: float = 0.05,
+    rest_z: float = 0.0,
+    rest_z_tol: float = 0.03,
+    max_tilt_rad: float = 0.174532925,
+    max_lin_speed: float = 0.05,
+    carrier_half_extents_xy: tuple[float, float] = (0.14, 0.11),
+    cargo_z_min: float = -0.03,
+    cargo_z_max: float = 0.20,
+) -> torch.Tensor:
+    """Success for retrieve-and-place tasks: the carrier (tray) rests at the goal
+    pad, level and still, with its cargo (food) still on board.
+
+    * ``xy_threshold``: carrier root within this xy distance of the goal root;
+    * ``rest_z`` / ``rest_z_tol``: carrier root height (world z) at which it rests on
+      the tabletop, with tolerance -- rules out "hovering over the pad";
+    * ``max_tilt_rad``: tilt of the carrier's local +Z from world +Z;
+    * ``max_lin_speed``: carrier root linear speed (m/s);
+    * cargo check as in :func:`cargo_off_carrier` (skipped when ``cargo_cfg`` is None).
+    """
+    carrier: RigidObject = env.scene[carrier_cfg.name]
+    goal: RigidObject = env.scene[goal_cfg.name]
+    dxy = torch.norm(carrier.data.root_pos_w[:, :2] - goal.data.root_pos_w[:, :2], dim=1)
+    at_goal = dxy <= xy_threshold
+    resting = (carrier.data.root_pos_w[:, 2] - rest_z).abs() <= rest_z_tol
+    tilt = axis_tilt_angle(carrier.data.root_quat_w, axis_local=(0.0, 0.0, 1.0), world_axis=(0.0, 0.0, 1.0))
+    level = tilt <= max_tilt_rad
+    still = torch.norm(carrier.data.root_lin_vel_w, dim=1) <= max_lin_speed
+    ok = at_goal & resting & level & still
+    if cargo_cfg is not None:
+        ok &= _cargo_on_carrier(env, cargo_cfg, carrier_cfg, carrier_half_extents_xy, cargo_z_min, cargo_z_max)
+    return ok
+
+
+class carrier_held_aloft_with_cargo(ManagerTermBase):
+    """Success for retrieve-and-hold tasks: the carrier (tray) is held *in the
+    air* over the goal pad -- inside a height band above the pad, level, slow
+    -- with its cargo (food) still on board, for ``hold_steps`` consecutive env
+    steps. The dwell is what makes it a genuine hold: slamming the tray down
+    on a table pad or swinging it through the goal band never accrues
+    ``hold_steps`` in a row.
+
+    * ``xy_threshold``: carrier root within this xy distance of the goal root;
+    * ``z_above_goal``: (min, max) carrier-root height above the goal root;
+    * ``max_tilt_rad``: tilt of the carrier's local +Z from world +Z;
+    * ``max_lin_speed``: carrier root linear speed (m/s);
+    * cargo check as in :func:`cargo_off_carrier` (skipped when ``cargo_cfg`` is None).
+
+    Per-env resets clear the dwell counter (detected from ``episode_length_buf``).
+    """
+
+    def __init__(self, cfg, env):
+        super().__init__(cfg, env)
+        self._counter: torch.Tensor | None = None
+        self._last_step: torch.Tensor | None = None
+
+    def reset(self, env_ids=None):
+        if self._counter is not None:
+            if env_ids is None:
+                self._counter.zero_()
+            else:
+                self._counter[env_ids] = 0
+
+    def __call__(
+        self,
+        env: ManagerBasedRLEnv,
+        carrier_cfg: SceneEntityCfg = SceneEntityCfg("object"),
+        goal_cfg: SceneEntityCfg = SceneEntityCfg("goal_pad"),
+        cargo_cfg: SceneEntityCfg | None = SceneEntityCfg("food"),
+        xy_threshold: float = 0.08,
+        z_above_goal: tuple[float, float] = (0.10, 0.25),
+        max_tilt_rad: float = 0.174532925,
+        max_lin_speed: float = 0.10,
+        hold_steps: int = 30,
+        carrier_half_extents_xy: tuple[float, float] = (0.14, 0.11),
+        cargo_z_min: float = -0.03,
+        cargo_z_max: float = 0.20,
+    ) -> torch.Tensor:
+        carrier: RigidObject = env.scene[carrier_cfg.name]
+        goal: RigidObject = env.scene[goal_cfg.name]
+        if self._counter is None or self._counter.shape[0] != env.num_envs:
+            self._counter = torch.zeros(env.num_envs, dtype=torch.long, device=env.device)
+            self._last_step = torch.zeros(env.num_envs, dtype=torch.long, device=env.device)
+        current = env.episode_length_buf.to(dtype=torch.long)
+        reset_rows = current < self._last_step
+        if reset_rows.any():
+            self._counter[reset_rows] = 0
+        self._last_step = current.clone()
+
+        dxy = torch.norm(carrier.data.root_pos_w[:, :2] - goal.data.root_pos_w[:, :2], dim=1)
+        dz = carrier.data.root_pos_w[:, 2] - goal.data.root_pos_w[:, 2]
+        in_band = (dz >= z_above_goal[0]) & (dz <= z_above_goal[1])
+        tilt = axis_tilt_angle(carrier.data.root_quat_w, axis_local=(0.0, 0.0, 1.0), world_axis=(0.0, 0.0, 1.0))
+        ok = (dxy <= xy_threshold) & in_band & (tilt <= max_tilt_rad)
+        ok &= torch.norm(carrier.data.root_lin_vel_w, dim=1) <= max_lin_speed
+        if cargo_cfg is not None:
+            ok &= _cargo_on_carrier(env, cargo_cfg, carrier_cfg, carrier_half_extents_xy, cargo_z_min, cargo_z_max)
+        self._counter = torch.where(ok, self._counter + 1, torch.zeros_like(self._counter))
+        return self._counter >= hold_steps
+
+
+def carrier_aloft_progress(
+    env: ManagerBasedRLEnv,
+    carrier_cfg: SceneEntityCfg = SceneEntityCfg("object"),
+    goal_cfg: SceneEntityCfg = SceneEntityCfg("goal_pad"),
+    xy_threshold: float = 0.08,
+    z_above_goal: tuple[float, float] = (0.10, 0.25),
+    max_tilt_rad: float = 0.174532925,
+) -> torch.Tensor:
+    """Per-env float in [0, 1]: instantaneous "held aloft at the goal" score
+    (xy closeness x height-band membership x levelness), for shaping / cues."""
+    carrier: RigidObject = env.scene[carrier_cfg.name]
+    goal: RigidObject = env.scene[goal_cfg.name]
+    dxy = torch.norm(carrier.data.root_pos_w[:, :2] - goal.data.root_pos_w[:, :2], dim=1)
+    xy_score = torch.clamp(1.0 - dxy / max(xy_threshold, 1e-6), 0.0, 1.0)
+    dz = carrier.data.root_pos_w[:, 2] - goal.data.root_pos_w[:, 2]
+    mid = 0.5 * (z_above_goal[0] + z_above_goal[1])
+    half = max(0.5 * (z_above_goal[1] - z_above_goal[0]), 1e-6)
+    z_score = torch.clamp(1.0 - (dz - mid).abs() / half, 0.0, 1.0)
+    tilt = axis_tilt_angle(carrier.data.root_quat_w, axis_local=(0.0, 0.0, 1.0), world_axis=(0.0, 0.0, 1.0))
+    level_score = torch.clamp(1.0 - tilt / max(max_tilt_rad, 1e-6), 0.0, 1.0)
+    return xy_score * z_score * level_score
+
+
+def articulation_closed_and_inserted(
+    env: ManagerBasedRLEnv,
+    asset_cfg: SceneEntityCfg = SceneEntityCfg("articulation"),
+    shelf_cfg: SceneEntityCfg = SceneEntityCfg("shelf"),
+    slot_center_local: tuple[float, float, float] = (0.0, 0.0, 0.15),
+    slot_half_extents: tuple[float, float, float] = (0.15, 0.045, 0.15),
+    xy_margin: float = 0.03,
+    z_margin: float = 0.05,
+    closed_threshold: float = 0.35,
+    thickness_axis_local: tuple[float, float, float] = (0.0, 0.0, 1.0),
+    slot_width_axis_local: tuple[float, float, float] = (0.0, 1.0, 0.0),
+    upright_axis_local: tuple[float, float, float] | None = None,
+    slot_up_axis_local: tuple[float, float, float] = (0.0, 0.0, 1.0),
+    slot_front_x_local: float | None = None,
+    min_insertion_depth: float = 0.0,
+    max_axis_angle_rad: float = 0.5236,
+    max_lin_speed: float = 0.05,
+) -> torch.Tensor:
+    """Success for close-and-insert tasks (e.g. a folder into a shelf slot).
+
+    All of: the articulation's joints (``asset_cfg.joint_names``) are below
+    ``closed_threshold``; its root lies inside the slot box (shelf frame,
+    ``slot_center_local`` +- ``slot_half_extents`` + margins); its
+    ``thickness_axis_local`` is aligned (either sign) with the requested shelf
+    axis ``slot_width_axis_local`` within ``max_axis_angle_rad``. When
+    ``upright_axis_local`` is provided, it must also align with
+    ``slot_up_axis_local``; this disambiguates a face-on vertical insertion from
+    other rotations sharing the same thickness direction. If
+    ``slot_front_x_local`` is provided, the root must pass the opening by at
+    least ``min_insertion_depth``. Root speed must be below ``max_lin_speed``.
+    """
+    asset: Articulation = env.scene[asset_cfg.name]
+    shelf: RigidObject = env.scene[shelf_cfg.name]
+    joint_ids = asset_cfg.joint_ids if asset_cfg.joint_ids is not None else slice(None)
+    closed = (asset.data.joint_pos[:, joint_ids].abs() <= closed_threshold).all(dim=1)
+
+    rel = quat_apply_inverse(shelf.data.root_quat_w, asset.data.root_pos_w - shelf.data.root_pos_w)
+    c = torch.tensor(slot_center_local, device=env.device, dtype=rel.dtype)
+    h = torch.tensor(slot_half_extents, device=env.device, dtype=rel.dtype)
+    margin = torch.tensor([xy_margin, xy_margin, z_margin], device=env.device, dtype=rel.dtype)
+    inside = ((rel - c).abs() <= h + margin).all(dim=1)
+    if slot_front_x_local is not None:
+        inside &= rel[:, 0] >= float(slot_front_x_local) + float(min_insertion_depth)
+
+    thick_w = quat_apply(asset.data.root_quat_w, torch.tensor(thickness_axis_local, device=env.device, dtype=rel.dtype).expand(env.num_envs, -1))
+    width_w = quat_apply(shelf.data.root_quat_w, torch.tensor(slot_width_axis_local, device=env.device, dtype=rel.dtype).expand(env.num_envs, -1))
+    cos = (thick_w * width_w).sum(dim=1).abs().clamp(max=1.0)
+    aligned = torch.acos(cos) <= max_axis_angle_rad
+    if upright_axis_local is not None:
+        upright_w = quat_apply(
+            asset.data.root_quat_w,
+            torch.tensor(upright_axis_local, device=env.device, dtype=rel.dtype).expand(env.num_envs, -1),
+        )
+        shelf_up_w = quat_apply(
+            shelf.data.root_quat_w,
+            torch.tensor(slot_up_axis_local, device=env.device, dtype=rel.dtype).expand(env.num_envs, -1),
+        )
+        upright_cos = (upright_w * shelf_up_w).sum(dim=1).abs().clamp(max=1.0)
+        aligned &= torch.acos(upright_cos) <= max_axis_angle_rad
+
+    still = torch.norm(asset.data.root_lin_vel_w, dim=1) <= max_lin_speed
+    return closed & inside & aligned & still
+
+
+class object_fit_in_cue_success(ManagerTermBase):
+    """Success for holding an object on a selected face inside a shaped cue.
+
+    A per-episode choice ``env.<buffer_name>`` (see ``mdp.sample_env_choice``)
+    selects the active entries of the per-choice lists:
+
+    * ``cue_half_extents_per_choice`` / ``object_half_extents_per_choice``: half
+      extents of the cue box and of the object in its required orientation,
+      both in the ``goal_cfg`` asset's root frame. The object's centre
+      (``object_center_local``) must stay within ``cue_half - object_half`` of
+      ``cue_center_local`` per axis -- i.e. the object fits inside the cue
+      when correctly oriented;
+    * ``down_normals_per_choice``: object-frame unit vector that must point to
+      world -z within ``upright_cos`` (the selected face is the bottom);
+    * ``horizontal_axes_per_choice``: object-frame unit vector that must align
+      (either sign) with the goal frame's +x within ``yaw_cos`` -- the cue is a
+      cuboid, so its yaw matters.
+
+    Position, yaw and tilt are gated separately so each tolerance can be
+    tuned on its own. Success fires when all gates hold, with the root slower
+    than ``max_lin_speed``, for ``hold_steps`` consecutive steps. Set
+    ``DEXVERSE_GOAL_DEBUG=1`` to print env 0's gates every 10 steps.
+    """
+
+    def __init__(self, cfg, env: ManagerBasedRLEnv):
+        super().__init__(cfg, env)
+        p = cfg.params
+        cue = torch.tensor(p["cue_half_extents_per_choice"], device=env.device, dtype=torch.float32)
+        objh = torch.tensor(p["object_half_extents_per_choice"], device=env.device, dtype=torch.float32)
+        self._slack = torch.clamp(cue - objh, min=0.0)  # (C,3)
+        self._down = torch.tensor(p["down_normals_per_choice"], device=env.device, dtype=torch.float32)  # (C,3)
+        self._horiz = torch.tensor(p["horizontal_axes_per_choice"], device=env.device, dtype=torch.float32)  # (C,3)
+        self._obj_center = torch.tensor(p["object_center_local"], device=env.device, dtype=torch.float32)
+        self._counter = torch.zeros(env.num_envs, device=env.device, dtype=torch.long)
+        self._last_step = torch.zeros(env.num_envs, device=env.device, dtype=torch.long)
+        self._debug = os.environ.get("DEXVERSE_GOAL_DEBUG", "0") not in ("", "0", "false", "False")
+        self._tick = 0
+
+    def reset(self, env_ids=None):
+        if env_ids is None:
+            self._counter.zero_()
+        else:
+            self._counter[env_ids] = 0
+        return {}
+
+    def __call__(
+        self,
+        env: ManagerBasedRLEnv,
+        cue_half_extents_per_choice: list,
+        object_half_extents_per_choice: list,
+        down_normals_per_choice: list,
+        horizontal_axes_per_choice: list,
+        object_center_local: tuple[float, float, float],
+        buffer_name: str,
+        goal_cfg: SceneEntityCfg,
+        cue_center_local: tuple[float, float, float] = (0.0, 0.0, 0.2),
+        object_cfg: SceneEntityCfg = SceneEntityCfg("object"),
+        upright_cos: float = 0.82,
+        yaw_cos: float = 0.9,
+        max_lin_speed: float = 0.15,
+        hold_steps: int = 30,
+    ) -> torch.Tensor:
+        obj: RigidObject = env.scene[object_cfg.name]
+        goal: RigidObject = env.scene[goal_cfg.name]
+        E = env.num_envs
+        current = env.episode_length_buf.to(dtype=torch.long)
+        reset_rows = current < self._last_step
+        if reset_rows.any():
+            self._counter[reset_rows] = 0
+        self._last_step = current.clone()
+        choice = getattr(env, buffer_name, None)
+        if choice is None or choice.shape[0] != E:
+            choice = torch.zeros(E, dtype=torch.long, device=env.device)
+
+        # 1) object centre within the cue's slack box (goal frame)
+        center_w = obj.data.root_pos_w + quat_apply(obj.data.root_quat_w, self._obj_center.unsqueeze(0).expand(E, -1))
+        center_g = quat_apply_inverse(goal.data.root_quat_w, center_w - goal.data.root_pos_w)
+        cue_c = torch.tensor(cue_center_local, device=env.device, dtype=center_g.dtype)
+        fits = ((center_g - cue_c).abs() <= self._slack[choice]).all(dim=1)
+
+        # 2) selected face points down; 3) horizontal axis aligns with goal +x.
+        n_w = quat_apply(obj.data.root_quat_w, self._down[choice])
+        upright = (-n_w[:, 2]) >= upright_cos
+        ax_w = quat_apply(obj.data.root_quat_w, self._horiz[choice])
+        gx_w = quat_apply(goal.data.root_quat_w, torch.tensor([[1.0, 0.0, 0.0]], device=env.device).expand(E, -1))
+        ax_h = ax_w.clone(); ax_h[:, 2] = 0.0
+        yaw_ok = (ax_h * gx_w).sum(dim=1).abs() / torch.clamp(torch.norm(ax_h, dim=1), min=1e-6) >= yaw_cos
+
+        still = torch.norm(obj.data.root_lin_vel_w, dim=1) <= max_lin_speed
+        ok = fits & upright & yaw_ok & still
+        self._counter = torch.where(ok, self._counter + 1, torch.zeros_like(self._counter))
+        if self._debug:
+            self._tick += 1
+            if self._tick % 10 == 0:
+                d = (center_g - cue_c)[0]
+                print(
+                    f"[goal_hold] fits={bool(fits[0])} "
+                    f"(d={[round(v, 3) for v in d.tolist()]} slack={[round(v, 3) for v in self._slack[choice[0]].tolist()]}) "
+                    f"upright={bool(upright[0])}(cos={float(-n_w[0, 2]):.2f}) yaw_ok={bool(yaw_ok[0])} "
+                    f"still={bool(still[0])}(v={float(torch.norm(obj.data.root_lin_vel_w[0])):.3f}) count={int(self._counter[0])}/{hold_steps}"
+                )
+        return self._counter >= hold_steps
+
+
+class forbidden_faces_goal_hold_success(ManagerTermBase):
+    """Success for "hold it by the allowed face inside the goal box" tasks.
+
+    A per-episode choice ``env.<buffer_name>`` (see ``mdp.sample_env_choice``)
+    selects which entry of ``forbidden_zones_per_choice`` is active: a list of
+    boxes ``(center(3), half_extents(3))`` in the object's root frame (e.g. the
+    five non-graspable faces of a carton, shrunk next to the graspable face so
+    fingers may wrap its edges). Success fires when, for ``hold_steps``
+    consecutive steps, all hold at once:
+
+    * at most ``max_bodies_on_forbidden`` robot bodies (``forbidden_asset_cfg``'s
+      ``body_names``, or every robot body) lie inside any active forbidden box;
+    * the object root lies inside the goal box ``goal_box_center_local`` +-
+      ``goal_box_half_extents`` expressed in the ``goal_cfg`` asset's root frame;
+    * the object root moves slower than ``max_lin_speed``.
+
+    Per-env resets clear the dwell (``reset`` hook + ``episode_length_buf``).
+    """
+
+    def __init__(self, cfg, env: ManagerBasedRLEnv):
+        super().__init__(cfg, env)
+        p = cfg.params
+        robot = env.scene[p.get("robot_cfg", SceneEntityCfg("robot")).name]
+        fcfg = p.get("forbidden_asset_cfg")
+        if fcfg is not None and fcfg.body_names is not None:
+            self._body_ids = robot.find_bodies(list(fcfg.body_names), preserve_order=True)[0]
+        else:
+            self._body_ids = list(range(robot.num_bodies))
+        zones = p["forbidden_zones_per_choice"]  # (C choices) x (K boxes) x (center, half)
+        K = max(len(z) for z in zones)
+        C = len(zones)
+        fc = torch.zeros((C, K, 3), device=env.device)
+        fh = torch.full((C, K, 3), -1.0, device=env.device)  # negative half-extent = inert box
+        for ci, boxes in enumerate(zones):
+            for ki, (c, h) in enumerate(boxes):
+                fc[ci, ki] = torch.tensor(c, device=env.device)
+                fh[ci, ki] = torch.tensor(h, device=env.device)
+        self._fc, self._fh = fc, fh
+        self._counter = torch.zeros(env.num_envs, device=env.device, dtype=torch.long)
+        self._last_step = torch.zeros(env.num_envs, device=env.device, dtype=torch.long)
+
+    def reset(self, env_ids=None):
+        if env_ids is None:
+            self._counter.zero_()
+        else:
+            self._counter[env_ids] = 0
+        return {}
+
+    def __call__(
+        self,
+        env: ManagerBasedRLEnv,
+        forbidden_zones_per_choice: list,
+        buffer_name: str,
+        goal_cfg: SceneEntityCfg,
+        goal_box_center_local: tuple[float, float, float],
+        goal_box_half_extents: tuple[float, float, float],
+        object_cfg: SceneEntityCfg = SceneEntityCfg("object"),
+        robot_cfg: SceneEntityCfg = SceneEntityCfg("robot"),
+        forbidden_asset_cfg: SceneEntityCfg | None = None,
+        max_bodies_on_forbidden: int = 0,
+        max_lin_speed: float = 0.10,
+        hold_steps: int = 30,
+    ) -> torch.Tensor:
+        obj: RigidObject = env.scene[object_cfg.name]
+        robot: Articulation = env.scene[robot_cfg.name]
+        goal: RigidObject = env.scene[goal_cfg.name]
+        E = env.num_envs
+        current = env.episode_length_buf.to(dtype=torch.long)
+        reset_rows = current < self._last_step
+        if reset_rows.any():
+            self._counter[reset_rows] = 0
+        self._last_step = current.clone()
+
+        # Robot bodies in the object frame vs the active forbidden boxes.
+        body_pos = robot.data.body_pos_w[:, self._body_ids]  # (E,B,3)
+        B = body_pos.shape[1]
+        oq = obj.data.root_quat_w.unsqueeze(1).expand(-1, B, -1).reshape(-1, 4)
+        rel = quat_apply_inverse(oq, (body_pos - obj.data.root_pos_w.unsqueeze(1)).reshape(-1, 3)).reshape(E, B, 3)
+        choice = getattr(env, buffer_name, None)
+        if choice is None or choice.shape[0] != E:
+            choice = torch.zeros(E, dtype=torch.long, device=env.device)
+        c = self._fc[choice].unsqueeze(1)  # (E,1,K,3)
+        h = self._fh[choice].unsqueeze(1)
+        inside = ((rel.unsqueeze(2) - c).abs() <= h).all(dim=3)  # (E,B,K)
+        n_bad = inside.any(dim=2).sum(dim=1)
+        clear = n_bad <= max_bodies_on_forbidden
+
+        # Object root inside the goal box (goal frame).
+        rel_g = quat_apply_inverse(goal.data.root_quat_w, obj.data.root_pos_w - goal.data.root_pos_w)
+        gc = torch.tensor(goal_box_center_local, device=env.device, dtype=rel_g.dtype)
+        gh = torch.tensor(goal_box_half_extents, device=env.device, dtype=rel_g.dtype)
+        in_goal = ((rel_g - gc).abs() <= gh).all(dim=1)
+        still = torch.norm(obj.data.root_lin_vel_w, dim=1) <= max_lin_speed
+
+        ok = clear & in_goal & still
+        self._counter = torch.where(ok, self._counter + 1, torch.zeros_like(self._counter))
+        return self._counter >= hold_steps
+
+
+class bimanual_hold_faces_success(ManagerTermBase):
+    """Success when the object is lifted and held by both hands on the two faces
+    of the per-episode required axis (``env.<buffer_name>``, 0/1/2 = x/y/z of
+    the object frame; see ``mdp.sample_env_choice``).
+
+    ``face_zones``: 6 boxes in the object frame, ordered ``[+x,-x,+y,-y,+z,-z]``,
+    each ``(center(3), half_extents(3))``. A hand "holds" a face when at least
+    ``min_bodies_per_hand`` of its bodies (``left_body_names`` / ``right_body_names``,
+    typically palm + fingertips) are inside that face's zone. Either assignment
+    (left on +, right on -, or the reverse) counts; ``min_bodies_per_hand = 0``
+    disables this requirement (only the forbidden-face gate remains). The condition must persist for
+    ``hold_steps`` consecutive steps, together with ``root_height_delta >=
+    min_height`` and root speed <= ``max_lin_speed``. With ``forbid_other_faces``
+    the four faces that are *not* the required pair act as a per-episode forbidden
+    zone (``forbidden_face_zones``, same layout; defaults to ``face_zones``): more
+    than ``max_bodies_on_forbidden`` hand bodies on them blocks success.
+    """
+
+    def __init__(self, cfg, env: ManagerBasedRLEnv):
+        super().__init__(cfg, env)
+        p = cfg.params
+        self.object_cfg: SceneEntityCfg = p.get("object_cfg", SceneEntityCfg("object"))
+        robot = env.scene[p.get("robot_cfg", SceneEntityCfg("robot")).name]
+        left = list(p.get("left_body_names") or [])
+        right = list(p.get("right_body_names") or [])
+        self._left_ids = robot.find_bodies(left, preserve_order=True)[0] if left else []
+        self._right_ids = robot.find_bodies(right, preserve_order=True)[0] if right else []
+        # bodies tested against the forbidden faces: every robot body by default
+        # (cross-embodiment: palm, finger links, wrist, arm links), or the robot
+        # config's ``forbidden_zone_body_names`` via ``forbidden_asset_cfg``
+        fcfg = p.get("forbidden_asset_cfg")
+        if fcfg is not None and fcfg.body_names is not None:
+            self._forbidden_ids = robot.find_bodies(list(fcfg.body_names), preserve_order=True)[0]
+        else:
+            self._forbidden_ids = list(range(robot.num_bodies))
+        zones = p["face_zones"]
+        self._zc = torch.tensor([z[0] for z in zones], device=env.device, dtype=torch.float32)  # (6,3)
+        self._zh = torch.tensor([z[1] for z in zones], device=env.device, dtype=torch.float32)  # (6,3)
+        fz = p.get("forbidden_face_zones") or zones
+        self._fc = torch.tensor([z[0] for z in fz], device=env.device, dtype=torch.float32)  # (6,3)
+        self._fh = torch.tensor([z[1] for z in fz], device=env.device, dtype=torch.float32)  # (6,3)
+        self._counter = torch.zeros(env.num_envs, device=env.device, dtype=torch.long)
+
+    def reset(self, env_ids=None):
+        if env_ids is None:
+            self._counter.zero_()
+        else:
+            self._counter[env_ids] = 0
+        return {}
+
+    def _bodies_in_zone(self, rel: torch.Tensor, zone_idx: torch.Tensor) -> torch.Tensor:
+        """rel: (E,B,3) body positions in the object frame; zone_idx: (E,) -> (E,) counts."""
+        c = self._zc[zone_idx].unsqueeze(1)  # (E,1,3)
+        h = self._zh[zone_idx].unsqueeze(1)
+        return ((rel - c).abs() <= h).all(dim=2).sum(dim=1)
+
+    def __call__(
+        self,
+        env: ManagerBasedRLEnv,
+        face_zones: list,
+        left_body_names: list,
+        right_body_names: list,
+        buffer_name: str = "hold_axis",
+        object_cfg: SceneEntityCfg = SceneEntityCfg("object"),
+        robot_cfg: SceneEntityCfg = SceneEntityCfg("robot"),
+        min_bodies_per_hand: int = 3,
+        min_height: float = 0.10,
+        max_lin_speed: float = 0.10,
+        hold_steps: int = 5,
+        forbidden_face_zones: list | None = None,
+        forbid_other_faces: bool = True,
+        max_bodies_on_forbidden: int = 0,
+        forbidden_asset_cfg: SceneEntityCfg | None = None,
+    ) -> torch.Tensor:
+        obj: RigidObject = env.scene[object_cfg.name]
+        robot: Articulation = env.scene[robot_cfg.name]
+        E = env.num_envs
+        axis = getattr(env, buffer_name, None)
+        if axis is None or axis.shape[0] != E:
+            axis = torch.zeros(E, device=env.device, dtype=torch.long)
+        pos_w = robot.data.body_pos_w  # (E,B,3)
+        oq = obj.data.root_quat_w
+        def to_obj(ids):
+            p = pos_w[:, ids, :]
+            q = oq.unsqueeze(1).expand(-1, p.shape[1], -1).reshape(-1, 4)
+            return quat_apply_inverse(q, (p - obj.data.root_pos_w.unsqueeze(1)).reshape(-1, 3)).reshape(E, -1, 3)
+        plus, minus = 2 * axis, 2 * axis + 1
+        if min_bodies_per_hand > 0 and len(self._left_ids) and len(self._right_ids):
+            rel_l, rel_r = to_obj(self._left_ids), to_obj(self._right_ids)
+            hold_a = (self._bodies_in_zone(rel_l, plus) >= min_bodies_per_hand) & (self._bodies_in_zone(rel_r, minus) >= min_bodies_per_hand)
+            hold_b = (self._bodies_in_zone(rel_l, minus) >= min_bodies_per_hand) & (self._bodies_in_zone(rel_r, plus) >= min_bodies_per_hand)
+            holding = hold_a | hold_b
+        else:
+            holding = torch.ones(E, dtype=torch.bool, device=env.device)
+        if forbid_other_faces:
+            # any robot body on one of the four faces that are NOT the allowed pair blocks success
+            rel_all = to_obj(self._forbidden_ids)  # (E, B, 3)
+            face_idx = torch.arange(6, device=env.device)
+            forbidden = (face_idx.unsqueeze(0) // 2) != axis.unsqueeze(1)  # (E,6)
+            c = self._fc.unsqueeze(0).unsqueeze(2)  # (1,6,1,3)
+            h = self._fh.unsqueeze(0).unsqueeze(2)
+            inside = ((rel_all.unsqueeze(1) - c).abs() <= h).all(dim=3)  # (E,6,B)
+            # bodies inside either required zone (which may wrap past the face edges)
+            # are exempt: a thumb hooked around the edge of a required face is fine
+            rc = self._zc.unsqueeze(0).unsqueeze(2)
+            rh = self._zh.unsqueeze(0).unsqueeze(2)
+            in_required = ((rel_all.unsqueeze(1) - rc).abs() <= rh).all(dim=3)  # (E,6,B)
+            in_required = (in_required & (~forbidden).unsqueeze(2)).any(dim=1)  # (E,B)
+            n_forbidden = (inside & forbidden.unsqueeze(2) & (~in_required).unsqueeze(1)).sum(dim=(1, 2))
+            holding &= n_forbidden <= max_bodies_on_forbidden
+        lifted = root_height_delta(obj) >= min_height
+        still = torch.norm(obj.data.root_lin_vel_w, dim=1) <= max_lin_speed
+        ok = holding & lifted & still
+        self._counter = torch.where(ok, self._counter + 1, torch.zeros_like(self._counter))
+        return self._counter >= hold_steps
+
+
+def hand_near_body_point(
+    env: ManagerBasedRLEnv,
+    robot_cfg: SceneEntityCfg = SceneEntityCfg("robot"),
+    target_cfg: SceneEntityCfg = SceneEntityCfg("target"),
+    local_offset: tuple[float, float, float] = (0.0, 0.0, 0.0),
+    radius: float = 0.03,
+) -> torch.Tensor:
+    """True where any of the robot bodies in ``robot_cfg`` (all bodies when
+    ``body_names`` is unset) is within ``radius`` of a point attached to a target
+    body: ``target_cfg.body_names[0]`` of ``target_cfg`` (root when unset) offset by
+    ``local_offset`` in that body's frame. Use as a failure termination for
+    "do not touch this with the hand" rules (e.g. the nail head in HammerStrike);
+    the point follows the body, so it stays valid while the target moves.
+    """
+    robot: Articulation = env.scene[robot_cfg.name]
+    target = env.scene[target_cfg.name]
+    body_ids = robot_cfg.body_ids if robot_cfg.body_ids is not None else slice(None)
+    hand_pos = robot.data.body_pos_w[:, body_ids, :]  # (E,B,3)
+    if isinstance(target, Articulation) and target_cfg.body_ids is not None and target_cfg.body_ids != slice(None):
+        tid = target_cfg.body_ids[0] if isinstance(target_cfg.body_ids, (list, tuple)) else target_cfg.body_ids
+        tpos = target.data.body_pos_w[:, tid, :]
+        tquat = target.data.body_quat_w[:, tid, :]
+    else:
+        tpos, tquat = target.data.root_pos_w, target.data.root_quat_w
+    offset = torch.tensor(local_offset, device=env.device, dtype=tpos.dtype).unsqueeze(0).expand(env.num_envs, -1)
+    point = tpos + quat_apply(tquat, offset)
+    d = torch.norm(hand_pos - point.unsqueeze(1), dim=2)  # (E,B)
+    return (d <= float(radius)).any(dim=1)
+
+
+def _point_segment_distance(p: torch.Tensor, a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
+    """Distance from each point in ``p`` (E, 3) to the segment ``a``-``b`` (each (3,))."""
+    ab = b - a
+    t = ((p - a) @ ab / (ab @ ab).clamp_min(1e-12)).clamp(0.0, 1.0)
+    closest = a + t.unsqueeze(-1) * ab
+    return torch.norm(p - closest, dim=-1)
+
+
+def body_point_near_object_segment(
+    env: ManagerBasedRLEnv,
+    object_cfg: SceneEntityCfg = SceneEntityCfg("object"),
+    target_cfg: SceneEntityCfg = SceneEntityCfg("target"),
+    target_local_offset: tuple[float, float, float] = (0.0, 0.0, 0.0),
+    segment_start: tuple[float, float, float] = (0.0, 0.0, 0.0),
+    segment_end: tuple[float, float, float] = (0.0, 0.0, 0.0),
+    radius: float = 0.03,
+) -> torch.Tensor:
+    """True where a point attached to a target body lies within ``radius`` of a
+    line segment fixed in a rigid object's local frame (a capsule test).
+
+    The point is ``target_cfg.body_names[0]`` of ``target_cfg`` (root when unset)
+    offset by ``target_local_offset`` in that body's frame; the segment runs from
+    ``segment_start`` to ``segment_end`` in the local frame of ``object_cfg`` (a
+    rigid-object root). Use as a failure termination for "this part of the tool
+    must not touch that" rules -- e.g. the hammer *handle* pressing the nail in
+    HammerStrike: a capsule around the handle's centre line catches handle
+    strikes while a proper head strike stays well outside it.
+    """
+    obj = env.scene[object_cfg.name]
+    target = env.scene[target_cfg.name]
+    if isinstance(target, Articulation) and target_cfg.body_ids is not None and target_cfg.body_ids != slice(None):
+        tid = target_cfg.body_ids[0] if isinstance(target_cfg.body_ids, (list, tuple)) else target_cfg.body_ids
+        tpos, tquat = target.data.body_pos_w[:, tid, :], target.data.body_quat_w[:, tid, :]
+    else:
+        tpos, tquat = target.data.root_pos_w, target.data.root_quat_w
+    offset = torch.tensor(target_local_offset, device=env.device, dtype=tpos.dtype).unsqueeze(0).expand(env.num_envs, -1)
+    point_w = tpos + quat_apply(tquat, offset)
+    point_obj = quat_apply_inverse(obj.data.root_quat_w, point_w - obj.data.root_pos_w)
+    a = torch.tensor(segment_start, device=env.device, dtype=tpos.dtype)
+    b = torch.tensor(segment_end, device=env.device, dtype=tpos.dtype)
+    return _point_segment_distance(point_obj, a, b) <= float(radius)

--- a/source/dexverse/dexverse/baseline_v1/mdp/utils.py
+++ b/source/dexverse/dexverse/baseline_v1/mdp/utils.py
@@ -1,0 +1,921 @@
+# Copyright (c) 2025-2026, The DexVerse Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# Copyright (c) 2022-2025, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import math
+
+import isaacsim.core.utils.prims as prim_utils
+import numpy as np
+import torch
+import trimesh
+from isaaclab.assets import Articulation, RigidObject
+from isaaclab.envs import ManagerBasedRLEnv
+from isaaclab.managers import SceneEntityCfg
+from isaaclab.sim.utils import get_all_matching_child_prims
+from isaaclab.utils.math import (
+    euler_xyz_from_quat,
+    normalize,
+    quat_apply,
+    quat_apply_inverse,
+    quat_inv,
+    quat_mul,
+    subtract_frame_transforms,
+)
+from pxr import UsdGeom
+from trimesh.sample import sample_surface
+
+# ---- module-scope caches ----
+_PRIM_SAMPLE_CACHE: dict[tuple[str, int], np.ndarray] = {}  # (prim_hash, num_points) -> (N,3) in root frame
+_FINAL_SAMPLE_CACHE: dict[str, np.ndarray] = {}  # env_hash -> (num_points,3) in root frame
+
+
+def normalize_axis(
+    axis_local: tuple[float, float, float] | list[float] | torch.Tensor,
+    *,
+    device: torch.device | str,
+    dtype: torch.dtype,
+) -> torch.Tensor:
+    """Return a normalized 3D axis tensor on the requested device/dtype."""
+    axis = torch.as_tensor(axis_local, device=device, dtype=dtype).flatten()
+    if axis.numel() != 3:
+        raise ValueError(f"Expected axis_local with 3 elements, got shape {tuple(axis.shape)}.")
+    return axis / torch.clamp(torch.linalg.norm(axis), min=1e-6)
+
+
+def axis_in_world_from_quat(
+    quat_w: torch.Tensor,
+    axis_local: tuple[float, float, float] | list[float] | torch.Tensor = (0.0, 0.0, 1.0),
+) -> torch.Tensor:
+    """Rotate a local axis by world-frame quaternion(s), returning a world-frame axis per env."""
+    axis = normalize_axis(axis_local, device=quat_w.device, dtype=quat_w.dtype)
+    axis_batch = axis.unsqueeze(0).expand(quat_w.shape[0], -1)
+    return quat_apply(quat_w, axis_batch)
+
+
+def root_quat_w(
+    env: ManagerBasedRLEnv,
+    asset_cfg: SceneEntityCfg = SceneEntityCfg("robot"),
+) -> torch.Tensor:
+    """Read root quaternion in world frame for a rigid/articulated asset."""
+    asset: Articulation | RigidObject = env.scene[asset_cfg.name]
+    return asset.data.root_quat_w
+
+
+def command_quat_w(
+    env: ManagerBasedRLEnv,
+    command_name: str,
+    robot_cfg: SceneEntityCfg = SceneEntityCfg("robot"),
+) -> torch.Tensor:
+    """Get command orientation in world frame regardless of command frame setting."""
+    command = env.command_manager.get_command(command_name)
+    command_quat = normalize(command[:, 3:7])
+    command_term = env.command_manager.get_term(command_name)
+    if getattr(command_term.cfg, "use_world_frame", False):
+        return command_quat
+    return quat_mul(root_quat_w(env, robot_cfg), command_quat)
+
+
+def command_axis_w(
+    env: ManagerBasedRLEnv,
+    command_name: str,
+    axis_local: tuple[float, float, float] | list[float] | torch.Tensor = (0.0, 0.0, 1.0),
+    robot_cfg: SceneEntityCfg = SceneEntityCfg("robot"),
+) -> torch.Tensor:
+    """Get a commanded local axis expressed in world frame."""
+    return axis_in_world_from_quat(command_quat_w(env, command_name, robot_cfg), axis_local)
+
+
+def asset_axis_w(
+    env: ManagerBasedRLEnv,
+    asset_cfg: SceneEntityCfg = SceneEntityCfg("object"),
+    axis_local: tuple[float, float, float] | list[float] | torch.Tensor = (0.0, 0.0, 1.0),
+) -> torch.Tensor:
+    """Get an asset-local axis expressed in world frame."""
+    quat_w = root_quat_w(env, asset_cfg)
+    return axis_in_world_from_quat(quat_w, axis_local)
+
+
+def world_points_from_local(
+    env: ManagerBasedRLEnv,
+    asset_cfg: SceneEntityCfg,
+    local_points: torch.Tensor,
+) -> torch.Tensor:
+    """Transform ``(N, 3)`` asset-local points to world frame, returning ``(E, N, 3)``."""
+    asset: Articulation | RigidObject = env.scene[asset_cfg.name]
+    pos_w = asset.data.root_pos_w  # (E, 3)
+    quat_w = asset.data.root_quat_w  # (E, 4)
+    E = pos_w.shape[0]
+    N = local_points.shape[0]
+    if N == 0:
+        return torch.zeros(E, 0, 3, device=pos_w.device, dtype=pos_w.dtype)
+    pts = local_points.unsqueeze(0).expand(E, -1, -1).reshape(-1, 3)
+    quat = quat_w.unsqueeze(1).expand(-1, N, -1).reshape(-1, 4)
+    rotated = quat_apply(quat, pts).reshape(E, N, 3)
+    return pos_w.unsqueeze(1) + rotated
+
+
+def axis_in_frame_from_quat(
+    axis_w: torch.Tensor,
+    frame_quat_w: torch.Tensor,
+) -> torch.Tensor:
+    """Express world-frame axis vectors in a target frame defined by quaternion(s)."""
+    return quat_apply_inverse(frame_quat_w, axis_w)
+
+
+def axis_alignment_dot(axis_a_w: torch.Tensor, axis_b_w: torch.Tensor) -> torch.Tensor:
+    """Signed cosine similarity between two world-frame axis tensors."""
+    return torch.sum(axis_a_w * axis_b_w, dim=1).clamp(-1.0, 1.0)
+
+
+def vector_projection_on_axis(vector_w: torch.Tensor, axis_w: torch.Tensor) -> torch.Tensor:
+    """Projection magnitude of vectors onto axes in world frame."""
+    return torch.sum(vector_w * axis_w, dim=1)
+
+
+def resolve_env_ids(
+    env: ManagerBasedRLEnv,
+    env_ids: torch.Tensor | slice | list[int] | tuple[int, ...] | None,
+) -> torch.Tensor:
+    """Normalize env ids to a contiguous tensor on env.device."""
+    if env_ids is None or isinstance(env_ids, slice):
+        return torch.arange(env.num_envs, device=env.device, dtype=torch.long)
+    if isinstance(env_ids, torch.Tensor):
+        return env_ids.to(device=env.device, dtype=torch.long)
+    return torch.as_tensor(env_ids, device=env.device, dtype=torch.long)
+
+
+def resolve_joint_ids(env: ManagerBasedRLEnv, asset_cfg: SceneEntityCfg):
+    """Resolve named joint selections and return explicit IDs for them.
+
+    Isaac Lab canonicalizes a selection that happens to contain every joint to
+    ``slice(None)``.  That is normally convenient, but it loses the distinction
+    between an implicit "all joints" selection and an explicit named selection.
+    In particular, a one-joint articulation makes any matching joint name turn
+    into ``slice(None)``, which cannot be passed to tensor constructors used by
+    per-joint event helpers.  Preserve implicit all-joint selections as slices,
+    while expanding named selections to concrete integer IDs.
+    """
+    if (
+        isinstance(asset_cfg.joint_ids, slice)
+        and asset_cfg.joint_ids == slice(None)
+        and asset_cfg.joint_names is not None
+    ):
+        asset_cfg.resolve(env.scene)
+    if isinstance(asset_cfg.joint_ids, slice) and asset_cfg.joint_names is not None:
+        asset: Articulation = env.scene[asset_cfg.name]
+        return list(range(asset.num_joints))[asset_cfg.joint_ids]
+    return asset_cfg.joint_ids
+
+
+def get_init_joint_pos(asset: Articulation, joint_ids) -> torch.Tensor:
+    """Initial joint positions honoring cfg.init_state.joint_pos overrides."""
+    init_joint_pos = asset.data.default_joint_pos.clone()
+    init_cfg = getattr(asset.cfg.init_state, "joint_pos", None) or {}
+    if init_cfg:
+        name_to_id = {name: idx for idx, name in enumerate(asset.joint_names)}
+        if isinstance(joint_ids, slice):
+            target_ids = None
+        else:
+            if torch.is_tensor(joint_ids):
+                target_ids = set(joint_ids.tolist())
+            else:
+                target_ids = set(joint_ids)
+        for name, value in init_cfg.items():
+            jid = name_to_id.get(name)
+            if jid is None:
+                continue
+            if target_ids is not None and jid not in target_ids:
+                continue
+            init_joint_pos[:, jid] = float(value)
+    return init_joint_pos[:, joint_ids]
+
+
+def root_height_delta(asset: Articulation | RigidObject) -> torch.Tensor:
+    """Root z-height delta relative to default root state."""
+    return asset.data.root_pos_w[:, 2] - asset.data.default_root_state[:, 2]
+
+
+def axis_tilt_angle(
+    quat_w: torch.Tensor,
+    axis_local: tuple[float, float, float] | list[float] | torch.Tensor = (0.0, 0.0, 1.0),
+    world_axis: tuple[float, float, float] | list[float] | torch.Tensor = (0.0, 0.0, 1.0),
+) -> torch.Tensor:
+    """Angle (rad) between rotated local axis and world axis for each env."""
+    axis_w = axis_in_world_from_quat(quat_w, axis_local=axis_local)
+    world_axis_t = normalize_axis(world_axis, device=quat_w.device, dtype=quat_w.dtype)
+    world_axis_w = world_axis_t.unsqueeze(0).expand_as(axis_w)
+    cos_angle = torch.sum(axis_w * world_axis_w, dim=1).clamp(-1.0, 1.0)
+    return torch.acos(cos_angle)
+
+
+def axis_to_plane_angle(
+    quat_w: torch.Tensor,
+    axis_local: tuple[float, float, float] | list[float] | torch.Tensor = (0.0, 1.0, 0.0),
+    plane_normal: tuple[float, float, float] | list[float] | torch.Tensor = (0.0, 0.0, 1.0),
+) -> torch.Tensor:
+    """Angle (rad) between the rotated local axis and the plane with normal ``plane_normal``.
+
+    Returns values in ``[0, π/2]``: ``0`` when the axis lies in the plane,
+    ``π/2`` when the axis is perpendicular to it. The sign of the dot product
+    is discarded, so the metric is symmetric about the plane (an axis tilted
+    30° above and 30° below the plane both return 30°). Useful as an
+    alternative tilt metric for "has the object's chosen axis tipped enough
+    out of the ground plane to count" success criteria, where the choice of
+    ``axis_local`` decides which physical axis you're tracking.
+    """
+    axis_w = axis_in_world_from_quat(quat_w, axis_local=axis_local)
+    n = normalize_axis(plane_normal, device=quat_w.device, dtype=quat_w.dtype)
+    n_w = n.unsqueeze(0).expand_as(axis_w)
+    sin_angle = torch.sum(axis_w * n_w, dim=1).abs().clamp(0.0, 1.0)
+    return torch.asin(sin_angle)
+
+
+def tracked_axis_rotation_step(
+    env: ManagerBasedRLEnv,
+    quat_w: torch.Tensor,
+    axis_w: torch.Tensor,
+    tracker_name: str = "default",
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Track cumulative signed rotation around an axis and return (accumulated, delta).
+
+    The tracker is idempotent within one env step: repeated calls at the same
+    ``progress_buf`` value return cached results without double-counting.
+    """
+    if quat_w.ndim != 2 or quat_w.shape[1] != 4:
+        raise ValueError(f"Expected quat_w with shape (N, 4), got {tuple(quat_w.shape)}.")
+
+    num_envs = quat_w.shape[0]
+    if axis_w.ndim == 1:
+        axis_w = axis_w.unsqueeze(0).expand(num_envs, -1)
+    if axis_w.ndim != 2 or axis_w.shape[1] != 3 or axis_w.shape[0] != num_envs:
+        raise ValueError(f"Expected axis_w with shape (N, 3), got {tuple(axis_w.shape)}.")
+    axis_w = axis_w / torch.clamp(torch.linalg.norm(axis_w, dim=1, keepdim=True), min=1e-6)
+
+    trackers = getattr(env, "_axis_rotation_trackers", None)
+    if trackers is None:
+        trackers = {}
+        setattr(env, "_axis_rotation_trackers", trackers)
+
+    tracker = trackers.get(tracker_name)
+    needs_init = (
+        tracker is None
+        or tracker["accumulated_angle"].shape[0] != num_envs
+        or tracker["accumulated_angle"].device != quat_w.device
+        or tracker["accumulated_angle"].dtype != quat_w.dtype
+    )
+    if needs_init:
+        tracker = {
+            "accumulated_angle": torch.zeros(num_envs, device=quat_w.device, dtype=quat_w.dtype),
+            "delta_angle": torch.zeros(num_envs, device=quat_w.device, dtype=quat_w.dtype),
+            "prev_quat_w": quat_w.clone(),
+            "last_progress": torch.full((num_envs,), -1, device=quat_w.device, dtype=torch.long),
+        }
+        trackers[tracker_name] = tracker
+
+    progress_buf = getattr(env, "progress_buf", None)
+    if progress_buf is None:
+        progress = torch.zeros(num_envs, device=quat_w.device, dtype=torch.long)
+    else:
+        progress = progress_buf.to(device=quat_w.device, dtype=torch.long)
+
+    new_step = progress != tracker["last_progress"]
+    if not torch.any(new_step):
+        return tracker["accumulated_angle"], tracker["delta_angle"]
+
+    tracker["delta_angle"][new_step] = 0.0
+
+    reset_mask = new_step & (progress == 0)
+    if torch.any(reset_mask):
+        tracker["accumulated_angle"][reset_mask] = 0.0
+        tracker["prev_quat_w"][reset_mask] = quat_w[reset_mask]
+
+    step_mask = new_step & (~reset_mask)
+    if torch.any(step_mask):
+        prev_quat = tracker["prev_quat_w"][step_mask]
+        curr_quat = quat_w[step_mask]
+        delta_quat = quat_mul(curr_quat, quat_inv(prev_quat))
+
+        # Enforce shortest-path quaternion before extracting angle.
+        neg_w_mask = delta_quat[:, 0] < 0.0
+        delta_quat[neg_w_mask] = -delta_quat[neg_w_mask]
+
+        vec = delta_quat[:, 1:4]
+        vec_norm = torch.linalg.norm(vec, dim=1)
+        scalar = torch.clamp(delta_quat[:, 0], min=1e-6)
+        angle = 2.0 * torch.atan2(vec_norm, scalar)
+        angle = torch.clamp(angle, 0.0, math.pi)
+
+        axis_delta = vec / torch.clamp(vec_norm.unsqueeze(1), min=1e-6)
+        sign = torch.sign(torch.sum(axis_delta * axis_w[step_mask], dim=1))
+        sign = torch.where(sign == 0.0, torch.ones_like(sign), sign)
+        signed_delta = angle * sign
+
+        tracker["delta_angle"][step_mask] = signed_delta
+        tracker["accumulated_angle"][step_mask] += signed_delta
+        tracker["prev_quat_w"][step_mask] = curr_quat
+
+    tracker["last_progress"][new_step] = progress[new_step]
+    return tracker["accumulated_angle"], tracker["delta_angle"]
+
+
+def get_or_update_joint_reference(
+    env: ManagerBasedRLEnv,
+    current_joint_pos: torch.Tensor,
+    reference_name: str = "default",
+) -> torch.Tensor:
+    """Return a per-env joint reference buffer and refresh it automatically at reset."""
+    if current_joint_pos.ndim != 2:
+        raise ValueError(f"Expected current_joint_pos with shape (N, D), got {tuple(current_joint_pos.shape)}.")
+
+    refs = getattr(env, "_joint_position_references", None)
+    if refs is None:
+        refs = {}
+        setattr(env, "_joint_position_references", refs)
+
+    ref = refs.get(reference_name)
+    needs_init = (
+        ref is None
+        or ref.shape != current_joint_pos.shape
+        or ref.device != current_joint_pos.device
+        or ref.dtype != current_joint_pos.dtype
+    )
+    if needs_init:
+        ref = current_joint_pos.clone()
+        refs[reference_name] = ref
+
+    progress_buf = getattr(env, "progress_buf", None)
+    if progress_buf is None:
+        reset_mask = torch.ones(current_joint_pos.shape[0], device=current_joint_pos.device, dtype=torch.bool)
+    else:
+        reset_mask = progress_buf.to(device=current_joint_pos.device, dtype=torch.long) == 0
+    if torch.any(reset_mask):
+        ref[reset_mask] = current_joint_pos[reset_mask]
+    return ref
+
+
+def _compute_body_components_b(
+    env: ManagerBasedRLEnv,
+    body_asset_cfg: SceneEntityCfg,
+    base_asset_cfg: SceneEntityCfg,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Per-body pose + velocity in the base asset's root frame (flattened per body).
+
+    Returns ``(body_pos_b, body_quat_b, body_lin_vel_b, body_ang_vel_b, body_pos_w_flat)``.
+    Shared by :func:`compute_body_state_b` (13/body) and
+    :func:`compute_body_pose_vel_b` (pose 7/body + vel 6/body).
+    """
+    body_asset: Articulation | RigidObject = env.scene[body_asset_cfg.name]
+    base_asset: Articulation | RigidObject = env.scene[base_asset_cfg.name]
+
+    # Articulation path: observe requested bodies.
+    if hasattr(body_asset.data, "body_pos_w"):
+        body_pos_w = body_asset.data.body_pos_w[:, body_asset_cfg.body_ids]
+        body_quat_w = body_asset.data.body_quat_w[:, body_asset_cfg.body_ids]
+        body_lin_vel_w = body_asset.data.body_lin_vel_w[:, body_asset_cfg.body_ids]
+        body_ang_vel_w = body_asset.data.body_ang_vel_w[:, body_asset_cfg.body_ids]
+    # Rigid-object path: treat root as a single "body".
+    else:
+        body_pos_w = body_asset.data.root_pos_w.unsqueeze(1)
+        body_quat_w = body_asset.data.root_quat_w.unsqueeze(1)
+        body_lin_vel_w = body_asset.data.root_lin_vel_w.unsqueeze(1)
+        body_ang_vel_w = body_asset.data.root_ang_vel_w.unsqueeze(1)
+    num_bodies = body_pos_w.shape[1]
+
+    if hasattr(base_asset.data, "root_link_pos_w"):
+        base_pos_w = base_asset.data.root_link_pos_w
+        base_quat_w = base_asset.data.root_link_quat_w
+    else:
+        base_pos_w = base_asset.data.root_pos_w
+        base_quat_w = base_asset.data.root_quat_w
+
+    root_pos_w = base_pos_w.unsqueeze(1).repeat_interleave(num_bodies, dim=1)
+    root_quat_w = base_quat_w.unsqueeze(1).repeat_interleave(num_bodies, dim=1)
+
+    body_pos_w_flat = body_pos_w.view(-1, 3)
+    body_quat_w_flat = body_quat_w.view(-1, 4)
+    body_lin_vel_w_flat = body_lin_vel_w.view(-1, 3)
+    body_ang_vel_w_flat = body_ang_vel_w.view(-1, 3)
+    root_pos_w_flat = root_pos_w.view(-1, 3)
+    root_quat_w_flat = root_quat_w.view(-1, 4)
+
+    body_pos_b, body_quat_b = subtract_frame_transforms(
+        root_pos_w_flat, root_quat_w_flat, body_pos_w_flat, body_quat_w_flat
+    )
+    body_lin_vel_b = quat_apply_inverse(root_quat_w_flat, body_lin_vel_w_flat)
+    body_ang_vel_b = quat_apply_inverse(root_quat_w_flat, body_ang_vel_w_flat)
+    return body_pos_b, body_quat_b, body_lin_vel_b, body_ang_vel_b, body_pos_w_flat
+
+
+def compute_body_state_b(
+    env: ManagerBasedRLEnv,
+    body_asset_cfg: SceneEntityCfg,
+    base_asset_cfg: SceneEntityCfg,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Compute body states in base frame and return flattened world positions for optional visualization.
+
+    Per-body layout is ``[pos(3), quat(4), linvel(3), angvel(3)]`` (13), concatenated over bodies.
+    """
+    body_pos_b, body_quat_b, body_lin_vel_b, body_ang_vel_b, body_pos_w_flat = _compute_body_components_b(
+        env, body_asset_cfg=body_asset_cfg, base_asset_cfg=base_asset_cfg
+    )
+    out = torch.cat((body_pos_b, body_quat_b, body_lin_vel_b, body_ang_vel_b), dim=1).view(env.num_envs, -1)
+    return out, body_pos_w_flat
+
+
+def compute_body_pose_vel_b(
+    env: ManagerBasedRLEnv,
+    body_asset_cfg: SceneEntityCfg,
+    base_asset_cfg: SceneEntityCfg,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Split body state into pose and velocity in the base asset's root frame.
+
+    Returns ``(pose_b, vel_b, body_pos_w_flat)``. Per-body layout is
+    ``pose_b = [pos(3), quat(4)]`` (7) and ``vel_b = [linvel(3), angvel(3)]`` (6),
+    each concatenated over bodies. Lets observations route observable pose into
+    ``state`` and sim-only velocity into ``privileged``.
+    """
+    body_pos_b, body_quat_b, body_lin_vel_b, body_ang_vel_b, body_pos_w_flat = _compute_body_components_b(
+        env, body_asset_cfg=body_asset_cfg, base_asset_cfg=base_asset_cfg
+    )
+    pose_b = torch.cat((body_pos_b, body_quat_b), dim=1).view(env.num_envs, -1)
+    vel_b = torch.cat((body_lin_vel_b, body_ang_vel_b), dim=1).view(env.num_envs, -1)
+    return pose_b, vel_b, body_pos_w_flat
+
+
+def factory_insert_success_mask(
+    env: ManagerBasedRLEnv,
+    held_cfg: SceneEntityCfg,
+    fixed_cfg: SceneEntityCfg,
+    held_base_local_offset: tuple[float, float, float] = (0.0, 0.0, 0.0),
+    target_local_offset: tuple[float, float, float] = (0.0, 0.0, 0.0),
+    center_dist_thresh: float = 0.0025,
+    z_threshold: float = 0.001,
+    held_base_local_offset_2: tuple[float, float, float] | None = None,
+) -> torch.Tensor:
+    """Factory-style success test: XY centered and sufficiently inserted in Z.
+
+    When ``held_base_local_offset_2`` is given, the held asset is tested at
+    *both* reference points (e.g. the two ends of a pen) and the result passes
+    if *either* end is centered over and inserted below the target — so the
+    object counts as inserted whichever way round it goes in.
+    """
+    held: Articulation | RigidObject = env.scene[held_cfg.name]
+    fixed: Articulation | RigidObject = env.scene[fixed_cfg.name]
+
+    held_pos = held.data.root_pos_w
+    held_quat = held.data.root_quat_w
+    fixed_pos = fixed.data.root_pos_w
+    fixed_quat = fixed.data.root_quat_w
+
+    target_offset = (
+        torch.tensor(target_local_offset, device=env.device, dtype=fixed_pos.dtype).unsqueeze(0).repeat(env.num_envs, 1)
+    )
+    target_pos = fixed_pos + quat_apply(fixed_quat, target_offset)
+
+    held_local_offsets = [held_base_local_offset]
+    if held_base_local_offset_2 is not None:
+        held_local_offsets.append(held_base_local_offset_2)
+
+    mask: torch.Tensor | None = None
+    for local_offset in held_local_offsets:
+        held_offset = (
+            torch.tensor(local_offset, device=env.device, dtype=held_pos.dtype).unsqueeze(0).repeat(env.num_envs, 1)
+        )
+        held_base_pos = held_pos + quat_apply(held_quat, held_offset)
+
+        xy_dist = torch.linalg.vector_norm(target_pos[:, 0:2] - held_base_pos[:, 0:2], dim=1)
+        z_disp = held_base_pos[:, 2] - target_pos[:, 2]
+        centered = xy_dist < float(center_dist_thresh)
+        close_or_below = z_disp < float(z_threshold)
+        end_mask = torch.logical_and(centered, close_or_below)
+        mask = end_mask if mask is None else torch.logical_or(mask, end_mask)
+
+    return mask
+
+
+def plug_charger_insertion_mask(
+    env: ManagerBasedRLEnv,
+    held_cfg: SceneEntityCfg,
+    fixed_cfg: SceneEntityCfg,
+    held_local_offset: tuple[float, float, float] = (0.0, 0.0, 0.0),
+    fixed_local_offset: tuple[float, float, float] = (0.0, 0.0, 0.0),
+    insertion_x_threshold: float = 0.02,
+    lateral_y_threshold: float = 0.01,
+    vertical_z_threshold: float = 0.01,
+) -> torch.Tensor:
+    """Insertion-like success mask in receptacle frame.
+
+    In receptacle frame:
+    - x >= insertion_x_threshold
+    - |y| <= lateral_y_threshold
+    - |z| <= vertical_z_threshold
+    """
+    held: Articulation | RigidObject = env.scene[held_cfg.name]
+    fixed: Articulation | RigidObject = env.scene[fixed_cfg.name]
+
+    held_pos = held.data.root_pos_w
+    held_quat = held.data.root_quat_w
+    fixed_pos = fixed.data.root_pos_w
+    fixed_quat = fixed.data.root_quat_w
+
+    held_offset = torch.tensor(held_local_offset, device=env.device, dtype=held_pos.dtype).unsqueeze(0)
+    fixed_offset = torch.tensor(fixed_local_offset, device=env.device, dtype=fixed_pos.dtype).unsqueeze(0)
+
+    held_point_w = held_pos + quat_apply(held_quat, held_offset.repeat(held_pos.shape[0], 1))
+    fixed_point_w = fixed_pos + quat_apply(fixed_quat, fixed_offset.repeat(fixed_pos.shape[0], 1))
+    rel_pos_w = held_point_w - fixed_point_w
+    held_pos_at_fixed = quat_apply_inverse(fixed_quat, rel_pos_w)
+
+    # Success requires the sampled charger point's x in receptacle frame to be
+    # larger than insertion_x_threshold (e.g., threshold can be negative).
+    x_flag = held_pos_at_fixed[:, 0] >= float(insertion_x_threshold)
+    y_flag = torch.abs(held_pos_at_fixed[:, 1]) <= float(lateral_y_threshold)
+    z_flag = torch.abs(held_pos_at_fixed[:, 2]) <= float(vertical_z_threshold)
+    return x_flag & y_flag & z_flag
+
+
+def insert_peg_head_in_hole_frame(
+    env: ManagerBasedRLEnv,
+    peg_cfg: SceneEntityCfg,
+    hole_cfg: SceneEntityCfg,
+    peg_head_local_offset: tuple[float, float, float] = (0.10, 0.0, 0.0),
+    hole_center_local_offset: tuple[float, float, float] = (0.0, 0.0, 0.0),
+) -> torch.Tensor:
+    """Return peg-head position expressed in hole local frame.
+
+    This mirrors ManiSkill `PegInsertionSide-v1`:
+    `peg_head_pos_at_hole = (box_hole_pose.inv() * peg_head_pose).p`
+    """
+    peg: Articulation | RigidObject = env.scene[peg_cfg.name]
+    hole: Articulation | RigidObject = env.scene[hole_cfg.name]
+
+    peg_pos = peg.data.root_pos_w
+    peg_quat = peg.data.root_quat_w
+    hole_pos = hole.data.root_pos_w
+    hole_quat = hole.data.root_quat_w
+
+    peg_head_local = torch.tensor(peg_head_local_offset, device=env.device, dtype=peg_pos.dtype).unsqueeze(0)
+    hole_center_local = torch.tensor(hole_center_local_offset, device=env.device, dtype=hole_pos.dtype).unsqueeze(0)
+
+    peg_head_pos_w = peg_pos + quat_apply(peg_quat, peg_head_local.repeat(peg_pos.shape[0], 1))
+    hole_center_pos_w = hole_pos + quat_apply(hole_quat, hole_center_local.repeat(hole_pos.shape[0], 1))
+
+    rel_pos_w = peg_head_pos_w - hole_center_pos_w
+    return quat_apply_inverse(hole_quat, rel_pos_w)
+
+
+def insert_peg_success_mask(
+    env: ManagerBasedRLEnv,
+    peg_cfg: SceneEntityCfg,
+    hole_cfg: SceneEntityCfg,
+    peg_head_local_offset: tuple[float, float, float] = (0.10, 0.0, 0.0),
+    hole_center_local_offset: tuple[float, float, float] = (0.0, 0.0, 0.0),
+    hole_radius: float = 0.023,
+    insertion_x_threshold: float = 0.015,
+) -> torch.Tensor:
+    """ManiSkill-style success mask for side peg insertion.
+
+    In hole frame:
+    - x >= -insertion_x_threshold
+    - |y| <= hole_radius
+    - |z| <= hole_radius
+    """
+    peg_head_pos_at_hole = insert_peg_head_in_hole_frame(
+        env=env,
+        peg_cfg=peg_cfg,
+        hole_cfg=hole_cfg,
+        peg_head_local_offset=peg_head_local_offset,
+        hole_center_local_offset=hole_center_local_offset,
+    )
+    x_flag = peg_head_pos_at_hole[:, 0] >= -float(insertion_x_threshold)
+    y_flag = torch.abs(peg_head_pos_at_hole[:, 1]) <= float(hole_radius)
+    z_flag = torch.abs(peg_head_pos_at_hole[:, 2]) <= float(hole_radius)
+    return x_flag & y_flag & z_flag
+
+
+def sample_object_point_cloud(num_envs: int, num_points: int, prim_path: str, device: str = "cpu") -> torch.Tensor:
+    """
+    Samples point clouds for each environment instance by collecting points
+    from all matching USD prims under `prim_path`, then downsamples to
+    exactly `num_points` per env using farthest-point sampling.
+
+    Caching is in-memory within this module:
+      - per-prim raw samples:   _PRIM_SAMPLE_CACHE[(prim_hash, num_points)]
+      - final downsampled env:  _FINAL_SAMPLE_CACHE[env_hash]
+
+    Returns:
+        torch.Tensor: Shape (num_envs, num_points, 3) on `device`.
+    """
+
+    points = torch.zeros((num_envs, num_points, 3), dtype=torch.float32, device=device)
+    xform_cache = UsdGeom.XformCache()
+
+    for i in range(num_envs):
+        # Resolve prim path
+        obj_path = prim_path.replace(".*", str(i))
+
+        # Gather prims
+        prims = get_all_matching_child_prims(
+            obj_path, predicate=lambda p: p.GetTypeName() in ("Mesh", "Cube", "Sphere", "Cylinder", "Capsule", "Cone")
+        )
+        if not prims:
+            raise KeyError(f"No valid prims under {obj_path}")
+
+        object_prim = prim_utils.get_prim_at_path(obj_path)
+        world_root = xform_cache.GetLocalToWorldTransform(object_prim)
+
+        # hash each child prim by its rel transform + geometry
+        prim_hashes = []
+        for prim in prims:
+            prim_type = prim.GetTypeName()
+            hasher = hashlib.sha256()
+
+            rel = world_root.GetInverse() * xform_cache.GetLocalToWorldTransform(prim)  # prim -> root
+            mat_np = np.array([[rel[r][c] for c in range(4)] for r in range(4)], dtype=np.float32)
+            hasher.update(mat_np.tobytes())
+
+            if prim_type == "Mesh":
+                mesh = UsdGeom.Mesh(prim)
+                verts = np.asarray(mesh.GetPointsAttr().Get(), dtype=np.float32)
+                hasher.update(verts.tobytes())
+            else:
+                if prim_type == "Cube":
+                    size = UsdGeom.Cube(prim).GetSizeAttr().Get()
+                    hasher.update(np.float32(size).tobytes())
+                elif prim_type == "Sphere":
+                    r = UsdGeom.Sphere(prim).GetRadiusAttr().Get()
+                    hasher.update(np.float32(r).tobytes())
+                elif prim_type == "Cylinder":
+                    c = UsdGeom.Cylinder(prim)
+                    hasher.update(np.float32(c.GetRadiusAttr().Get()).tobytes())
+                    hasher.update(np.float32(c.GetHeightAttr().Get()).tobytes())
+                elif prim_type == "Capsule":
+                    c = UsdGeom.Capsule(prim)
+                    hasher.update(np.float32(c.GetRadiusAttr().Get()).tobytes())
+                    hasher.update(np.float32(c.GetHeightAttr().Get()).tobytes())
+                elif prim_type == "Cone":
+                    c = UsdGeom.Cone(prim)
+                    hasher.update(np.float32(c.GetRadiusAttr().Get()).tobytes())
+                    hasher.update(np.float32(c.GetHeightAttr().Get()).tobytes())
+
+            prim_hashes.append(hasher.hexdigest())
+
+        # scale on root (default to 1 if missing)
+        attr = object_prim.GetAttribute("xformOp:scale")
+        scale_val = attr.Get() if attr else None
+        if scale_val is None:
+            base_scale = torch.ones(3, dtype=torch.float32, device=device)
+        else:
+            base_scale = torch.tensor(scale_val, dtype=torch.float32, device=device)
+
+        # env-level cache key (includes num_points)
+        env_key = "_".join(sorted(prim_hashes)) + f"_{num_points}"
+        env_hash = hashlib.sha256(env_key.encode()).hexdigest()
+
+        # load from env-level in-memory cache
+        if env_hash in _FINAL_SAMPLE_CACHE:
+            arr = _FINAL_SAMPLE_CACHE[env_hash]  # (num_points,3) in root frame
+            points[i] = torch.from_numpy(arr).to(device) * base_scale.unsqueeze(0)
+            continue
+
+        # otherwise build per-prim samples (with per-prim cache)
+        all_samples_np: list[np.ndarray] = []
+        for prim, ph in zip(prims, prim_hashes):
+            key = (ph, num_points)
+            if key in _PRIM_SAMPLE_CACHE:
+                samples = _PRIM_SAMPLE_CACHE[key]
+            else:
+                prim_type = prim.GetTypeName()
+                if prim_type == "Mesh":
+                    mesh = UsdGeom.Mesh(prim)
+                    verts = np.asarray(mesh.GetPointsAttr().Get(), dtype=np.float32)
+                    faces = _triangulate_faces(prim)
+                    mesh_tm = trimesh.Trimesh(vertices=verts, faces=faces, process=False)
+                else:
+                    mesh_tm = create_primitive_mesh(prim)
+
+                face_weights = mesh_tm.area_faces
+                samples_np, _ = sample_surface(mesh_tm, num_points * 2, face_weight=face_weights)
+
+                # FPS to num_points on chosen device
+                tensor_pts = torch.from_numpy(samples_np.astype(np.float32)).to(device)
+                prim_idxs = farthest_point_sampling(tensor_pts, num_points)
+                local_pts = tensor_pts[prim_idxs]
+
+                # prim -> root transform
+                rel = xform_cache.GetLocalToWorldTransform(prim) * world_root.GetInverse()
+                mat_np = np.array([[rel[r][c] for c in range(4)] for r in range(4)], dtype=np.float32)
+                mat_t = torch.from_numpy(mat_np).to(device)
+
+                ones = torch.ones((num_points, 1), device=device)
+                pts_h = torch.cat([local_pts, ones], dim=1)
+                root_h = pts_h @ mat_t
+                samples = root_h[:, :3].detach().cpu().numpy()
+
+                if prim_type == "Cone":
+                    samples[:, 2] -= UsdGeom.Cone(prim).GetHeightAttr().Get() / 2
+
+                _PRIM_SAMPLE_CACHE[key] = samples  # cache in root frame @ num_points
+
+            all_samples_np.append(samples)
+
+        # combine & env-level FPS (if needed)
+        if len(all_samples_np) == 1:
+            samples_final = torch.from_numpy(all_samples_np[0]).to(device)
+        else:
+            combined = torch.from_numpy(np.concatenate(all_samples_np, axis=0)).to(device)
+            idxs = farthest_point_sampling(combined, num_points)
+            samples_final = combined[idxs]
+
+        # store env-level cache in root frame (CPU)
+        _FINAL_SAMPLE_CACHE[env_hash] = samples_final.detach().cpu().numpy()
+
+        # apply root scale and write out
+        points[i] = samples_final * base_scale.unsqueeze(0)
+
+    return points
+
+
+def _triangulate_faces(prim) -> np.ndarray:
+    """Convert a USD Mesh prim into triangulated face indices (N, 3)."""
+
+    mesh = UsdGeom.Mesh(prim)
+    counts = mesh.GetFaceVertexCountsAttr().Get()
+    indices = mesh.GetFaceVertexIndicesAttr().Get()
+    faces = []
+    it = iter(indices)
+    for cnt in counts:
+        poly = [next(it) for _ in range(cnt)]
+        for k in range(1, cnt - 1):
+            faces.append([poly[0], poly[k], poly[k + 1]])
+    return np.asarray(faces, dtype=np.int64)
+
+
+def create_primitive_mesh(prim):
+    """Create a trimesh mesh from a USD primitive (Cube, Sphere, Cylinder, etc.)."""
+    import trimesh
+    from pxr import UsdGeom
+
+    prim_type = prim.GetTypeName()
+    if prim_type == "Cube":
+        size = UsdGeom.Cube(prim).GetSizeAttr().Get()
+        return trimesh.creation.box(extents=(size, size, size))
+    elif prim_type == "Sphere":
+        r = UsdGeom.Sphere(prim).GetRadiusAttr().Get()
+        return trimesh.creation.icosphere(subdivisions=3, radius=r)
+    elif prim_type == "Cylinder":
+        c = UsdGeom.Cylinder(prim)
+        return trimesh.creation.cylinder(radius=c.GetRadiusAttr().Get(), height=c.GetHeightAttr().Get())
+    elif prim_type == "Capsule":
+        c = UsdGeom.Capsule(prim)
+        return trimesh.creation.capsule(radius=c.GetRadiusAttr().Get(), height=c.GetHeightAttr().Get())
+    elif prim_type == "Cone":  # Cone
+        c = UsdGeom.Cone(prim)
+        return trimesh.creation.cone(radius=c.GetRadiusAttr().Get(), height=c.GetHeightAttr().Get())
+    else:
+        raise KeyError(f"{prim_type} is not a valid primitive mesh type")
+
+
+def farthest_point_sampling(
+    points: torch.Tensor, n_samples: int, memory_threashold=2 * 1024**3
+) -> torch.Tensor:  # 2 GiB
+    """
+    Farthest Point Sampling (FPS) for point sets.
+
+    Selects `n_samples` points such that each new point is farthest from the
+    already chosen ones. Uses a full pairwise distance matrix if memory allows,
+    otherwise falls back to an iterative version.
+
+    Args:
+        points (torch.Tensor): Input points of shape (N, D).
+        n_samples (int): Number of samples to select.
+        memory_threashold (int): Max allowed bytes for distance matrix. Default 2 GiB.
+
+    Returns:
+        torch.Tensor: Indices of sampled points (n_samples,).
+    """
+    device = points.device
+    N = points.shape[0]
+    elem_size = points.element_size()
+    bytes_needed = N * N * elem_size
+    if bytes_needed <= memory_threashold:
+        dist_mat = torch.cdist(points, points)
+        sampled_idx = torch.zeros(n_samples, dtype=torch.long, device=device)
+        min_dists = torch.full((N,), float("inf"), device=device)
+        farthest = torch.randint(0, N, (1,), device=device)
+        for j in range(n_samples):
+            sampled_idx[j] = farthest
+            min_dists = torch.minimum(min_dists, dist_mat[farthest].view(-1))
+            farthest = torch.argmax(min_dists)
+        return sampled_idx
+    logging.warning(f"FPS fallback to iterative (needed {bytes_needed} > {memory_threashold})")
+    sampled_idx = torch.zeros(n_samples, dtype=torch.long, device=device)
+    distances = torch.full((N,), float("inf"), device=device)
+    farthest = torch.randint(0, N, (1,), device=device)
+    for j in range(n_samples):
+        sampled_idx[j] = farthest
+        dist = torch.norm(points - points[farthest], dim=1)
+        distances = torch.minimum(distances, dist)
+        farthest = torch.argmax(distances)
+    return sampled_idx
+
+
+def push_t_overlap_ratio(
+    env: ManagerBasedRLEnv,
+    object_cfg: SceneEntityCfg = SceneEntityCfg("object"),
+    goal_cfg: SceneEntityCfg = SceneEntityCfg("goal_tee"),
+    point_step: float = 0.005,
+    horizontal_size: tuple[float, float] = (0.20, 0.05),
+    vertical_size: tuple[float, float] = (0.05, 0.15),
+    com_y: float = 0.0375,
+) -> torch.Tensor:
+    """Approximate PushT overlap ratio by sampling the T area in goal frame.
+
+    The ratio is the fraction of sampled points from the movable T-shape that falls
+    inside the goal T-shape after projecting both to XY plane.
+    """
+    moving_t: Articulation | RigidObject = env.scene[object_cfg.name]
+    goal_t: Articulation | RigidObject = env.scene[goal_cfg.name]
+
+    obj_pos_xy = moving_t.data.root_pos_w[:, :2]
+    goal_pos_xy = goal_t.data.root_pos_w[:, :2]
+    _, _, obj_yaw = euler_xyz_from_quat(moving_t.data.root_quat_w)
+    _, _, goal_yaw = euler_xyz_from_quat(goal_t.data.root_quat_w)
+
+    def _sample_rect_points(center_y: float, size_x: float, size_y: float) -> torch.Tensor:
+        nx = max(1, int(math.ceil(float(size_x) / float(point_step))))
+        ny = max(1, int(math.ceil(float(size_y) / float(point_step))))
+        dx = float(size_x) / float(nx)
+        dy = float(size_y) / float(ny)
+        xs = torch.linspace(
+            -0.5 * float(size_x) + 0.5 * dx,
+            0.5 * float(size_x) - 0.5 * dx,
+            nx,
+            device=obj_pos_xy.device,
+            dtype=obj_pos_xy.dtype,
+        )
+        ys = torch.linspace(
+            center_y - 0.5 * float(size_y) + 0.5 * dy,
+            center_y + 0.5 * float(size_y) - 0.5 * dy,
+            ny,
+            device=obj_pos_xy.device,
+            dtype=obj_pos_xy.dtype,
+        )
+        grid_x, grid_y = torch.meshgrid(xs, ys, indexing="xy")
+        return torch.stack([grid_x.reshape(-1), grid_y.reshape(-1)], dim=1)
+
+    h_size_x, h_size_y = float(horizontal_size[0]), float(horizontal_size[1])
+    v_size_x, v_size_y = float(vertical_size[0]), float(vertical_size[1])
+    h_center_y = -float(com_y)
+    v_center_y = h_center_y + 0.5 * h_size_y + 0.5 * v_size_y
+    horizontal_pts = _sample_rect_points(h_center_y, h_size_x, h_size_y)
+    vertical_pts = _sample_rect_points(v_center_y, v_size_x, v_size_y)
+    local_points = torch.cat([horizontal_pts, vertical_pts], dim=0)
+
+    local_x = local_points[:, 0].unsqueeze(0)
+    local_y = local_points[:, 1].unsqueeze(0)
+    cos_obj = torch.cos(obj_yaw).unsqueeze(1)
+    sin_obj = torch.sin(obj_yaw).unsqueeze(1)
+    pts_world_x = local_x * cos_obj - local_y * sin_obj + obj_pos_xy[:, 0:1]
+    pts_world_y = local_x * sin_obj + local_y * cos_obj + obj_pos_xy[:, 1:2]
+
+    delta_x = pts_world_x - goal_pos_xy[:, 0:1]
+    delta_y = pts_world_y - goal_pos_xy[:, 1:2]
+    cos_goal = torch.cos(goal_yaw).unsqueeze(1)
+    sin_goal = torch.sin(goal_yaw).unsqueeze(1)
+    pts_goal_x = delta_x * cos_goal + delta_y * sin_goal
+    pts_goal_y = -delta_x * sin_goal + delta_y * cos_goal
+
+    h_size_x, h_size_y = float(horizontal_size[0]), float(horizontal_size[1])
+    v_size_x, v_size_y = float(vertical_size[0]), float(vertical_size[1])
+    h_half_x = 0.5 * h_size_x
+    h_half_y = 0.5 * h_size_y
+    v_half_x = 0.5 * v_size_x
+    v_half_y = 0.5 * v_size_y
+    h_center_y = -float(com_y)
+    v_center_y = h_center_y + h_half_y + v_half_y
+
+    in_horizontal = (
+        (pts_goal_x >= -h_half_x)
+        & (pts_goal_x <= h_half_x)
+        & (pts_goal_y >= h_center_y - h_half_y)
+        & (pts_goal_y <= h_center_y + h_half_y)
+    )
+    in_vertical = (
+        (pts_goal_x >= -v_half_x)
+        & (pts_goal_x <= v_half_x)
+        & (pts_goal_y >= v_center_y - v_half_y)
+        & (pts_goal_y <= v_center_y + v_half_y)
+    )
+    inside_goal_t = in_horizontal | in_vertical
+    return inside_goal_t.float().mean(dim=1)

--- a/source/dexverse/dexverse/baseline_v1/object_annotations.py
+++ b/source/dexverse/dexverse/baseline_v1/object_annotations.py
@@ -1,0 +1,352 @@
+# Copyright (c) 2025-2026, The DexVerse Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# Copyright (c) 2022-2025, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Discover object USDs with sibling ``manipulation_annotations.json`` files and
+convert their ``active.place.id_0`` entries into canonical upright placements.
+
+The expected annotation layout is::
+
+    {
+      "active": {
+        "place": {
+          "id_0": {
+            "position": [x, y, z],        # supporting-contact point in object local frame
+            "rotation": [ax, ay, az],     # object-local axis that should point world +z
+            "face": "-z",                  # which local face is the supporting face (informational)
+            "dimensions": [...],
+            ...
+          }
+        }
+      }
+    }
+
+This module is intentionally a lightweight, torch-free layer so it can run at
+config-construction time before Isaac Lab is initialised.
+"""
+
+from __future__ import annotations
+
+import glob
+import json
+import math
+import os
+import random
+from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+__all__ = [
+    "ObjectPlacement",
+    "IDENTITY_QUAT",
+    "list_usd_files",
+    "load_place_annotation",
+    "load_bounding_box",
+    "placement_from_annotation",
+    "collect_object_pool",
+    "placements_for_num_envs",
+]
+
+
+_USD_EXTENSIONS = (".usd", ".usda", ".usdc", ".usdz")
+_ANNOTATION_FILENAME = "manipulation_annotations.json"
+_UNPACKED_DIRNAME = "base_rescaled_unpacked"
+_UNPACKED_ROOT_USD = "output.usdc"
+
+
+def prefer_unpacked_usd(files: Sequence[str]) -> list[str]:
+    """Drop ``base_rescaled.usdz`` entries when a patched unpacked sibling exists.
+
+    The ManiTwin pipeline unpacks ``base_rescaled.usdz`` into
+    ``base_rescaled_unpacked/output.usdc`` and applies
+    ``UsdPhysics.MeshCollisionAPI`` there. The raw ``.usdz`` archive is not
+    patched, so if both end up in the asset pool PhysX complains about
+    triangle-mesh collision on dynamic bodies. This filter keeps the unpacked
+    USD and discards the sibling archive.
+    """
+    result: list[str] = []
+    for f in files:
+        if f.lower().endswith(".usdz"):
+            sibling = os.path.join(os.path.dirname(f), _UNPACKED_DIRNAME, _UNPACKED_ROOT_USD)
+            if os.path.isfile(sibling):
+                continue
+        result.append(f)
+    return result
+
+
+IDENTITY_QUAT: tuple[float, float, float, float] = (1.0, 0.0, 0.0, 0.0)
+
+
+@dataclass(frozen=True)
+class ObjectPlacement:
+    """Canonical upright placement derived from a ``place.id_0`` entry.
+
+    Attributes
+    ----------
+    position_offset:
+        Translation from the supporting surface to the object's origin, in the
+        world-aligned "placed" frame. Concretely the object's origin sits at
+        ``(x + position_offset[0], y + position_offset[1], support_z + position_offset[2])``
+        so its annotated supporting-contact point lands on the surface.
+    quat:
+        Canonical upright quaternion in ``(w, x, y, z)`` order.
+    usd_path:
+        Absolute path to the USD this placement is associated with (convenience).
+    raw:
+        The original ``place.id_0`` dict, preserved for downstream use.
+    """
+
+    position_offset: tuple[float, float, float]
+    quat: tuple[float, float, float, float]
+    usd_path: str | None = None
+    raw: dict | None = None
+
+
+def list_usd_files(usd_parent_dir: str, object_ids: Sequence[str] | None = None) -> list[str]:
+    """Recursively list USD files under ``usd_parent_dir`` in deterministic order."""
+    files: list[str] = []
+    for ext in _USD_EXTENSIONS:
+        files.extend(glob.glob(os.path.join(usd_parent_dir, f"**/*{ext}"), recursive=True))
+    files = sorted({f for f in files if "instanceable_meshes" not in f})
+    files = prefer_unpacked_usd(files)
+    if object_ids is not None:
+        files = [f for f in files if any(oid in f for oid in object_ids)]
+    if not files:
+        raise ValueError(f"No USD assets found under {usd_parent_dir}")
+    return files
+
+
+def _find_annotation_path(usd_path: str) -> str | None:
+    """Find the nearest ``manipulation_annotations.json`` next to ``usd_path``.
+
+    Looks in the USD's directory and one level up (many assets store the JSON
+    alongside the object id folder rather than next to the concrete USD).
+    """
+    parent = Path(usd_path).resolve().parent
+    for candidate in (parent, parent.parent):
+        ann = candidate / _ANNOTATION_FILENAME
+        if ann.is_file():
+            return str(ann)
+    return None
+
+
+def _load_annotation_file(usd_path: str) -> dict | None:
+    """Load the raw annotation JSON next to ``usd_path``, or ``None``."""
+    ann_path = _find_annotation_path(usd_path)
+    if ann_path is None:
+        return None
+    try:
+        with open(ann_path) as f:
+            return json.load(f)
+    except (json.JSONDecodeError, OSError):
+        return None
+
+
+def load_place_annotation(usd_path: str) -> dict | None:
+    """Return the ``active.place.id_0`` dict for ``usd_path`` or ``None``."""
+    data = _load_annotation_file(usd_path)
+    if data is None:
+        return None
+    active = data.get("active") or {}
+    place = active.get("place") or {}
+    entry = place.get("id_0")
+    if not isinstance(entry, dict):
+        return None
+    return entry
+
+
+def load_bounding_box(usd_path: str) -> dict | None:
+    """Return the top-level ``bounding_box`` block for ``usd_path`` or ``None``.
+
+    The expected schema is the one produced by the ManiTwin annotation pipeline:
+    ``{"min_bounds": [x, y, z], "max_bounds": [x, y, z], ...}`` in the object's
+    local frame.
+    """
+    data = _load_annotation_file(usd_path)
+    if data is None:
+        return None
+    bbox = data.get("bounding_box")
+    if not isinstance(bbox, dict):
+        return None
+    return bbox
+
+
+def _quat_from_axis_angle(axis: tuple[float, float, float], angle: float) -> tuple[float, float, float, float]:
+    ax, ay, az = axis
+    n = math.sqrt(ax * ax + ay * ay + az * az)
+    if n < 1e-9:
+        return IDENTITY_QUAT
+    ax, ay, az = ax / n, ay / n, az / n
+    half = 0.5 * angle
+    s = math.sin(half)
+    return (math.cos(half), ax * s, ay * s, az * s)
+
+
+def _quat_align_vec_to_z(
+    up_local: tuple[float, float, float],
+) -> tuple[float, float, float, float]:
+    """Shortest-arc quaternion rotating ``up_local`` to world +z.
+
+    Returned quaternion is in ``(w, x, y, z)`` order.
+    """
+    ux, uy, uz = up_local
+    n = math.sqrt(ux * ux + uy * uy + uz * uz)
+    if n < 1e-9:
+        return IDENTITY_QUAT
+    ux, uy, uz = ux / n, uy / n, uz / n
+    dot = uz
+    if dot > 1.0 - 1e-6:
+        return IDENTITY_QUAT
+    if dot < -1.0 + 1e-6:
+        # up_local antiparallel to +z: pick a 180 rotation around x.
+        return (0.0, 1.0, 0.0, 0.0)
+    # axis = up_local x +z  (=> flip object so up_local points up)
+    axis = (uy, -ux, 0.0)
+    angle = math.acos(max(-1.0, min(1.0, dot)))
+    return _quat_from_axis_angle(axis, angle)
+
+
+def _apply_quat(
+    q: tuple[float, float, float, float],
+    v: tuple[float, float, float],
+) -> tuple[float, float, float]:
+    """Rotate vector ``v`` by quaternion ``q`` (w, x, y, z)."""
+    w, x, y, z = q
+    vx, vy, vz = v
+    tx = 2.0 * (y * vz - z * vy)
+    ty = 2.0 * (z * vx - x * vz)
+    tz = 2.0 * (x * vy - y * vx)
+    rx = vx + w * tx + (y * tz - z * ty)
+    ry = vy + w * ty + (z * tx - x * tz)
+    rz = vz + w * tz + (x * ty - y * tx)
+    return (rx, ry, rz)
+
+
+def _rotated_aabb_min_z(
+    quat: tuple[float, float, float, float],
+    min_bounds: tuple[float, float, float],
+    max_bounds: tuple[float, float, float],
+) -> float:
+    """Return the minimum world-z over the 8 AABB corners rotated by ``quat``."""
+    mn = min(
+        _apply_quat(quat, (x, y, z))[2]
+        for x in (min_bounds[0], max_bounds[0])
+        for y in (min_bounds[1], max_bounds[1])
+        for z in (min_bounds[2], max_bounds[2])
+    )
+    return mn
+
+
+def placement_from_annotation(
+    place: dict | None,
+    *,
+    bounding_box: dict | None = None,
+    usd_path: str | None = None,
+) -> ObjectPlacement:
+    """Build an :class:`ObjectPlacement` from a ``place.id_0`` dict.
+
+    When ``bounding_box`` is provided (the ManiTwin ``bounding_box`` block with
+    ``min_bounds``/``max_bounds`` in the object-local frame), the z-component
+    of the resulting ``position_offset`` is taken as the larger of:
+
+    - ``-rotated_pos[2]`` (the contact-point-derived lift, current behaviour); and
+    - ``-min_z_after_rotation`` of the eight rotated AABB corners.
+
+    The latter is conservative: the mesh always lies inside the AABB, so this
+    guarantees no vertex sinks below the support surface even when the
+    ``place.position`` annotation is offset from the true lowest mesh point or
+    when the upright quaternion swings a non-z face downward.
+
+    If ``place`` is ``None`` (no annotation available), returns an identity
+    placement (zero offset, identity quaternion) -- with a bbox-derived z lift
+    if ``bounding_box`` is available, so even unannotated objects clear the
+    table.
+    """
+    if place is None and bounding_box is None:
+        return ObjectPlacement(
+            position_offset=(0.0, 0.0, 0.0),
+            quat=IDENTITY_QUAT,
+            usd_path=usd_path,
+            raw=None,
+        )
+
+    if place is None:
+        pos_local: tuple[float, float, float] = (0.0, 0.0, 0.0)
+        up_local: tuple[float, float, float] = (0.0, 0.0, 1.0)
+    else:
+        pos_local = tuple(float(v) for v in place.get("position", (0.0, 0.0, 0.0)))
+        up_local = tuple(float(v) for v in place.get("rotation", (0.0, 0.0, 1.0)))
+
+    quat = _quat_align_vec_to_z(up_local)
+    rotated_pos = _apply_quat(quat, pos_local)
+
+    z_lift = -rotated_pos[2]
+    if bounding_box is not None:
+        try:
+            min_bounds = tuple(float(v) for v in bounding_box["min_bounds"])
+            max_bounds = tuple(float(v) for v in bounding_box["max_bounds"])
+        except (KeyError, TypeError, ValueError):
+            min_bounds = max_bounds = None  # type: ignore[assignment]
+        if min_bounds is not None and max_bounds is not None and len(min_bounds) == 3 and len(max_bounds) == 3:
+            bbox_lift = -_rotated_aabb_min_z(quat, min_bounds, max_bounds)
+            z_lift = max(z_lift, bbox_lift)
+
+    position_offset = (-rotated_pos[0], -rotated_pos[1], z_lift)
+
+    return ObjectPlacement(
+        position_offset=position_offset,
+        quat=quat,
+        usd_path=usd_path,
+        raw=dict(place) if place is not None else None,
+    )
+
+
+def collect_object_pool(
+    usd_parent_dir: str,
+    *,
+    object_ids: Sequence[str] | None = None,
+    shuffle: bool = True,
+    seed: int = 0,
+) -> tuple[list[str], list[ObjectPlacement]]:
+    """Discover USDs and their placements under ``usd_parent_dir``.
+
+    Returns ``(usd_paths, placements)`` aligned by index. When ``shuffle=True``
+    both lists are shuffled in lockstep using ``seed`` so the same seed gives
+    the same (env_idx -> object) mapping across runs.
+    """
+    usd_files = list_usd_files(usd_parent_dir, object_ids)
+    placements = [
+        placement_from_annotation(
+            load_place_annotation(f),
+            bounding_box=load_bounding_box(f),
+            usd_path=f,
+        )
+        for f in usd_files
+    ]
+    if shuffle:
+        rng = random.Random(seed)
+        indices = list(range(len(usd_files)))
+        rng.shuffle(indices)
+        usd_files = [usd_files[i] for i in indices]
+        placements = [placements[i] for i in indices]
+    return usd_files, placements
+
+
+def placements_for_num_envs(
+    placements: Sequence[ObjectPlacement],
+    num_envs: int,
+) -> list[ObjectPlacement]:
+    """Cycle ``placements`` round-robin so each env index has an aligned entry.
+
+    This matches Isaac Lab's ``MultiAssetSpawnerCfg(random_choice=False)`` which
+    assigns ``assets[i % N]`` to environment ``i``.
+    """
+    if not placements:
+        raise ValueError("placements must be non-empty")
+    return [placements[i % len(placements)] for i in range(num_envs)]

--- a/source/dexverse/dexverse/baseline_v1/visual_purpose.py
+++ b/source/dexverse/dexverse/baseline_v1/visual_purpose.py
@@ -1,0 +1,66 @@
+# Copyright (c) 2025-2026, The DexVerse Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Tag prims as USD ``purpose='guide'``.
+
+Cameras (the RTX render product behind ``TiledCamera``) ignore ``guide``
+prims by default, while the Kit viewport shows them. Use this to hide
+visualization-only assets (camera-body cuboids, goal markers, fingertip
+spheres, frame markers, forbidden-zone shells, …) from policy/recorded
+RGB without hiding them from the human teleoperator.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from isaaclab.markers import VisualizationMarkers
+
+
+#: Process-wide switch. When ``False``, :func:`hide_marker_from_cameras` /
+#: :func:`set_prim_purpose_guide` become no-ops, so operator cues also show up
+#: in camera RGB. Escape hatch for teleop set-ups whose XR render path does not
+#: display ``guide`` prims (``scripts/teleop_agent.py --cues_in_rgb``).
+CAMERA_HIDING_ENABLED: bool = True
+
+
+def set_camera_hiding_enabled(enabled: bool) -> None:
+    """Enable/disable camera hiding of visualization markers process-wide."""
+    global CAMERA_HIDING_ENABLED
+    CAMERA_HIDING_ENABLED = bool(enabled)
+
+
+def set_prim_purpose_guide(prim_path: str) -> None:
+    """Set ``purpose=guide`` on the prim at ``prim_path`` **and every imageable
+    descendant** (no-op if missing).
+
+    Purpose is inheritable in USD namespace, but the RTX render products behind
+    ``TiledCamera`` read the *authored* purpose of the prims they draw --
+    ``VisualizationMarkers`` are ``PointInstancer`` prims whose prototypes are
+    child Xforms/meshes, and tagging only the instancer root left the instances
+    visible in recorded RGB (verified Aug 2026: 440 marker pixels with the root
+    tag alone, 0 with descendants tagged). Authoring the tag down the subtree
+    fixes that for every marker style.
+    """
+    if not CAMERA_HIDING_ENABLED:
+        return
+    import omni.usd
+    from pxr import Usd, UsdGeom
+
+    stage = omni.usd.get_context().get_stage()
+    if stage is None:
+        return
+    root = stage.GetPrimAtPath(prim_path)
+    if not root.IsValid():
+        return
+    for prim in Usd.PrimRange(root):
+        if prim.IsA(UsdGeom.Imageable):
+            UsdGeom.Imageable(prim).CreatePurposeAttr().Set(UsdGeom.Tokens.guide)
+
+
+def hide_marker_from_cameras(marker: VisualizationMarkers) -> None:
+    """Tag a ``VisualizationMarkers`` so its instances are camera-invisible."""
+    set_prim_purpose_guide(marker.prim_path)

--- a/source/dexverse/dexverse/benchmark.py
+++ b/source/dexverse/dexverse/benchmark.py
@@ -1,0 +1,182 @@
+# Copyright (c) 2025-2026, The DexVerse Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Simulator-independent identity of the task-upgrade development suite.
+
+The original 100 v0 registrations remain unchanged. Twenty baseline families
+also have a v1 implementation, selected by an explicit Gym version suffix.
+"""
+
+V0_BENCHMARK_REVISION = "official-v0-30cc673"
+BENCHMARK_REVISION = "baseline-v1-2026-09-08"
+TASK_SOURCE_REVISION = "4f7262f"
+V0_SOURCE_REVISION = "30cc673"
+LEGACY_UPGRADE_REVISION = "task-upgrades-2026-09-04"
+DOOR_LATCH_REVISION = "door-cutaway-auto-latch-v1-2026-09-08"
+CUP_RACK_SMALL_DESTINATION_REVISION = "cup-rack-15cm-destination-v1-2026-09-09"
+DISPENSER_SMALL_CUP_REVISION = "dispenser-small-cup-v1-2026-09-09"
+PUSH_T_RODS_REVISION = "push-t-goal-rods-15cm-v1-2026-09-10"
+
+BASELINE_TASKS = (
+    "Dexverse-GraspBleach-v0",
+    "Dexverse-GraspPan-v0",
+    "Dexverse-GraspKettle-v0",
+    "Dexverse-GraspCup-v0",
+    "Dexverse-RemoveCupFromRack-v0",
+    "Dexverse-FunctionalPourCan-v0",
+    "Dexverse-FunctionalPourMug-v0",
+    "Dexverse-FunctionalHammerStrike-v0",
+    "Dexverse-OpenFaucet-v0",
+    "Dexverse-OpenDoor-v0",
+    "Dexverse-OpenLaptop-v0",
+    "Dexverse-SqueezeScissors-v0",
+    "Dexverse-SlideUtilityKnife-v0",
+    "Dexverse-OpenStapler-v0",
+    "Dexverse-OpenFlatFolder-v0",
+    "Dexverse-BimanualLiftTray-v0",
+    "Dexverse-BimanualLiftCarton-v0",
+    "Dexverse-InsertPen-v0",
+    "Dexverse-PushSmallSphereObstacleSlope-v0",
+    "Dexverse-PushT-v0",
+)
+
+BASELINE_V0_TASKS = BASELINE_TASKS
+BASELINE_V1_TASKS = tuple(task.removesuffix("-v0") + "-v1" for task in BASELINE_V0_TASKS)
+UPGRADED_TASKS = BASELINE_V1_TASKS
+BASELINE_PAIRS = dict(zip(BASELINE_V0_TASKS, BASELINE_V1_TASKS))
+
+# Descriptive names used by private/pre-versioned recordings, not Gym aliases.
+LEGACY_UPGRADE_TASKS = {
+    "Dexverse-CloseFolderInsertShelf-v0": "Dexverse-OpenFlatFolder-v1",
+    "Dexverse-CutSeamUtilityKnife-v0": "Dexverse-SlideUtilityKnife-v1",
+    "Dexverse-CutStripScissors-v0": "Dexverse-SqueezeScissors-v1",
+    "Dexverse-ReloadStapler-v0": "Dexverse-OpenStapler-v1",
+    "Dexverse-BimanualRetrieveTrayFromRack-v0": "Dexverse-BimanualLiftTray-v1",
+    "Dexverse-BimanualCartonRegrasp-v0": "Dexverse-BimanualLiftCarton-v1",
+    "Dexverse-PlaceCupUnderDispenser-v0": "Dexverse-GraspCup-v1",
+    "Dexverse-OpenTiltedDoor-v0": "Dexverse-OpenDoor-v1",
+}
+
+# Ordered with BASELINE_V1_TASKS; strings keep catalogue use simulator-free.
+_V1_IMPLEMENTATIONS = (
+    ("functional.grasp_bleach_cfg", "GraspBleachEnvFloatingDexHandRightCfg"),
+    ("functional.grasp_pan_cfg", "GraspPanEnvFloatingDexHandRightCfg"),
+    ("functional.grasp_kettle_cfg", "GraspKettleEnvFloatingDexHandRightCfg"),
+    ("functional.place_cup_under_dispenser_cfg", "PlaceCupUnderDispenserEnvFloatingDexHandRightCfg"),
+    ("functional.remove_cup_from_rack_cfg", "RemoveCupFromRackEnvFloatingDexHandRightCfg"),
+    ("functional.pour_can_cfg", "PourCanEnvFloatingDexHandRightCfg"),
+    ("functional.pour_mug_cfg", "PourMugEnvFloatingDexHandRightCfg"),
+    ("functional.hammer_strike_cfg", "HammerStrikeEnvFloatingDexHandRightCfg"),
+    ("articulation.openfaucet_cfg", "OpenFaucetEnvFloatingDexHandRightCfg"),
+    ("articulation.open_cutaway_door_cfg", "OpenCutawayDoorEnvFloatingDexHandRightCfg"),
+    ("articulation.open_laptop_cfg", "OpenLaptopEnvFloatingDexHandRightCfg"),
+    ("articulation.cut_strip_scissors_cfg", "CutStripScissorsEnvFloatingDexHandRightCfg"),
+    ("articulation.cut_seam_utility_knife_cfg", "CutSeamUtilityKnifeEnvFloatingDexHandRightCfg"),
+    ("articulation.reload_stapler_cfg", "ReloadStaplerEnvFloatingDexHandRightCfg"),
+    ("articulation.close_folder_insert_shelf_cfg", "CloseFolderInsertShelfEnvFloatingDexHandRightCfg"),
+    ("bimanual.retrieve_tray_from_rack_cfg", "RetrieveTrayFromRackEnvFloatingShadowBimanualCfg"),
+    ("bimanual.carton_regrasp_cfg", "CartonRegraspEnvFloatingShadowBimanualCfg"),
+    ("contact_rich.insertpen_cfg", "InsertPenEnvFloatingDexHandRightCfg"),
+    ("non_prehensile.push_small_sphere_obstacle_slope_cfg", "PushSmallSphereObstacleSlopeEnvFloatingDexHandRightCfg"),
+    ("non_prehensile.pusht_cfg", "PushTEnvFloatingDexHandRightCfg"),
+)
+V1_CONFIGS = dict(zip(BASELINE_V1_TASKS, _V1_IMPLEMENTATIONS))
+
+
+def baseline_tasks(version: str = "v0") -> tuple[str, ...]:
+    if version == "v0":
+        return BASELINE_V0_TASKS
+    if version == "v1":
+        return BASELINE_V1_TASKS
+    if version == "all":
+        return tuple(task for pair in BASELINE_PAIRS.items() for task in pair)
+    raise ValueError(f"Unknown baseline version: {version}")
+
+
+def task_identity(task: str) -> dict:
+    """Metadata describes the selected environment, not the checkout alone."""
+    task = task.split(":")[-1]
+    if task == "Dexverse-PushT-v1":
+        return {"task_version": 1, "benchmark_revision": PUSH_T_RODS_REVISION,
+                "task_source_revision": "local-push-t-goal-rods-15cm-v1"}
+    if task == "Dexverse-OpenDoor-v1":
+        return {"task_version": 1, "benchmark_revision": DOOR_LATCH_REVISION,
+                "task_source_revision": "local-cutaway-door-auto-latch-v1"}
+    if task == "Dexverse-RemoveCupFromRack-v1":
+        return {"task_version": 1, "benchmark_revision": CUP_RACK_SMALL_DESTINATION_REVISION,
+                "task_source_revision": "local-cup-rack-15cm-destination-v1"}
+    if task == "Dexverse-GraspCup-v1":
+        return {"task_version": 1, "benchmark_revision": DISPENSER_SMALL_CUP_REVISION,
+                "task_source_revision": "local-dispenser-small-cup-v1"}
+    if task in BASELINE_V1_TASKS:
+        return {
+            "task_version": 1,
+            "benchmark_revision": BENCHMARK_REVISION,
+            "task_source_revision": TASK_SOURCE_REVISION,
+        }
+    if task in LEGACY_UPGRADE_TASKS or not task.startswith("Dexverse-") or not task.endswith("-v0"):
+        raise ValueError(f"Unknown canonical task identity: {task}")
+    return {"task_version": 0, "benchmark_revision": V0_BENCHMARK_REVISION, "task_source_revision": V0_SOURCE_REVISION}
+
+
+def validate_replay_identity(payload: dict, target_task: str, explicit_override: bool = False) -> None:
+    """Never silently replay a known pre-versioned upgrade as official v0."""
+    if explicit_override:
+        return  # CLI override is a deliberate provenance decision, recorded separately.
+    imported = payload.get("demo_import") or {}
+    if imported.get("compatibility") == "needs_review":
+        raise ValueError(
+            f"Imported recording needs review: {imported.get('review_reasons', [])}. "
+            "Resolve the incompatibility before using --task-override explicitly."
+        )
+    source_task = payload.get("env_name") or payload.get("task")
+    revision = payload.get("benchmark_revision")
+    if source_task in LEGACY_UPGRADE_TASKS:
+        raise ValueError(
+            f"Legacy upgraded task {source_task!r} is not a v0 alias. Review provenance and use "
+            f"--task-override {LEGACY_UPGRADE_TASKS[source_task]} explicitly."
+        )
+    expected = task_identity(target_task)["benchmark_revision"]
+    if target_task == "Dexverse-PushT-v1" and revision != PUSH_T_RODS_REVISION:
+        raise ValueError(
+            "Push-T v1 now includes ten low orange rods around the goal with 15 cm minimum gaps, "
+            "a rotation-aware verified route and 70% overlap success. "
+            "Earlier obstacle-free, three-tall-rod or table-wide 38 cm-gap recordings use a different layout; "
+            "review provenance before an explicit task override."
+        )
+    if target_task == "Dexverse-GraspCup-v1" and revision != DISPENSER_SMALL_CUP_REVISION:
+        raise ValueError(
+            "Dispenser v1 now uses a 10% smaller cup (scale 0.81) with matching spawn heights, "
+            "rim zone and release geometry. Earlier recordings use the larger cup; "
+            "review provenance before an explicit task override."
+        )
+    if target_task == "Dexverse-RemoveCupFromRack-v1" and revision != CUP_RACK_SMALL_DESTINATION_REVISION:
+        raise ValueError(
+            "Cup-from-rack v1 now uses a 10% smaller cup and a 15 x 15 cm raised destination table. "
+            "Earlier recordings use a larger cup, a main-table goal, or a larger destination table; "
+            "review provenance before an explicit task override."
+        )
+    if target_task == "Dexverse-OpenDoor-v1" and revision != DOOR_LATCH_REVISION:
+        raise ValueError(
+            "Door v1 now uses the narrow cutaway and automatic spring latch. Review provenance; "
+            "tilted-door and previous manual-catch recordings are incompatible."
+        )
+    if source_task in LEGACY_UPGRADE_TASKS or (revision is not None and revision != expected):
+        suggestion = LEGACY_UPGRADE_TASKS.get(source_task, BASELINE_PAIRS.get(source_task))
+        raise ValueError(
+            f"Recording identity {source_task!r} / {revision!r} does not match {target_task!r}. "
+            f"Review provenance and use --task-override explicitly (candidate: {suggestion})."
+        )
+
+
+def action_layout(env) -> dict:
+    """Describe action terms and joint order without importing the simulator."""
+    manager = env.action_manager
+    terms = []
+    for name in manager.active_terms:
+        term = manager.get_term(name)
+        terms.append({"name": name, "dimension": int(term.action_dim)})
+    robot = env.scene["robot"]
+    return {"dimension": int(manager.total_action_dim), "terms": terms, "robot_joint_names": list(robot.joint_names)}

--- a/source/dexverse/dexverse/devices/retargeters/simple_relative_retargeting.py
+++ b/source/dexverse/dexverse/devices/retargeters/simple_relative_retargeting.py
@@ -98,6 +98,12 @@ class SimpleRelativeRetargeter(RetargeterBase):
     def __init__(self, cfg: SimpleRelativeRetargeterCfg):
         super().__init__(cfg)
         self.cfg = cfg
+        self._debug_visualization_enabled = cfg.task_version != 1 or cfg.debug_vis
+        # Preserve original marker semantics for v0 while honoring v1's cue switch.
+        if cfg.task_version == 1:
+            from dexverse.baseline_v1.visual_purpose import hide_marker_from_cameras as hide_task_marker
+        else:
+            hide_task_marker = hide_marker_from_cameras
         self._layout = self._get_action_layout(cfg.robot_type)
         self._tracked_hands = tuple(self._layout["hands"].keys())
         self._bound_hand = cfg.bound_hand
@@ -115,6 +121,11 @@ class SimpleRelativeRetargeter(RetargeterBase):
 
         self.latest_wrist_poses = {hand: None for hand in self._tracked_hands}
         self.retarget_base_wrist_poses = {hand: _default_wrist_pose() for hand in self._tracked_hands}
+        # Continuous Euler history for joint-controlled floating wrists. This
+        # prevents the principal-angle +pi -> -pi branch change from becoming
+        # a full-revolution absolute joint command before configured limits are
+        # applied.
+        self._previous_wrist_euler_commands = {hand: None for hand in self._tracked_hands}
         self._dex_retgt = {}
         self._dex_output_joint_names = {}
         self._dex_to_action_finger_indices = {}
@@ -134,8 +145,8 @@ class SimpleRelativeRetargeter(RetargeterBase):
             },
         )
         self._markers = VisualizationMarkers(point_marker_cfg)
-        hide_marker_from_cameras(self._markers)
-        self._markers.set_visibility(True)
+        hide_task_marker(self._markers)
+        self._markers.set_visibility(self._debug_visualization_enabled)
 
         canonical_point_marker_cfg = VisualizationMarkersCfg(
             prim_path="/Visuals/simple_relative_canonical_hand_keypoints",
@@ -147,16 +158,16 @@ class SimpleRelativeRetargeter(RetargeterBase):
             },
         )
         self._canonical_markers = VisualizationMarkers(canonical_point_marker_cfg)
-        hide_marker_from_cameras(self._canonical_markers)
-        self._canonical_markers.set_visibility(True)
+        hide_task_marker(self._canonical_markers)
+        self._canonical_markers.set_visibility(self._debug_visualization_enabled)
 
         wrist_frame_cfg = FRAME_MARKER_CFG.copy()
         wrist_frame_cfg.markers["frame"].scale = (0.1, 0.1, 0.1)
         self._wrist_markers = VisualizationMarkers(
             wrist_frame_cfg.replace(prim_path="/Visuals/simple_relative_wrist_frames")
         )
-        hide_marker_from_cameras(self._wrist_markers)
-        self._wrist_markers.set_visibility(True)
+        hide_task_marker(self._wrist_markers)
+        self._wrist_markers.set_visibility(self._debug_visualization_enabled)
 
         if cfg.initialize_dex_retargeting:
             self._initialize_dex_retargeters()
@@ -198,6 +209,7 @@ class SimpleRelativeRetargeter(RetargeterBase):
                 missing_hands.append(hand.name)
                 continue
             self.retarget_base_wrist_poses[hand] = wrist_pose.copy()
+            self._previous_wrist_euler_commands[hand] = None
             calibrated_hands.append(hand.name)
 
         if not calibrated_hands:
@@ -224,6 +236,10 @@ class SimpleRelativeRetargeter(RetargeterBase):
         module_name, attr_name = SIMPLE_RETARGETER_LAYOUT_SOURCES[robot_type]
         module = import_module(module_name)
         raw_layout = getattr(module, attr_name)
+        if self.cfg.task_version == 1 and module_name == "dexverse.robot_agents.shadow.floating":
+            from dexverse.baseline_v1.control_profile import action_layout
+
+            raw_layout = action_layout(raw_layout)
 
         hands = {}
         for hand_name, hand_layout in raw_layout["hands"].items():
@@ -309,6 +325,10 @@ class SimpleRelativeRetargeter(RetargeterBase):
         if "retargeting" not in config:
             raise ValueError(f"Invalid dex-retargeting config '{config_path}': missing 'retargeting' section.")
 
+        if self.cfg.task_version == 1 and self._get_robot_module().__name__ == "dexverse.robot_agents.shadow.floating":
+            from dexverse.baseline_v1.control_profile import retargeting_config
+
+            config = retargeting_config(config, getattr(self.cfg, "retargeting_scheme", "dexpilot"))
         config["retargeting"]["urdf_path"] = urdf_path
 
         with tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False) as temp_file:
@@ -458,8 +478,41 @@ class SimpleRelativeRetargeter(RetargeterBase):
             raise ValueError(f"Unsupported wrist_rot_repr '{rot_repr}'. Use 'euler', 'rotvec', or 'quat_absolute'.")
         rot_signs = np.asarray(hand_layout.get("wrist_rot_signs", (1.0, 1.0, 1.0)), dtype=np.float32)
         relative_rot_cmd = relative_rot_cmd * rot_signs
+        if rot_repr == "euler" and self.cfg.task_version == 1:
+            relative_rot_cmd = self._unwrap_and_clip_wrist_euler(relative_rot_cmd, hand, hand_layout)
         self._assign(action, hand_layout["wrist_trans_indices"], wrist_abs_pos_cmd)
         self._assign(action, hand_layout["wrist_rot_indices"], relative_rot_cmd)
+
+    def _unwrap_and_clip_wrist_euler(
+        self,
+        command: np.ndarray,
+        hand: DeviceBase.TrackingTarget,
+        hand_layout: dict[str, Any],
+    ) -> np.ndarray:
+        """Choose the continuous Euler branch, then apply optional joint limits.
+
+        ``Rotation.as_euler`` returns principal angles, so a smooth physical
+        motion can jump numerically from +pi to -pi. Absolute joint controllers
+        interpret that as a nearly full-revolution target change. Unwrapping
+        first makes clipping stable at a limit instead of alternating between
+        the positive and negative limits.
+        """
+        current = np.asarray(command, dtype=np.float32).reshape(-1)
+        previous = self._previous_wrist_euler_commands.get(hand)
+        if isinstance(previous, np.ndarray) and previous.shape == current.shape:
+            delta = (current - previous + np.pi) % (2.0 * np.pi) - np.pi
+            current = previous + delta
+        self._previous_wrist_euler_commands[hand] = current.copy()
+
+        limits = hand_layout.get("wrist_euler_limits")
+        if limits is None:
+            return current
+        limits_array = np.asarray(limits, dtype=np.float32)
+        if limits_array.shape != (current.size, 2):
+            raise ValueError(
+                f"wrist_euler_limits must have shape ({current.size}, 2), got {limits_array.shape}."
+            )
+        return np.clip(current, limits_array[:, 0], limits_array[:, 1]).astype(np.float32, copy=False)
 
     def _assign_absolute_wrist_command(
         self,
@@ -671,6 +724,8 @@ class SimpleRelativeRetargeter(RetargeterBase):
 
     def _visualize_hand_keypoints(self, hand_data_by_target: dict[DeviceBase.TrackingTarget, Any]) -> None:
         """Visualize the current hand keypoints as small spheres."""
+        if not self._debug_visualization_enabled:
+            return
         joint_positions = []
         for hand_data in hand_data_by_target.values():
             if not isinstance(hand_data, dict):
@@ -690,6 +745,8 @@ class SimpleRelativeRetargeter(RetargeterBase):
         hand_data_by_target: dict[DeviceBase.TrackingTarget, Any],
     ) -> None:
         """Visualize canonicalized hand joints, translated back to the wrist position."""
+        if not self._debug_visualization_enabled:
+            return
         canonical_joint_positions_world = []
         for hand, hand_data in hand_data_by_target.items():
             if not isinstance(hand_data, dict):
@@ -712,6 +769,8 @@ class SimpleRelativeRetargeter(RetargeterBase):
 
     def _visualize_wrist_poses(self) -> None:
         """Visualize tracked wrist poses as frame markers."""
+        if not self._debug_visualization_enabled:
+            return
         wrist_positions = []
         wrist_orientations = []
         for hand in self._tracked_hands:
@@ -774,4 +833,8 @@ class SimpleRelativeRetargeterCfg(RetargeterCfg):
     default_command: tuple[float, ...] = field(default_factory=tuple)
     finger_scales: dict[str, float] = field(default_factory=dict)
     retargeting_scheme: str = "dexpilot"
+    task_version: int = 0
+    """Use v1 wrist continuity/vector settings only for explicitly upgraded tasks."""
+    debug_vis: bool = True
+    """v1 follows the task debug switch; v0 ignores this field to preserve its visuals."""
     retargeter_type: type[RetargeterBase] = SimpleRelativeRetargeter

--- a/source/dexverse/dexverse/tasks/__init__.py
+++ b/source/dexverse/dexverse/tasks/__init__.py
@@ -21,3 +21,7 @@ from isaaclab_tasks.utils import import_packages
 _BLACKLIST_PKGS = ["utils", ".mdp", "_archive"]
 # Import all configs in this package
 import_packages(__name__, _BLACKLIST_PKGS)
+
+# Keep the established task-discovery entry point registering both versions.
+# Only baseline upgrades live in this sibling package; original tasks stay here.
+from dexverse import baseline_v1  # noqa: E402, F401

--- a/source/dexverse/dexverse/teleop_utils/__init__.py
+++ b/source/dexverse/dexverse/teleop_utils/__init__.py
@@ -1,0 +1,46 @@
+# Copyright (c) 2025-2026, The DexVerse Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Operator-facing teleoperation aids.
+
+Two features, both aimed at giving the teleoperator information they otherwise
+only get after the session is over:
+
+* :mod:`~dexverse.teleop_utils.range_vis` outlines the environment's
+  randomization ranges (object spawn envelopes, goal sampling boxes) as
+  wireframe boxes in the scene, so the operator can see the space the task
+  samples from rather than inferring it one episode at a time.
+* :mod:`~dexverse.teleop_utils.stats_panel` re-scores demonstration diversity
+  after every recorded trajectory and shows it as an in-headset panel, backed by
+  the simulator-free metrics in :mod:`~dexverse.teleop_utils.diversity_core`.
+
+``diversity_core`` is pure numpy and imports nothing from Isaac Sim, and
+``stats_panel`` keeps its Kit/USD imports inside functions -- both are usable
+offline. ``range_vis`` subclasses an Isaac Lab manager base class, so importing
+it requires the Isaac Sim runtime; it is deliberately *not* re-exported here so
+that this package stays importable without a simulator.
+"""
+
+__all__ = [
+    "analyze_demos",
+    "analyze_task",
+    "demos_from_episodes",
+    "load_task_demos",
+]
+
+
+def __getattr__(name):
+    """Load optional analysis helpers only when explicitly requested.
+
+    Task runtime helpers such as door latch progress must be importable without
+    pulling in the collection/analysis utilities through this package initializer.
+    """
+    if name in __all__:
+        from . import diversity_core
+
+        value = getattr(diversity_core, name)
+        globals()[name] = value
+        return value
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/source/dexverse/dexverse/teleop_utils/debug_visualization.py
+++ b/source/dexverse/dexverse/teleop_utils/debug_visualization.py
@@ -1,0 +1,45 @@
+"""Shared launch-time visualization controls, without simulator imports at load."""
+
+import argparse
+
+
+def add_debug_visualization_args(parser, *, teleop=False):
+    parser.add_argument(
+        "--enable_debug_vis", action=argparse.BooleanOptionalAction,
+        default=True if teleop else None,
+        help=(
+            "Enable operator debug cues (zones, reference frames and v1 hand-tracking dots). "
+            "Goal-defining markers remain visible. Teleop/recording defaults to on; other tools "
+            "keep the task default. Camera visibility is controlled separately by --cues_in_rgb."
+        ),
+    )
+    parser.add_argument(
+        "--cues_in_rgb", action=argparse.BooleanOptionalAction, default=teleop,
+        help=(
+            "For v1, render enabled debug cues in camera RGB as well as the viewport. "
+            "Defaults on in teleop/recording for CloudXR/AVP, which may hide guide prims; "
+            "otherwise defaults off. --no-cues_in_rgb tags cues as guide for clean camera RGB. "
+            "Does not enable disabled cues or hide task goals. v0 rendering is unchanged."
+        ),
+    )
+
+
+def configure_v1_debug_visualization(env_cfg, *, cues_in_rgb=False):
+    """Apply after config/retargeter overrides, before gym.make and device creation.
+
+    Task cues are created by config __post_init__, so enable_debug_vis must be
+    supplied when rebuilding the config. Never clear scene_vis wholesale: it
+    also contains task-defining goals. Camera-purpose policy is process-wide,
+    launch-time only; this is not a runtime UI toggle for existing prims.
+    """
+    if not type(env_cfg).__module__.startswith("dexverse.baseline_v1."):
+        return
+    from dexverse.baseline_v1.visual_purpose import set_camera_hiding_enabled
+
+    set_camera_hiding_enabled(not cues_in_rgb)
+    devices = getattr(getattr(env_cfg, "teleop_devices", None), "devices", {})
+    for device in devices.values():
+        for retargeter in getattr(device, "retargeters", []):
+            if hasattr(retargeter, "task_version"):
+                retargeter.task_version = 1
+                retargeter.debug_vis = bool(env_cfg.enable_debug_vis)

--- a/source/dexverse/dexverse/teleop_utils/diversity_core.py
+++ b/source/dexverse/dexverse/teleop_utils/diversity_core.py
@@ -1,0 +1,979 @@
+# Copyright (c) 2025-2026, The DexVerse Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Offline demo-diversity metrics computed directly from teleop trajectory pickles.
+
+Everything in this module runs on the raw ``dexverse_trajectory`` pickles written
+by ``record_demos.py`` -- no simulator, no dexverse imports, numpy only (scipy
+optional, for fast k-NN). It powers ``analyze_demo_diversity.py`` and is written
+so that replay-derived features (true fingertip contact modes from stage-2
+instrumentation) can reuse the same entropy / perplexity / saturation machinery
+on their categorical labels.
+
+What is measured, and from what:
+
+* **Initial-state coverage** -- per-episode initial poses of every scene entity
+  whose reset pose actually varies across episodes (data-driven detection), plus
+  the recorded goal command when present. Reported as per-dimension dispersion
+  and as occupied discretization bins, whose permutation-averaged accumulation
+  curve is the "marginal coverage gain per added demo" artifact.
+* **Strategy modes (kinematic proxies)** -- the approach direction of each palm
+  relative to the manipulated entity at *manipulation onset* (the first step the
+  entity measurably moves), binned into octants; plus a hand-retreat/return
+  counter as a regrasp *proxy*. True contact modes need the replay pass; these
+  are the closest sim-free stand-ins and are labeled as proxies in the report.
+* **Effective strategy count** -- Shannon entropy over the observed mode
+  distribution, reported as perplexity ``exp(H)``.
+* **Conditional multimodality** -- k-NN in whitened state space over all
+  (state, action) pairs, restricted to neighbors from *other* episodes; the
+  action spread among neighbors relative to the global action spread. Near zero
+  means the demos are effectively one deterministic policy on shared states.
+
+Palm positions are recovered without forward kinematics by exploiting the
+floating-hand rig: the articulation root never moves and the first virtual
+joints are pure x/y/z translations (chain order verified against
+``robot_agents/*/floating.py`` and the recorded joint values). Single-hand
+robots use ``joints[0:3]``; bimanual robots interleave the two chains
+(``[rh_x, lh_x, rh_y, lh_y, rh_z, lh_z, ...]``) and each chain hangs off a
+fixed mount offset from the articulation root (``rh_base``/``lh_base`` at
+y = -0.3 / +0.3 for the shadow bimanual rig). Arm-mounted embodiments (no
+``floating_`` prefix) get no palm-based features here -- those need replay.
+"""
+
+from __future__ import annotations
+
+import pickle
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import numpy as np
+
+try:
+    from scipy.spatial import cKDTree
+except ImportError:  # pragma: no cover - scipy is present in practice
+    cKDTree = None
+
+# Entities that mirror other state for visualization only; keeping them would
+# double-count the goal in coverage metrics.
+_VISUAL_ONLY_ENTITIES = ("success_marker",)
+
+# Per-hand mount offset of each translation-joint chain from the articulation
+# root, keyed by the hand-family token inside robot_type. Values documented in
+# ``robot_agents/shadow/floating.py`` (read from the bimanual USD). Families not
+# listed fall back to (0, -/+0.3, 0) with a warning, since every bimanual rig in
+# the repo uses the same layout convention.
+_BIMANUAL_MOUNT_OFFSETS: dict[str, tuple[tuple[float, float, float], tuple[float, float, float]]] = {
+    "shadow": ((0.0, -0.3, 0.0), (0.0, 0.3, 0.0)),
+}
+_DEFAULT_BIMANUAL_MOUNT = ((0.0, -0.3, 0.0), (0.0, 0.3, 0.0))
+
+_FLOATING_SINGLE_RE = re.compile(r"^floating_([a-z0-9]+)_(right|left)$")
+_FLOATING_BIMANUAL_RE = re.compile(r"^floating_([a-z0-9]+)_bimanual$")
+
+
+"""
+Quaternion helpers (wxyz, Isaac Lab convention).
+"""
+
+
+def quat_canonical(q: np.ndarray) -> np.ndarray:
+    """Fix the double-cover sign so identical rotations compare equal."""
+    q = np.asarray(q, dtype=np.float64)
+    sign = np.where(q[..., :1] < 0.0, -1.0, 1.0)
+    return q * sign
+
+
+def quat_to_mat(q: np.ndarray) -> np.ndarray:
+    q = np.asarray(q, dtype=np.float64)
+    w, x, y, z = q[..., 0], q[..., 1], q[..., 2], q[..., 3]
+    n = np.maximum(w * w + x * x + y * y + z * z, 1e-12)
+    w, x, y, z = w / np.sqrt(n), x / np.sqrt(n), y / np.sqrt(n), z / np.sqrt(n)
+    mat = np.empty(q.shape[:-1] + (3, 3), dtype=np.float64)
+    mat[..., 0, 0] = 1 - 2 * (y * y + z * z)
+    mat[..., 0, 1] = 2 * (x * y - w * z)
+    mat[..., 0, 2] = 2 * (x * z + w * y)
+    mat[..., 1, 0] = 2 * (x * y + w * z)
+    mat[..., 1, 1] = 1 - 2 * (x * x + z * z)
+    mat[..., 1, 2] = 2 * (y * z - w * x)
+    mat[..., 2, 0] = 2 * (x * z - w * y)
+    mat[..., 2, 1] = 2 * (y * z + w * x)
+    mat[..., 2, 2] = 1 - 2 * (x * x + y * y)
+    return mat
+
+
+def quat_yaw(q: np.ndarray) -> np.ndarray:
+    """Heading of the body x-axis in the world xy-plane, radians."""
+    mat = quat_to_mat(q)
+    return np.arctan2(mat[..., 1, 0], mat[..., 0, 0])
+
+
+def tilt_from_initial(quats: np.ndarray) -> np.ndarray:
+    """Angle (rad) between the initially-up body axis and world up, per step.
+
+    Yaw-invariant by construction: spinning in place reads as zero tilt, which
+    keeps PushT rotations out of the "tilt" diagnostic.
+    """
+    quats = np.asarray(quats, dtype=np.float64)
+    mats = quat_to_mat(quats)
+    local_up = mats[0].T @ np.array([0.0, 0.0, 1.0])
+    up_world = mats @ local_up
+    return np.arccos(np.clip(up_world[..., 2], -1.0, 1.0))
+
+
+def geodesic_angle_from_initial(quats: np.ndarray) -> np.ndarray:
+    """Full rotation angle (rad) between each orientation and the first one."""
+    q = quat_canonical(quats)
+    dots = np.abs(np.sum(q * q[0], axis=-1))
+    return 2.0 * np.arccos(np.clip(dots, -1.0, 1.0))
+
+
+"""
+Pickle loading.
+"""
+
+
+@dataclass
+class EpisodeArrays:
+    """One demo episode parsed into plain arrays. Poses are (pos3, quat4) wxyz."""
+
+    actions: np.ndarray  # (T, A)
+    joint_pos: np.ndarray  # (T+1, J) robot joints, per-step
+    robot_root: np.ndarray  # (7,) static for floating rigs
+    rigid_poses: dict[str, np.ndarray]  # name -> (T+1, 7)
+    art_joints: dict[str, np.ndarray]  # non-robot articulation -> (T+1, Jk)
+    art_roots: dict[str, np.ndarray]  # non-robot articulation -> (7,) initial root
+    goal_pose: np.ndarray | None  # flattened goal command, if recorded
+    success: bool
+    num_steps: int
+
+
+@dataclass
+class TaskDemos:
+    task: str
+    category: str
+    robot_type: str | None
+    source_files: list[str]
+    episodes: list[EpisodeArrays] = field(default_factory=list)
+
+    @property
+    def num_episodes(self) -> int:
+        return len(self.episodes)
+
+
+def _flat(a) -> np.ndarray:
+    return np.asarray(a, dtype=np.float64).reshape(-1)
+
+
+def _parse_episode(ep: dict) -> EpisodeArrays | None:
+    states = ep.get("states")
+    actions = np.asarray(ep.get("actions"), dtype=np.float64)
+    if not isinstance(states, list) or len(states) < 2 or actions.ndim != 2 or actions.shape[0] == 0:
+        return None
+    arts = states[0].get("articulation", {}) or {}
+    if "robot" not in arts:
+        return None
+
+    joint_pos = np.stack([_flat(s["articulation"]["robot"]["joint_position"]) for s in states])
+    robot_root = _flat(states[0]["articulation"]["robot"]["root_pose"])[:7]
+
+    rigid_names = list((states[0].get("rigid_object", {}) or {}).keys())
+    rigid_poses = {
+        name: np.stack([_flat(s["rigid_object"][name]["root_pose"])[:7] for s in states]) for name in rigid_names
+    }
+    art_names = [n for n in arts.keys() if n != "robot"]
+    art_joints = {
+        name: np.stack([_flat(s["articulation"][name]["joint_position"]) for s in states]) for name in art_names
+    }
+    art_roots = {name: _flat(states[0]["articulation"][name]["root_pose"])[:7] for name in art_names}
+
+    goal = ep.get("goal_pose")
+    goal = _flat(goal) if goal is not None else None
+
+    return EpisodeArrays(
+        actions=actions,
+        joint_pos=joint_pos,
+        robot_root=robot_root,
+        rigid_poses=rigid_poses,
+        art_joints=art_joints,
+        art_roots=art_roots,
+        goal_pose=goal,
+        success=bool(ep.get("success")),
+        num_steps=int(ep.get("num_steps", actions.shape[0])),
+    )
+
+
+def discover_task_pickles(task_dir: Path) -> list[Path]:
+    """Prefer the merged ``<dirname>.pkl``; otherwise every session pickle."""
+    merged = task_dir / f"{task_dir.name}.pkl"
+    if merged.is_file():
+        return [merged]
+    return sorted(task_dir.glob("*.pkl"))
+
+
+def load_task_demos(task_dir: Path, include_failed: bool = False) -> TaskDemos:
+    """Load all demos for one task directory (``<category>/<task>/``)."""
+    paths = discover_task_pickles(task_dir)
+    if not paths:
+        raise FileNotFoundError(f"No pickles under {task_dir}")
+    task_name, robot_type = task_dir.name, None
+    demos = TaskDemos(
+        task=task_name,
+        category=task_dir.parent.name,
+        robot_type=None,
+        source_files=[str(p) for p in paths],
+    )
+    for path in paths:
+        with open(path, "rb") as fp:
+            payload = pickle.load(fp)
+        if payload.get("format") != "dexverse_trajectory":
+            continue
+        robot_type = robot_type or payload.get("robot_type")
+        for ep in payload.get("episodes") or []:
+            if not include_failed and not ep.get("success"):
+                continue
+            parsed = _parse_episode(ep)
+            if parsed is not None:
+                demos.episodes.append(parsed)
+    demos.robot_type = robot_type
+    return demos
+
+
+def demos_from_episodes(
+    episodes: list[dict],
+    *,
+    task: str,
+    category: str = "",
+    robot_type: str | None = None,
+    include_failed: bool = False,
+    history_dir: Path | None = None,
+    exclude: Path | None = None,
+) -> TaskDemos:
+    """Build a :class:`TaskDemos` from live, in-memory episode dicts.
+
+    ``episodes`` are the raw dicts ``TrajectoryPickleRecorder`` accumulates in
+    ``_episodes`` -- after ``finalize_episode`` they carry exactly the schema
+    :func:`_parse_episode` expects, so a live teleop session can be scored
+    without waiting for the pickle to be re-read.
+
+    When ``history_dir`` is given, previously recorded pickles in that directory
+    are loaded first so the numbers describe the whole dataset for the task, not
+    just this session. ``exclude`` skips one path -- pass the session's own
+    output file, which ``finalize_episode`` keeps flushed and would otherwise
+    double-count every in-memory episode.
+    """
+    demos = TaskDemos(task=task, category=category, robot_type=robot_type, source_files=[])
+
+    if history_dir is not None and history_dir.is_dir():
+        exclude_resolved = exclude.resolve() if exclude is not None else None
+        for path in sorted(history_dir.glob("*.pkl")):
+            if exclude_resolved is not None and path.resolve() == exclude_resolved:
+                continue
+            try:
+                with open(path, "rb") as fp:
+                    payload = pickle.load(fp)
+            except Exception:  # a half-written sibling session must not kill teleop
+                continue
+            if payload.get("format") != "dexverse_trajectory":
+                continue
+            demos.source_files.append(str(path))
+            demos.robot_type = demos.robot_type or payload.get("robot_type")
+            for ep in payload.get("episodes") or []:
+                if not include_failed and not ep.get("success"):
+                    continue
+                parsed = _parse_episode(ep)
+                if parsed is not None:
+                    demos.episodes.append(parsed)
+
+    for ep in episodes:
+        if not include_failed and not ep.get("success"):
+            continue
+        parsed = _parse_episode(ep)
+        if parsed is not None:
+            demos.episodes.append(parsed)
+    return demos
+
+
+"""
+Entity selection: which scene entity does this task manipulate?
+"""
+
+
+def _rigid_move_range(poses: np.ndarray) -> float:
+    return float(np.abs(poses[:, :3] - poses[0, :3]).max())
+
+
+def _art_move_range(joints: np.ndarray) -> float:
+    return float(np.abs(joints - joints[0]).max())
+
+
+def select_manipulated_entity(demos: TaskDemos, probe_episodes: int = 10) -> tuple[str, str]:
+    """Return ``(group, name)`` of the manipulated entity.
+
+    Priority: a rigid object literally named ``object`` that moves; else the
+    most-moving rigid object; else the most-moving non-robot articulation.
+    Max motion is taken over a probe of episodes so a single quiet demo cannot
+    misroute the choice. Visual-only entities are excluded outright.
+    """
+    probe = demos.episodes[: max(1, probe_episodes)]
+    rigid_move: dict[str, float] = {}
+    art_move: dict[str, float] = {}
+    for ep in probe:
+        for name, poses in ep.rigid_poses.items():
+            if name in _VISUAL_ONLY_ENTITIES:
+                continue
+            rigid_move[name] = max(rigid_move.get(name, 0.0), _rigid_move_range(poses))
+        for name, joints in ep.art_joints.items():
+            art_move[name] = max(art_move.get(name, 0.0), _art_move_range(joints))
+
+    if rigid_move.get("object", 0.0) > 0.02:
+        return "rigid_object", "object"
+    moving_rigids = {n: v for n, v in rigid_move.items() if v > 0.02}
+    if moving_rigids:
+        return "rigid_object", max(moving_rigids, key=moving_rigids.get)
+    if art_move:
+        return "articulation", max(art_move, key=art_move.get)
+    if rigid_move:
+        return "rigid_object", max(rigid_move, key=rigid_move.get)
+    raise ValueError(f"{demos.task}: no candidate manipulated entity found")
+
+
+def entity_positions(ep: EpisodeArrays, group: str, name: str) -> np.ndarray:
+    """Per-step world position (T+1, 3) of the entity's reference point."""
+    if group == "rigid_object":
+        return ep.rigid_poses[name][:, :3]
+    # Articulated fixtures do not translate; their root is the reference point.
+    return np.broadcast_to(ep.art_roots[name][:3], (ep.joint_pos.shape[0], 3))
+
+
+"""
+Palm recovery from the floating-rig virtual joints.
+"""
+
+
+@dataclass
+class PalmModel:
+    """Extracts per-hand palm(=wrist chain origin) positions from robot joints."""
+
+    kind: str  # "single" | "bimanual" | "none"
+    reason: str = ""
+    mount_offsets: tuple[tuple[float, float, float], ...] = ()
+    hand_labels: tuple[str, ...] = ()
+
+    def positions(self, ep: EpisodeArrays) -> np.ndarray | None:
+        """(T+1, n_hands, 3) world positions, or None if unsupported."""
+        if self.kind == "single":
+            trans = ep.joint_pos[:, :3]
+            return (ep.robot_root[:3] + trans)[:, None, :]
+        if self.kind == "bimanual":
+            # Interleaved virtual chains: joints[[0,2,4]] is one hand's x/y/z
+            # translation, joints[[1,3,5]] the other's (verified against the
+            # recorded init values 0.5/0.5/0/0/0.3/0.3).
+            out = np.empty((ep.joint_pos.shape[0], 2, 3))
+            for slot in (0, 1):
+                trans = ep.joint_pos[:, [slot, slot + 2, slot + 4]]
+                out[:, slot, :] = ep.robot_root[:3] + np.asarray(self.mount_offsets[slot]) + trans
+            return out
+        return None
+
+
+def build_palm_model(demos: TaskDemos) -> PalmModel:
+    robot_type = demos.robot_type or ""
+    if _FLOATING_SINGLE_RE.match(robot_type):
+        model = PalmModel(kind="single", hand_labels=("hand",))
+    elif _FLOATING_BIMANUAL_RE.match(robot_type):
+        family = _FLOATING_BIMANUAL_RE.match(robot_type).group(1)
+        offsets = _BIMANUAL_MOUNT_OFFSETS.get(family, _DEFAULT_BIMANUAL_MOUNT)
+        # Slot->side assignment: the chain mounted at negative y is the one
+        # whose recovered positions must start at root_y - 0.3. Both slots init
+        # identically in joint space, so try both assignments and keep the one
+        # whose hands do not cross at t=0 (they start mirrored about the root).
+        model = PalmModel(kind="bimanual", mount_offsets=offsets, hand_labels=("hand_neg_y", "hand_pos_y"))
+    else:
+        return PalmModel(kind="none", reason=f"robot_type={robot_type!r} is not a floating rig; needs replay FK")
+
+    # Workspace sanity check: recovered palms must be near the table, else the
+    # virtual-joint layout assumption does not hold for this rig.
+    probe = demos.episodes[: min(5, len(demos.episodes))]
+    for ep in probe:
+        pos = model.positions(ep)
+        if pos is None or not (np.all(np.abs(pos[..., :2]) < 1.5) and np.all(pos[..., 2] > -0.2) and np.all(pos[..., 2] < 2.0)):
+            return PalmModel(kind="none", reason="virtual-joint palm recovery failed the workspace sanity check")
+    return model
+
+
+"""
+Manipulation onset, approach octants, regrasp proxy, motion diagnostics.
+"""
+
+
+def manipulation_onset(ep: EpisodeArrays, group: str, name: str, pos_eps: float = 0.01, joint_eps: float = 0.01) -> int:
+    """First step index where the manipulated entity has measurably moved.
+
+    Falls back to the step of closest palm approach -- or 0 -- when the entity
+    never crosses the threshold (should not happen in successful demos).
+    """
+    if group == "rigid_object":
+        poses = ep.rigid_poses[name]
+        moved = np.abs(poses[:, :3] - poses[0, :3]).max(axis=1) > pos_eps
+        tilted = tilt_from_initial(poses[:, 3:7]) > np.deg2rad(5.0)
+        hits = np.flatnonzero(moved | tilted)
+    else:
+        joints = ep.art_joints[name]
+        hits = np.flatnonzero(np.abs(joints - joints[0]).max(axis=1) > joint_eps)
+    return int(hits[0]) if hits.size else 0
+
+
+def approach_octant(
+    palm_pos: np.ndarray,
+    entity_pos: np.ndarray,
+    entity_yaw: float,
+    azimuth_bins: int = 4,
+) -> tuple[str, float, float]:
+    """Bin the palm->entity offset into an azimuth x elevation octant.
+
+    Azimuth is measured in the entity's yaw-derotated frame so that "approached
+    the handle side" is the same mode regardless of how the object spawned.
+    Returns ``(label, azimuth_deg, elevation_deg)``.
+    """
+    offset = np.asarray(palm_pos, dtype=np.float64) - np.asarray(entity_pos, dtype=np.float64)
+    az = np.arctan2(offset[1], offset[0]) - entity_yaw
+    az = (az + np.pi) % (2.0 * np.pi) - np.pi
+    elev = np.arctan2(offset[2], max(np.hypot(offset[0], offset[1]), 1e-9))
+    az_bin = int(((az + np.pi) / (2.0 * np.pi)) * azimuth_bins) % azimuth_bins
+    label = f"az{az_bin}_{'up' if elev >= 0.0 else 'dn'}"
+    return label, float(np.degrees(az)), float(np.degrees(elev))
+
+
+def retreat_return_count(
+    palm_dist: np.ndarray, onset: int, rise_near: float = 0.04, rise_far: float = 0.10
+) -> int:
+    """Regrasp *proxy*: after onset, count near -> far -> near excursions.
+
+    The near/far bands sit ``rise_near`` / ``rise_far`` above the episode's own
+    post-onset closest approach, because the wrist-chain origin we can recover
+    without FK carries an embodiment-dependent forearm offset that makes any
+    absolute threshold meaningless. Hysteresis between the bands keeps jitter
+    from counting. True regrasps (contact loss and recovery) need the stage-2
+    contact replay; this proxies them with wrist-to-entity distance.
+    """
+    d = np.asarray(palm_dist, dtype=np.float64)[onset:]
+    if d.size == 0:
+        return 0
+    near_threshold = float(d.min()) + rise_near
+    far_threshold = float(d.min()) + rise_far
+    count = 0
+    state_near = bool(d[0] < near_threshold)
+    for value in d[1:]:
+        if state_near and value > far_threshold:
+            state_near = False
+        elif not state_near and value < near_threshold:
+            state_near = True
+            count += 1
+    # The first entry into "near" is the initial approach, not a re-grasp.
+    return max(0, count - (0 if bool(d[0] < near_threshold) else 1))
+
+
+def motion_diagnostics(ep: EpisodeArrays, group: str, name: str) -> dict[str, float]:
+    """Cheap physical strategy descriptors of the manipulated entity."""
+    if group == "rigid_object":
+        poses = ep.rigid_poses[name]
+        pos = poses[:, :3]
+        steps = np.linalg.norm(np.diff(pos, axis=0), axis=1)
+        return {
+            "max_lift_m": float((pos[:, 2] - pos[0, 2]).max()),
+            "max_tilt_deg": float(np.degrees(tilt_from_initial(poses[:, 3:7]).max())),
+            "max_rotation_deg": float(np.degrees(geodesic_angle_from_initial(poses[:, 3:7]).max())),
+            "net_xy_m": float(np.linalg.norm(pos[-1, :2] - pos[0, :2])),
+            "path_length_m": float(steps.sum()),
+        }
+    joints = ep.art_joints[name]
+    travel = np.abs(joints - joints[0])
+    return {
+        "max_joint_travel": float(travel.max()),
+        "final_joint_travel": float(np.abs(joints[-1] - joints[0]).max()),
+        "n_direction_reversals": int(
+            np.sum(np.abs(np.diff(np.sign(np.diff(joints[:, int(np.argmax(travel.max(axis=0)))])))) > 0) // 2
+        ),
+    }
+
+
+"""
+Initial-state coverage.
+"""
+
+
+def _circular_std_deg(angles_deg: np.ndarray) -> float:
+    """Circular standard deviation in degrees (wrap-safe, unlike np.std)."""
+    rad = np.deg2rad(np.asarray(angles_deg, dtype=np.float64))
+    resultant = float(np.abs(np.exp(1j * rad).mean()))
+    if resultant >= 1.0:
+        return 0.0
+    return float(np.degrees(np.sqrt(-2.0 * np.log(max(resultant, 1e-12)))))
+
+
+def _initial_pose_rows(demos: TaskDemos) -> dict[str, np.ndarray]:
+    """Per-entity (N, 7) initial poses across episodes, plus goal_pose rows."""
+    rows: dict[str, list[np.ndarray]] = {}
+    for ep in demos.episodes:
+        for name, poses in ep.rigid_poses.items():
+            if name in _VISUAL_ONLY_ENTITIES:
+                continue
+            rows.setdefault(name, []).append(poses[0])
+        for name, joints in ep.art_joints.items():
+            root = np.zeros(7)
+            root[: min(7, ep.art_roots[name].size)] = ep.art_roots[name][:7]
+            # Fixtures encode their randomization in the root pose; joint inits
+            # are appended separately below via a pseudo-row when they vary.
+            rows.setdefault(name, []).append(root)
+        if ep.goal_pose is not None and ep.goal_pose.size >= 3:
+            row = np.zeros(7)
+            row[: min(7, ep.goal_pose.size)] = ep.goal_pose[:7]
+            rows.setdefault("goal_pose", []).append(row)
+    return {name: np.stack(v) for name, v in rows.items() if len(v) == len(demos.episodes)}
+
+
+def initial_state_coverage(
+    demos: TaskDemos,
+    xy_bin_m: float = 0.02,
+    yaw_bin_deg: float = 30.0,
+    min_pos_std_m: float = 0.002,
+    min_yaw_std_deg: float = 1.0,
+) -> dict:
+    """Dispersion and occupied-bin coverage over entities whose reset varies."""
+    pose_rows = _initial_pose_rows(demos)
+    per_entity: dict[str, dict] = {}
+    episode_bins: list[set] = [set() for _ in range(demos.num_episodes)]
+
+    for name, rows in pose_rows.items():
+        pos = rows[:, :3]
+        yaw = np.degrees(quat_yaw(rows[:, 3:7])) if np.any(rows[:, 3:7]) else np.zeros(len(rows))
+        pos_std = pos.std(axis=0)
+        yaw_std_deg = _circular_std_deg(yaw)
+        randomized = bool(pos_std.max() > min_pos_std_m or yaw_std_deg > min_yaw_std_deg)
+        if not randomized:
+            continue
+        bins_x = np.floor(pos[:, 0] / xy_bin_m).astype(int)
+        bins_y = np.floor(pos[:, 1] / xy_bin_m).astype(int)
+        bins_yaw = np.floor(yaw / yaw_bin_deg).astype(int)
+        occupied = set()
+        for i in range(len(rows)):
+            key = (name, int(bins_x[i]), int(bins_y[i]), int(bins_yaw[i]))
+            occupied.add(key)
+            episode_bins[i].add(key)
+        per_entity[name] = {
+            "pos_std_m": [float(v) for v in pos_std],
+            "xy_range_m": [float(np.ptp(pos[:, 0])), float(np.ptp(pos[:, 1]))],
+            "yaw_std_deg": yaw_std_deg,
+            "n_bins_occupied": len(occupied),
+        }
+
+    # Articulated fixtures can also randomize their initial joint values (a
+    # laptop's starting lid angle); cover them with their own binning.
+    art_common = set.intersection(*[set(ep.art_joints) for ep in demos.episodes]) if demos.episodes else set()
+    for name in sorted(art_common):
+        inits = np.stack([ep.art_joints[name][0] for ep in demos.episodes])
+        if inits.std(axis=0).max() <= 0.005:
+            continue
+        joint_bin = 0.05  # rad or m per bin; virtual fixtures mix both units
+        keys = [tuple((name, "joints", *np.floor(row / joint_bin).astype(int))) for row in inits]
+        for i, key in enumerate(keys):
+            episode_bins[i].add(key)
+        per_entity[f"{name}(joints)"] = {
+            "joint_init_std": [float(v) for v in inits.std(axis=0)],
+            "n_bins_occupied": len(set(keys)),
+        }
+
+    return {
+        "bin_params": {"xy_bin_m": xy_bin_m, "yaw_bin_deg": yaw_bin_deg},
+        "randomized_entities": sorted(per_entity.keys()),
+        "per_entity": per_entity,
+        "episode_bins": episode_bins,  # consumed by saturation_curve, stripped from JSON
+    }
+
+
+"""
+Entropy / perplexity and saturation.
+"""
+
+
+def entropy_perplexity(counts: dict[str, int]) -> dict:
+    total = float(sum(counts.values()))
+    if total <= 0:
+        return {"counts": counts, "distinct": 0, "entropy_nats": 0.0, "perplexity": 0.0, "top_share": 0.0}
+    probs = np.array([c / total for c in counts.values() if c > 0], dtype=np.float64)
+    entropy = float(-(probs * np.log(probs)).sum())
+    return {
+        "counts": dict(sorted(counts.items(), key=lambda kv: -kv[1])),
+        "distinct": int(len(probs)),
+        "entropy_nats": entropy,
+        "perplexity": float(np.exp(entropy)),
+        "top_share": float(probs.max()),
+    }
+
+
+def saturation_curve(per_episode_items: list, n_permutations: int = 200, seed: int = 0) -> dict:
+    """Permutation-averaged cumulative distinct-item curve over added demos.
+
+    ``per_episode_items`` holds one hashable label *or* one set of hashables per
+    episode. Returns the mean curve, the marginal gain per added demo, and
+    ``n95`` -- how many demos reach 95% of the final coverage, i.e. the point
+    past which additional demos stop adding information of this kind.
+    """
+    sets = [items if isinstance(items, (set, frozenset)) else {items} for items in per_episode_items]
+    n = len(sets)
+    if n == 0:
+        return {"curve": [], "marginal": [], "n95": 0, "final": 0}
+    rng = np.random.default_rng(seed)
+    acc = np.zeros(n, dtype=np.float64)
+    for _ in range(n_permutations):
+        seen: set = set()
+        for pos, idx in enumerate(rng.permutation(n)):
+            seen |= sets[idx]
+            acc[pos] += len(seen)
+    curve = acc / n_permutations
+    marginal = np.diff(np.concatenate([[0.0], curve]))
+    final = curve[-1]
+    n95 = int(np.argmax(curve >= 0.95 * final) + 1) if final > 0 else 0
+    return {
+        "curve": [float(v) for v in curve],
+        "marginal": [float(v) for v in marginal],
+        "n95": n95,
+        "final": float(final),
+    }
+
+
+"""
+Conditional multimodality: k-NN action spread in whitened state space.
+"""
+
+
+def _episode_state_features(
+    ep: EpisodeArrays, moving_rigids: list[str], art_names: list[str], goal_dim: int
+) -> np.ndarray:
+    """(T, D) per-step state features for the T recorded actions (pre-step state)."""
+    steps = ep.actions.shape[0]
+    parts = [ep.joint_pos[:steps]]
+    for name in moving_rigids:
+        poses = ep.rigid_poses[name][:steps]
+        parts.extend([poses[:, :3], quat_canonical(poses[:, 3:7])])
+    for name in art_names:
+        parts.append(ep.art_joints[name][:steps])
+    if goal_dim > 0:
+        parts.append(np.broadcast_to(ep.goal_pose[:goal_dim], (steps, goal_dim)))
+    return np.concatenate(parts, axis=1)
+
+
+def knn_conditional_multimodality(
+    demos: TaskDemos,
+    k: int = 8,
+    max_pool: int = 60_000,
+    max_queries: int = 8_000,
+    seed: int = 0,
+) -> dict:
+    """Action variability among nearest *cross-episode* state neighbors.
+
+    Both states and actions are whitened per-dimension over the pooled dataset.
+    The headline number is ``spread_ratio``: mean per-dimension action std among
+    each query's k nearest other-episode neighbors, divided by the global std
+    (== 1 after whitening). ~0 means one deterministic policy; ~1 means actions
+    at similar states are as varied as the whole dataset. ``random_baseline``
+    repeats the computation with random other-episode samples in place of
+    neighbors and should sit near 1.
+    """
+    if demos.num_episodes < 2:
+        return {"skipped": "needs >= 2 episodes"}
+
+    # Feature layout must be identical across episodes.
+    rigid_names = sorted(set.intersection(*[set(ep.rigid_poses) for ep in demos.episodes]) - set(_VISUAL_ONLY_ENTITIES))
+    moving = [
+        n for n in rigid_names if max(_rigid_move_range(ep.rigid_poses[n]) for ep in demos.episodes[:10]) > 0.005
+    ]
+    # Randomized-but-static entities (receptacles, goals) are part of the state
+    # too: conditioning on them keeps "similar state" honest across episodes.
+    static_randomized = [
+        n
+        for n in rigid_names
+        if n not in moving and np.std([ep.rigid_poses[n][0, :3] for ep in demos.episodes], axis=0).max() > 0.002
+    ]
+    art_names = sorted(set.intersection(*[set(ep.art_joints) for ep in demos.episodes]))
+    feature_rigids = moving + static_randomized
+    goal_sizes = {0 if ep.goal_pose is None else min(7, ep.goal_pose.size) for ep in demos.episodes}
+    goal_dim = goal_sizes.pop() if len(goal_sizes) == 1 else 0
+
+    states, actions, episode_ids = [], [], []
+    for idx, ep in enumerate(demos.episodes):
+        feats = _episode_state_features(ep, feature_rigids, art_names, goal_dim)
+        states.append(feats)
+        actions.append(ep.actions)
+        episode_ids.append(np.full(feats.shape[0], idx))
+    states = np.concatenate(states)
+    actions = np.concatenate(actions)
+    episode_ids = np.concatenate(episode_ids)
+
+    rng = np.random.default_rng(seed)
+    if states.shape[0] > max_pool:
+        keep = np.sort(rng.choice(states.shape[0], size=max_pool, replace=False))
+        states, actions, episode_ids = states[keep], actions[keep], episode_ids[keep]
+
+    def whiten(x: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+        std = x.std(axis=0)
+        live = std > 1e-8
+        return (x[:, live] - x[:, live].mean(axis=0)) / std[live], live
+
+    s_w, _ = whiten(states)
+    a_w, a_live = whiten(actions)
+    if a_w.shape[1] == 0 or s_w.shape[1] == 0:
+        return {"skipped": "no varying state or action dimensions"}
+
+    n = s_w.shape[0]
+    queries = np.sort(rng.choice(n, size=min(max_queries, n), replace=False))
+    _, ep_counts = np.unique(episode_ids, return_counts=True)
+    k_search = int(min(n, k + ep_counts.max()))
+
+    if cKDTree is not None:
+        tree = cKDTree(s_w)
+        spreads, state_dists = [], []
+        for chunk in np.array_split(queries, max(1, len(queries) // 2048)):
+            dist, idx = tree.query(s_w[chunk], k=k_search, workers=-1)
+            for row, (di, ii) in enumerate(zip(dist, idx)):
+                qi = chunk[row]
+                mask = episode_ids[ii] != episode_ids[qi]
+                picked = ii[mask][:k]
+                if picked.size < max(2, k // 2):
+                    continue
+                spreads.append(a_w[picked].std(axis=0).mean())
+                state_dists.append(di[mask][: picked.size].mean())
+    else:  # chunked brute force
+        spreads, state_dists = [], []
+        for qi in queries:
+            d = np.linalg.norm(s_w - s_w[qi], axis=1)
+            d[episode_ids == episode_ids[qi]] = np.inf
+            picked = np.argpartition(d, k)[:k]
+            spreads.append(a_w[picked].std(axis=0).mean())
+            state_dists.append(float(d[picked].mean()))
+
+    if not spreads:
+        return {"skipped": "no queries with enough cross-episode neighbors"}
+
+    # Null control: random other-episode samples instead of nearest neighbors.
+    rand_spreads = []
+    for qi in rng.choice(queries, size=min(1000, len(queries)), replace=False):
+        others = np.flatnonzero(episode_ids != episode_ids[qi])
+        picked = rng.choice(others, size=min(k, others.size), replace=False)
+        rand_spreads.append(a_w[picked].std(axis=0).mean())
+
+    return {
+        "k": k,
+        "n_pool": int(n),
+        "n_queries": int(len(spreads)),
+        "state_dim": int(s_w.shape[1]),
+        "action_dim_used": int(a_w.shape[1]),
+        "action_dims_dropped": int((~a_live).sum()),
+        "spread_ratio": float(np.mean(spreads)),
+        "spread_ratio_median": float(np.median(spreads)),
+        "random_baseline": float(np.mean(rand_spreads)),
+        # Neighbor and random spreads share the same small-sample bias (std of
+        # k samples underestimates sigma), so their ratio is the fair headline:
+        # 1.0 = actions at similar states as varied as anywhere; 0 = one policy.
+        "spread_vs_baseline": float(np.mean(spreads) / max(np.mean(rand_spreads), 1e-9)),
+        "mean_neighbor_state_dist": float(np.mean(state_dists)),
+        "state_features": {"moving": moving, "static_randomized": static_randomized, "articulations": art_names},
+    }
+
+
+"""
+Task-level orchestration.
+"""
+
+
+def _resolve_bimanual_slots(demos: TaskDemos, model: PalmModel, group: str, name: str) -> PalmModel:
+    """Pick the slot->mount-offset assignment that the data supports.
+
+    Both interleave slots start at identical joint values, so the pickle alone
+    cannot say which chain carries which +/-y mount. The wrong assignment puts
+    every palm ~0.6 m off in y; the right one puts palms near the manipulated
+    entity at onset. Try both, keep the closer.
+    """
+    if model.kind != "bimanual":
+        return model
+    candidates = [model.mount_offsets, tuple(reversed(model.mount_offsets))]
+    scores = []
+    for offsets in candidates:
+        trial = PalmModel(kind="bimanual", mount_offsets=offsets, hand_labels=model.hand_labels)
+        dists = []
+        for ep in demos.episodes[: min(8, len(demos.episodes))]:
+            onset = manipulation_onset(ep, group, name)
+            palms = trial.positions(ep)[onset]
+            entity = entity_positions(ep, group, name)[onset]
+            dists.append(np.linalg.norm(palms - entity, axis=1).mean())
+        scores.append(float(np.mean(dists)))
+    best = candidates[int(np.argmin(scores))]
+    return PalmModel(kind="bimanual", mount_offsets=best, hand_labels=model.hand_labels)
+
+
+def analyze_task(
+    task_dir: Path,
+    *,
+    include_failed: bool = False,
+    xy_bin_m: float = 0.02,
+    yaw_bin_deg: float = 30.0,
+    azimuth_bins: int = 4,
+    knn_k: int = 8,
+    knn_max_pool: int = 60_000,
+    knn_max_queries: int = 8_000,
+    n_permutations: int = 200,
+    seed: int = 0,
+) -> dict:
+    """Run every offline diversity metric for one task directory; JSON-safe result."""
+    demos = load_task_demos(task_dir, include_failed=include_failed)
+    return analyze_demos(
+        demos,
+        include_failed=include_failed,
+        xy_bin_m=xy_bin_m,
+        yaw_bin_deg=yaw_bin_deg,
+        azimuth_bins=azimuth_bins,
+        knn_k=knn_k,
+        knn_max_pool=knn_max_pool,
+        knn_max_queries=knn_max_queries,
+        n_permutations=n_permutations,
+        seed=seed,
+    )
+
+
+def analyze_demos(
+    demos: TaskDemos,
+    *,
+    include_failed: bool = False,
+    xy_bin_m: float = 0.02,
+    yaw_bin_deg: float = 30.0,
+    azimuth_bins: int = 4,
+    knn_k: int = 8,
+    knn_max_pool: int = 60_000,
+    knn_max_queries: int = 8_000,
+    n_permutations: int = 200,
+    seed: int = 0,
+    include_knn: bool = True,
+) -> dict:
+    """Run the offline diversity metrics over an already-loaded :class:`TaskDemos`.
+
+    Split out of :func:`analyze_task` so live teleop can score episodes it is
+    holding in memory without a pickle round-trip. ``include_knn=False`` skips
+    :func:`knn_conditional_multimodality`, which is the only stage whose cost
+    grows with dataset size (~0.6 s at 50 episodes) -- the rest is milliseconds
+    and is safe to recompute after every recorded trajectory.
+    """
+    warnings_list: list[str] = []
+    if demos.num_episodes == 0:
+        return {"task": demos.task, "category": demos.category, "error": "no episodes"}
+
+    group, name = select_manipulated_entity(demos)
+    palm_model = build_palm_model(demos)
+    if palm_model.kind == "none":
+        warnings_list.append(f"palm-based features skipped: {palm_model.reason}")
+    palm_model = _resolve_bimanual_slots(demos, palm_model, group, name)
+
+    # --- initial-state coverage + its saturation ---------------------------
+    coverage = initial_state_coverage(demos, xy_bin_m=xy_bin_m, yaw_bin_deg=yaw_bin_deg)
+    episode_bins = coverage.pop("episode_bins")
+    coverage["saturation"] = saturation_curve(episode_bins, n_permutations=n_permutations, seed=seed)
+
+    # --- per-episode strategy features -------------------------------------
+    octant_labels: list = []
+    octant_details: list[dict] = []
+    regrasp_counts: list[int] = []
+    onset_steps: list[int] = []
+    motions: list[dict[str, float]] = []
+    for ep in demos.episodes:
+        onset = manipulation_onset(ep, group, name)
+        onset_steps.append(onset)
+        motions.append(motion_diagnostics(ep, group, name))
+        palms = palm_model.positions(ep)
+        if palms is None:
+            continue
+        entity_pos = entity_positions(ep, group, name)
+        if group == "rigid_object":
+            yaw = float(quat_yaw(ep.rigid_poses[name][onset, 3:7]))
+        else:
+            yaw = float(quat_yaw(ep.art_roots[name][3:7]))
+        hand_labels = []
+        detail = {}
+        for hand in range(palms.shape[1]):
+            label, az, elev = approach_octant(palms[onset, hand], entity_pos[onset], yaw, azimuth_bins)
+            hand_labels.append(label)
+            detail[palm_model.hand_labels[hand]] = {"octant": label, "azimuth_deg": az, "elevation_deg": elev}
+        octant_labels.append(hand_labels[0] if len(hand_labels) == 1 else "|".join(hand_labels))
+        octant_details.append(detail)
+        dist = np.linalg.norm(palms - entity_pos[:, None, :], axis=2).min(axis=1)
+        regrasp_counts.append(retreat_return_count(dist, onset))
+
+    strategy: dict = {
+        "onset_step": {
+            "mean": float(np.mean(onset_steps)),
+            "median": float(np.median(onset_steps)),
+            "max": int(np.max(onset_steps)),
+        },
+        "motion": {
+            key: {
+                "mean": float(np.mean([m[key] for m in motions])),
+                "std": float(np.std([m[key] for m in motions])),
+                "min": float(np.min([m[key] for m in motions])),
+                "max": float(np.max([m[key] for m in motions])),
+            }
+            for key in motions[0]
+        },
+    }
+    if octant_labels:
+        counts: dict[str, int] = {}
+        for label in octant_labels:
+            counts[label] = counts.get(label, 0) + 1
+        strategy["approach_octant"] = entropy_perplexity(counts)
+        strategy["approach_octant"]["basis"] = (
+            "wrist-chain origin from virtual translation joints; palm-surface offset"
+            " not included (exact palm poses come from the replay pass)"
+        )
+        all_az = [d[h]["azimuth_deg"] for d in octant_details for h in d]
+        all_elev = [d[h]["elevation_deg"] for d in octant_details for h in d]
+        strategy["approach_octant"]["azimuth_circ_std_deg"] = _circular_std_deg(np.array(all_az))
+        strategy["approach_octant"]["elevation_mean_deg"] = float(np.mean(all_elev))
+        strategy["approach_octant"]["per_episode"] = octant_details
+        strategy["approach_octant"]["saturation"] = saturation_curve(
+            octant_labels, n_permutations=n_permutations, seed=seed
+        )
+        strategy["regrasp_proxy"] = {
+            "mean": float(np.mean(regrasp_counts)),
+            "nonzero_episodes": int(np.sum(np.array(regrasp_counts) > 0)),
+            "max": int(np.max(regrasp_counts)),
+        }
+
+    # --- conditional multimodality -----------------------------------------
+    if include_knn:
+        knn = knn_conditional_multimodality(
+            demos, k=knn_k, max_pool=knn_max_pool, max_queries=knn_max_queries, seed=seed
+        )
+    else:
+        knn = {"skipped": "include_knn=False"}
+
+    return {
+        "task": demos.task,
+        "category": demos.category,
+        "robot_type": demos.robot_type,
+        "n_episodes": demos.num_episodes,
+        "manipulated_entity": {"group": group, "name": name},
+        "palm_model": {"kind": palm_model.kind, "hand_labels": list(palm_model.hand_labels)},
+        "initial_state_coverage": coverage,
+        "strategy": strategy,
+        "conditional_multimodality": knn,
+        "warnings": warnings_list,
+        "params": {
+            "xy_bin_m": xy_bin_m,
+            "yaw_bin_deg": yaw_bin_deg,
+            "azimuth_bins": azimuth_bins,
+            "knn_k": knn_k,
+            "n_permutations": n_permutations,
+            "seed": seed,
+            "include_failed": include_failed,
+        },
+    }

--- a/source/dexverse/dexverse/teleop_utils/door_latch_progress.py
+++ b/source/dexverse/dexverse/teleop_utils/door_latch_progress.py
@@ -1,0 +1,63 @@
+"""Pure episode bookkeeping for a physical automatic spring latch.
+
+State columns: opened, hand touched door, released, supported, dwell, last step,
+success, failed. No prescribed grasp history and no simulated locking.
+"""
+
+import math
+
+import torch
+
+
+def new_door_latch_state(num_envs, device):
+    state = torch.zeros((num_envs, 8), device=device)
+    state[:, 5] = -1
+    return state
+
+
+def update_door_latch_state(
+    state,
+    step,
+    door_angle,
+    door_speed,
+    latch_height,
+    latch_speed,
+    door_hand_contact,
+    supported,
+    hands_clear,
+    hold_steps=60,
+):
+    """Count consecutive stable, supported, hands-free steps after door contact."""
+    if hold_steps < 1:
+        raise ValueError("hold_steps must be positive")
+    fresh = step != state[:, 5]
+    reset = step < state[:, 5]
+    state[reset] = 0
+    state[reset, 5] = -1
+    # A skipped evaluation cannot certify the intervening release interval.
+    gap = step > state[:, 5] + 1
+    state[gap, 4] = 0
+    active = fresh & ~state[:, 7].bool()
+    # Start closed without failing. A return to closed after 15 degrees fails.
+    state[active, 0] = torch.maximum(state[active, 0], (door_angle[active] >= math.radians(15)).float())
+    state[active, 1] = torch.maximum(state[active, 1], door_hand_contact[active].float())
+    released = state[:, 1].bool() & hands_clear & ~door_hand_contact
+    state[fresh, 2] = released[fresh].float()
+    state[fresh, 3] = supported[fresh].float()
+    shut = state[:, 0].bool() & (door_angle <= math.radians(5))
+    state[fresh, 7] = torch.maximum(state[fresh, 7], shut[fresh].float())
+    seated = (
+        (door_angle >= math.radians(84))
+        & (door_angle <= math.radians(94))
+        & (door_speed.abs() < 0.08)
+        & (latch_height <= 0.012)
+        & (latch_speed.abs() < 0.03)
+        & supported
+        & released
+        & ~state[:, 7].bool()
+    )
+    state[fresh, 4] = torch.where(seated[fresh], state[fresh, 4] + 1, 0)
+    # Success is a current physical dwell, never a sticky angle-only latch.
+    state[fresh, 6] = (state[fresh, 4] >= hold_steps).float()
+    state[fresh, 5] = step[fresh].float()
+    return state[:, 6].bool(), state[:, 7].bool()

--- a/source/dexverse/dexverse/teleop_utils/episode_task_state.py
+++ b/source/dexverse/dexverse/teleop_utils/episode_task_state.py
@@ -1,0 +1,156 @@
+# Copyright (c) 2025-2026, The DexVerse Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Capture and restore episode state that is not owned by the scene.
+
+``InteractiveScene.get_state()`` covers articulations and rigid objects, but not
+command-manager buffers or task-specific tensors created by reset events.  Goal
+markers are often driven from exactly those values, so replaying only the scene
+state can produce a different goal (and different goal visuals) from recording.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import torch
+
+
+_COMMAND_BUFFER_NAMES = ("pose_command_b", "pose_command_w")
+
+
+def _row_copy(value: Any, env_index: int) -> torch.Tensor | None:
+    if not isinstance(value, torch.Tensor) or value.ndim == 0 or value.shape[0] <= env_index:
+        return None
+    return value[env_index].detach().clone()
+
+
+def _configured_env_buffer_names(env) -> set[str]:
+    """Find reset-event buffers declared through a ``buffer_name`` parameter."""
+    names: set[str] = set()
+    events_cfg = getattr(getattr(env, "cfg", None), "events", None)
+    if events_cfg is None:
+        return names
+    for term_name in dir(events_cfg):
+        if term_name.startswith("_"):
+            continue
+        try:
+            term_cfg = getattr(events_cfg, term_name)
+        except Exception:
+            continue
+        params = getattr(term_cfg, "params", None)
+        if isinstance(params, dict) and isinstance(params.get("buffer_name"), str):
+            names.add(params["buffer_name"])
+    return names
+
+
+def capture_episode_task_state(env, env_index: int = 0) -> dict[str, dict[str, torch.Tensor]]:
+    """Return replay-critical command and task-buffer state for one environment."""
+    state: dict[str, dict[str, torch.Tensor]] = {}
+
+    command_manager = getattr(env, "command_manager", None)
+    commands: dict[str, dict[str, torch.Tensor]] = {}
+    if command_manager is not None:
+        for name in getattr(command_manager, "active_terms", ()):
+            try:
+                term = command_manager.get_term(name)
+            except (AttributeError, KeyError):
+                continue
+            buffers: dict[str, torch.Tensor] = {}
+            for buffer_name in _COMMAND_BUFFER_NAMES:
+                row = _row_copy(getattr(term, buffer_name, None), env_index)
+                if row is not None:
+                    buffers[buffer_name] = row
+            # Preserve non-pose command terms too. Pose terms already expose the
+            # writable source buffer above, so duplicating ``command`` is needless.
+            if not buffers:
+                row = _row_copy(getattr(term, "command", None), env_index)
+                if row is not None:
+                    buffers["command"] = row
+            if buffers:
+                commands[str(name)] = buffers
+    if commands:
+        state["commands"] = commands
+
+    env_buffers: dict[str, torch.Tensor] = {}
+    for name in sorted(_configured_env_buffer_names(env)):
+        row = _row_copy(getattr(env, name, None), env_index)
+        if row is not None:
+            env_buffers[name] = row
+    if env_buffers:
+        state["env_buffers"] = env_buffers
+
+    return state
+
+
+def _restore_tensor_row(target: torch.Tensor, value: Any, env_index: int) -> None:
+    source = torch.as_tensor(value, device=target.device, dtype=target.dtype)
+    target[env_index].copy_(source.reshape(target[env_index].shape))
+
+
+def reset_managers_after_state_restore(env, env_ids=None) -> None:
+    """Rebase explicitly opted-in managers after restoring an episode's initial scene.
+
+    Call once at the start of an episode, never for intermediate replay frames.
+    Ordinary managers and v0 predicates are left untouched.
+    """
+    manager = getattr(env, "termination_manager", None)
+    if manager is None:
+        return
+    for name in manager.active_terms:
+        callback = getattr(manager.get_term_cfg(name).func, "reset_after_state_restore", None)
+        if callback is not None:
+            callback(env_ids=env_ids)
+
+
+def restore_episode_task_state(
+    env,
+    state: Any,
+    env_index: int = 0,
+    legacy_goal_pose: Any = None,
+) -> list[str]:
+    """Restore a snapshot from :func:`capture_episode_task_state`.
+
+    Missing terms/buffers are skipped and reported so recordings remain usable
+    after benign task configuration changes.
+    """
+    if not isinstance(state, dict):
+        state = {}
+    skipped: list[str] = []
+
+    command_manager = getattr(env, "command_manager", None)
+    commands = state.get("commands") or {}
+    if not commands and legacy_goal_pose is not None:
+        # Schema <= 3 recorded only object_pose and replay never applied it.
+        commands = {"object_pose": {"pose_command_b": legacy_goal_pose}}
+    for name, buffers in commands.items():
+        if command_manager is None or not isinstance(buffers, dict):
+            skipped.append(f"command:{name}")
+            continue
+        try:
+            term = command_manager.get_term(name)
+        except (AttributeError, KeyError):
+            skipped.append(f"command:{name}")
+            continue
+        for buffer_name, value in buffers.items():
+            target = getattr(term, buffer_name, None)
+            if not isinstance(target, torch.Tensor) or target.shape[0] <= env_index:
+                skipped.append(f"command:{name}.{buffer_name}")
+                continue
+            _restore_tensor_row(target, value, env_index)
+            if buffer_name == "pose_command_b" and getattr(getattr(term, "cfg", None), "use_world_frame", False):
+                pose_w = getattr(term, "pose_command_w", None)
+                if isinstance(pose_w, torch.Tensor) and pose_w.shape[0] > env_index:
+                    _restore_tensor_row(pose_w, value, env_index)
+
+    for name, value in (state.get("env_buffers") or {}).items():
+        target = getattr(env, name, None)
+        if not isinstance(target, torch.Tensor) or target.shape[0] <= env_index:
+            source = torch.as_tensor(value, device=env.device)
+            target = torch.zeros((env.num_envs, *source.shape), device=env.device, dtype=source.dtype)
+            setattr(env, name, target)
+        _restore_tensor_row(target, value, env_index)
+
+    return skipped

--- a/source/dexverse/dexverse/teleop_utils/range_vis.py
+++ b/source/dexverse/dexverse/teleop_utils/range_vis.py
@@ -1,0 +1,409 @@
+# Copyright (c) 2025-2026, The DexVerse Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Draw the environment's randomization ranges as wireframe boxes.
+
+A teleoperator sees one sample from each randomization range per episode and has
+no way to know how wide those ranges actually are. This module reads the ranges
+straight out of the resolved env config and outlines them in the scene, so the
+operator can see the whole spawn/goal envelope while demonstrating.
+
+Two pieces:
+
+* :func:`collect_range_boxes` -- introspects ``env.cfg.events`` (every reset term
+  carrying a ``pose_range``) and ``env.cfg.commands`` (goal-command sampling
+  ranges) and returns frame-resolved :class:`RangeBox` specs.
+* :class:`randomization_ranges_vis` -- a side-effect-only observation term (the
+  same ``ManagerTermBase`` pattern as ``mdp.forbidden_zones_vis``) that renders
+  those boxes as true wireframes: 12 thin cuboid edge bars per box, drawn from a
+  single instanced marker prototype via per-instance scales.
+
+Attach it with :func:`attach_range_vis` before ``gym.make``; the teleop scripts
+expose it as ``--show_ranges``.
+
+Frame semantics (these differ per reset function -- getting them wrong silently
+draws the box in the wrong place):
+
+* ``reset_root_state_uniform`` / ``reset_root_pose_uniform`` /
+  ``reset_root_pose_uniform_excluding`` treat ``pose_range`` as an offset from
+  the asset's ``default_root_state``, so the box is
+  ``default_root_state[:, :3] + env_origins + range``.
+* ``reset_object_from_place_annotations`` anchors on the annotation instead:
+  ``env_origins + per_env_positions`` with ``z`` replaced by ``support_z``, and
+  ``pose_range`` is extra jitter on top.
+* Goal commands sample ``ranges.pos_*`` directly into world coordinates when
+  ``use_world_frame`` is set -- ``env_origins`` is *not* added (see
+  ``mdp/commands/pose_commands.py::_resample_command``). Drawing them with an
+  env-origin offset would show where the goal ought to be, not where it is.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+
+import torch
+from isaaclab.managers import ManagerTermBase, SceneEntityCfg
+
+logger = logging.getLogger(__name__)
+
+# Reset functions whose ``pose_range`` is an offset from ``default_root_state``.
+_DEFAULT_ROOT_ANCHORED = (
+    "reset_root_state_uniform",
+    "reset_root_pose_uniform",
+    "reset_root_pose_uniform_excluding",
+    "reset_articulation_with_supports_uniform",
+)
+# Reset function anchored on per-object placement annotations instead.
+_ANNOTATION_ANCHORED = ("reset_object_from_place_annotations",)
+
+#: Entity/term name fragments that mark a range as a *goal* region even though
+#: it is randomized by a plain reset event. Several tasks implement the goal as
+#: a scene asset (``success_marker``, ``goal_tee``) rather than a command term,
+#: and the operator cares about the spawn/goal distinction, not the mechanism.
+_GOAL_NAME_HINTS = ("goal", "success_marker", "target")
+
+
+def _kind_for(term_name: str, entity: str) -> str:
+    haystack = f"{term_name} {entity}".lower()
+    return "goal" if any(hint in haystack for hint in _GOAL_NAME_HINTS) else "spawn"
+
+#: Colors keyed by range kind, chosen to stay distinct from the existing
+#: red forbidden-zone / green-blue goal markers already in the scene.
+DEFAULT_COLORS: dict[str, tuple[float, float, float]] = {
+    "spawn": (0.15, 0.75, 1.00),  # cyan  -- where an entity may be spawned
+    "goal": (1.00, 0.80, 0.10),  # amber -- where the goal may be sampled
+}
+
+
+@dataclass
+class RangeBox:
+    """One axis-aligned randomization envelope, in world coordinates."""
+
+    name: str
+    kind: str  # "spawn" | "goal"
+    entity: str
+    center: tuple[float, float, float]
+    half_extent: tuple[float, float, float]
+    #: Set when the range samples orientation too -- recorded for the readout,
+    #: not drawn (a yaw fan would clutter the box it belongs to).
+    rot_range: dict[str, tuple[float, float]] = field(default_factory=dict)
+    #: True when the box is degenerate in all three axes (a fixed pose). These
+    #: are kept for reporting but skipped by the renderer.
+    degenerate: bool = False
+
+
+def _as_pair(value) -> tuple[float, float]:
+    if value is None:
+        return (0.0, 0.0)
+    try:
+        lo, hi = float(value[0]), float(value[1])
+    except (TypeError, IndexError, ValueError):
+        return (0.0, 0.0)
+    return (lo, hi) if lo <= hi else (hi, lo)
+
+
+def _pos_ranges(pose_range: dict) -> tuple[tuple[float, float], ...]:
+    return tuple(_as_pair(pose_range.get(axis)) for axis in ("x", "y", "z"))
+
+
+def _rot_ranges(pose_range: dict) -> dict[str, tuple[float, float]]:
+    out = {}
+    for key in ("roll", "pitch", "yaw"):
+        lo, hi = _as_pair(pose_range.get(key))
+        if lo != hi:
+            out[key] = (lo, hi)
+    return out
+
+
+def _entity_name(params: dict) -> str | None:
+    for key in ("asset_cfg", "object_cfg", "reference_asset_cfg"):
+        value = params.get(key)
+        if isinstance(value, SceneEntityCfg):
+            return value.name
+    return None
+
+
+def _box_from_bounds(
+    name: str,
+    kind: str,
+    entity: str,
+    lo: tuple[float, float, float],
+    hi: tuple[float, float, float],
+    rot_range: dict,
+) -> RangeBox:
+    center = tuple((lo[i] + hi[i]) * 0.5 for i in range(3))
+    half = tuple((hi[i] - lo[i]) * 0.5 for i in range(3))
+    return RangeBox(
+        name=name,
+        kind=kind,
+        entity=entity,
+        center=center,  # type: ignore[arg-type]
+        half_extent=half,  # type: ignore[arg-type]
+        rot_range=rot_range,
+        degenerate=all(h <= 1.0e-9 for h in half),
+    )
+
+
+def collect_range_boxes(env, env_index: int = 0) -> list[RangeBox]:
+    """Resolve every randomization envelope in ``env`` to world-frame boxes.
+
+    ``env_index`` selects which environment instance the boxes describe; teleop
+    runs with ``num_envs=1`` so the default is the only one that exists there.
+    Unknown reset functions are skipped with a warning rather than guessed at,
+    since a box drawn under the wrong frame convention is worse than no box.
+    """
+    boxes: list[RangeBox] = []
+    origin = env.scene.env_origins[env_index].detach().cpu().numpy()
+
+    events_cfg = getattr(env.cfg, "events", None)
+    for term_name, term in vars(events_cfg).items() if events_cfg is not None else []:
+        params = getattr(term, "params", None)
+        func = getattr(term, "func", None)
+        if not isinstance(params, dict) or func is None:
+            continue
+        pose_range = params.get("pose_range")
+        if not isinstance(pose_range, dict):
+            continue
+        entity = _entity_name(params)
+        if entity is None or entity not in env.scene.keys():
+            continue
+
+        func_name = getattr(func, "__name__", str(func))
+        rot_range = _rot_ranges(pose_range)
+        (xr, yr, zr) = _pos_ranges(pose_range)
+
+        if func_name in _ANNOTATION_ANCHORED:
+            positions = params.get("per_env_positions") or []
+            if not positions:
+                continue
+            anchor = positions[min(env_index, len(positions) - 1)]
+            support_z = params.get("support_z")
+            base = (
+                origin[0] + float(anchor[0]),
+                origin[1] + float(anchor[1]),
+                float(support_z) if support_z is not None else origin[2] + float(anchor[2]),
+            )
+        elif func_name in _DEFAULT_ROOT_ANCHORED:
+            asset = env.scene[entity]
+            default_pos = asset.data.default_root_state[env_index, :3].detach().cpu().numpy()
+            base = (
+                float(default_pos[0]) + origin[0],
+                float(default_pos[1]) + origin[1],
+                float(default_pos[2]) + origin[2],
+            )
+        else:
+            logger.warning(
+                "range_vis: skipping event '%s' -- unrecognized reset function '%s'; "
+                "its pose_range frame convention is unknown.",
+                term_name,
+                func_name,
+            )
+            continue
+
+        boxes.append(
+            _box_from_bounds(
+                name=term_name,
+                kind=_kind_for(term_name, entity),
+                entity=entity,
+                lo=(base[0] + xr[0], base[1] + yr[0], base[2] + zr[0]),
+                hi=(base[0] + xr[1], base[1] + yr[1], base[2] + zr[1]),
+                rot_range=rot_range,
+            )
+        )
+
+    commands_cfg = getattr(env.cfg, "commands", None)
+    for cmd_name, cmd in vars(commands_cfg).items() if commands_cfg is not None else []:
+        ranges = getattr(cmd, "ranges", None)
+        if ranges is None:
+            continue
+        px, py, pz = (_as_pair(getattr(ranges, f"pos_{a}", None)) for a in ("x", "y", "z"))
+        rot_range = {
+            key: (lo, hi)
+            for key in ("roll", "pitch", "yaw")
+            for lo, hi in [_as_pair(getattr(ranges, key, None))]
+            if lo != hi
+        }
+        # Sampled straight into world coordinates; env_origins is deliberately
+        # not added (see module docstring).
+        offset = (0.0, 0.0, 0.0) if getattr(cmd, "use_world_frame", False) else tuple(origin)
+        boxes.append(
+            _box_from_bounds(
+                name=cmd_name,
+                kind="goal",
+                entity=getattr(cmd, "asset_name", "") or "",
+                lo=(offset[0] + px[0], offset[1] + py[0], offset[2] + pz[0]),
+                hi=(offset[0] + px[1], offset[1] + py[1], offset[2] + pz[1]),
+                rot_range=rot_range,
+            )
+        )
+
+    return boxes
+
+
+def describe_boxes(boxes: list[RangeBox]) -> str:
+    """Human-readable digest of the collected ranges, for the console."""
+    if not boxes:
+        return "range_vis: no randomization ranges found for this task."
+    lines = [f"range_vis: {len(boxes)} randomization range(s):"]
+    for b in boxes:
+        span = tuple(round(2.0 * h, 4) for h in b.half_extent)
+        centre = tuple(round(c, 4) for c in b.center)
+        flag = "  [fixed pose]" if b.degenerate else ""
+        rot = f"  rot={ {k: tuple(round(v, 3) for v in vs) for k, vs in b.rot_range.items()} }" if b.rot_range else ""
+        lines.append(f"  - {b.kind:5s} {b.name} ({b.entity}): centre={centre} span={span}{rot}{flag}")
+    return "\n".join(lines)
+
+
+def _edge_instances(box: RangeBox, thickness: float):
+    """Twelve edge bars for one box: (translation, scale) per edge."""
+    cx, cy, cz = box.center
+    hx, hy, hz = box.half_extent
+    half = (hx, hy, hz)
+    out = []
+    for axis in range(3):
+        u, v = [i for i in range(3) if i != axis]
+        # Full length along `axis`; thickness padded so corners meet cleanly.
+        scale = [thickness, thickness, thickness]
+        scale[axis] = max(2.0 * half[axis] + thickness, thickness)
+        for su in (-1.0, 1.0):
+            for sv in (-1.0, 1.0):
+                pos = [cx, cy, cz]
+                pos[u] += su * half[u]
+                pos[v] += sv * half[v]
+                out.append((pos, list(scale)))
+    return out
+
+
+class randomization_ranges_vis(ManagerTermBase):
+    """Outline every randomization range as a wireframe box.
+
+    Side-effect-only observation term (returns a zero-width tensor), matching
+    the ``forbidden_zones_vis`` convention already used in this repo. One
+    instanced ``VisualizationMarkers`` per range kind holds all edge bars, so
+    the whole overlay costs two prototypes regardless of how many ranges a task
+    declares.
+
+    The boxes are static, so geometry is computed once on the first call --
+    ``default_root_state`` is only meaningful after the scene is initialized,
+    which is why this is lazy rather than done in ``__init__``.
+    """
+
+    def __init__(self, cfg, env):
+        super().__init__(cfg, env)
+        self._thickness = float(cfg.params.get("thickness", 0.004))
+        self._colors = dict(DEFAULT_COLORS)
+        self._colors.update(cfg.params.get("colors", {}) or {})
+        self._opacity = float(cfg.params.get("opacity", 1.0))
+        self._prim_path_prefix = cfg.params.get("prim_path_prefix", "/Visuals/RandomizationRange")
+        self._verbose = bool(cfg.params.get("verbose", True))
+        self._hide_from_cameras = bool(cfg.params.get("hide_from_cameras", True))
+        self._visualizers: dict[str, object] = {}
+        self._instances: dict[str, tuple] = {}
+        self._built = False
+        self.boxes: list[RangeBox] = []
+
+    def _build(self, env) -> None:
+        import isaaclab.sim as sim_utils
+        if type(env.cfg).__module__.startswith("dexverse.baseline_v1."):
+            from dexverse.baseline_v1.visual_purpose import hide_marker_from_cameras
+        else:
+            from dexverse.visual_purpose import hide_marker_from_cameras
+        from isaaclab.markers import VisualizationMarkers, VisualizationMarkersCfg
+
+        self._built = True
+        self.boxes = collect_range_boxes(env)
+        if self._verbose:
+            print(describe_boxes(self.boxes))
+
+        drawable = [b for b in self.boxes if not b.degenerate]
+        for kind in sorted({b.kind for b in drawable}):
+            translations, scales = [], []
+            for box in (b for b in drawable if b.kind == kind):
+                for pos, scale in _edge_instances(box, self._thickness):
+                    translations.append(pos)
+                    scales.append(scale)
+            if not translations:
+                continue
+            color = self._colors.get(kind, (1.0, 1.0, 1.0))
+            marker_cfg = VisualizationMarkersCfg(
+                prim_path=f"{self._prim_path_prefix}/{kind}",
+                markers={
+                    "edge": sim_utils.CuboidCfg(
+                        # Unit prototype: per-instance `scales` gives each edge
+                        # bar its own dimensions from this single prototype.
+                        size=(1.0, 1.0, 1.0),
+                        visual_material=sim_utils.PreviewSurfaceCfg(
+                            diffuse_color=tuple(color),
+                            emissive_color=tuple(color),
+                            opacity=self._opacity,
+                        ),
+                    )
+                },
+            )
+            visualizer = VisualizationMarkers(marker_cfg)
+            if self._hide_from_cameras:
+                # Operator-only geometry: keep it out of every recorded RGB/depth
+                # observation, exactly as the zone markers do. Turning this off is
+                # only useful for capturing a screenshot of the overlay itself.
+                hide_marker_from_cameras(visualizer)
+            self._visualizers[kind] = visualizer
+            self._instances[kind] = (
+                torch.tensor(translations, device=env.device, dtype=torch.float32),
+                torch.tensor(scales, device=env.device, dtype=torch.float32),
+            )
+
+    def __call__(
+        self,
+        env,
+        thickness: float | None = None,
+        colors: dict | None = None,
+        opacity: float | None = None,
+        prim_path_prefix: str | None = None,
+        verbose: bool | None = None,
+        hide_from_cameras: bool | None = None,
+    ) -> torch.Tensor:
+        # Parameters are consumed in __init__ (the markers are built once);
+        # they are declared here because ObservationManager validates that every
+        # cfg param maps to a named argument and rejects **kwargs outright.
+        if not self._built:
+            try:
+                self._build(env)
+            except Exception as exc:  # never let an overlay break a teleop session
+                logger.warning("range_vis: disabled after build failure: %s", exc)
+                self._built = True
+        for kind, visualizer in self._visualizers.items():
+            translations, scales = self._instances[kind]
+            visualizer.visualize(
+                translations=translations,
+                scales=scales,
+                marker_indices=torch.zeros(translations.shape[0], dtype=torch.int32, device=env.device),
+            )
+        return torch.zeros(env.num_envs, 0, device=env.device)
+
+
+def attach_range_vis(env_cfg, **params) -> bool:
+    """Register :class:`randomization_ranges_vis` on ``env_cfg``.
+
+    Call before ``gym.make``. Returns whether the term was added. The term goes
+    into ``observations.scene_vis``, which observation presets never null out,
+    so the overlay survives whichever preset the task selects.
+    """
+    from isaaclab.managers import ObservationTermCfg as ObsTerm
+
+    observations = getattr(env_cfg, "observations", None)
+    if observations is None:
+        logger.warning("range_vis: env cfg exposes no observations group; overlay not attached.")
+        return False
+
+    if getattr(observations, "scene_vis", None) is None:
+        import dexverse.tasks.dexverse_base_env_cfg as dexverse_base_env
+
+        observations.scene_vis = dexverse_base_env.ObservationsCfg.SceneVisObsCfg()
+
+    observations.scene_vis.randomization_ranges_vis = ObsTerm(
+        func=randomization_ranges_vis, params=dict(params)
+    )
+    return True

--- a/source/dexverse/dexverse/teleop_utils/stats_panel.py
+++ b/source/dexverse/dexverse/teleop_utils/stats_panel.py
@@ -1,0 +1,458 @@
+# Copyright (c) 2025-2026, The DexVerse Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Live demonstration-diversity readout for the teleoperator.
+
+``record_demos.py`` writes trajectories blind: the operator has no feedback on
+whether the demos being collected are actually diverse until the offline
+analysis runs, long after the session. This module closes that loop -- after
+every recorded trajectory it re-scores the dataset and renders the result as an
+image the operator can read *inside the headset*.
+
+Pipeline per trajectory:
+
+1. :func:`dexverse.teleop_utils.diversity_core.demos_from_episodes` wraps the
+   recorder's in-memory episodes (optionally merged with previously recorded
+   pickles for the same task) -- no pickle round-trip.
+2. ``analyze_demos(..., include_knn=False)`` scores them. The k-NN
+   multimodality stage is skipped because it is the only one whose cost grows
+   with dataset size (~0.6 s at 50 episodes); everything kept here runs in
+   ~35 ms, which is invisible in the reset pause after a successful demo.
+3. :func:`render_report_figure` draws a dark-surface panel sized for VR.
+4. :meth:`TeleopStatsPanel.publish` pushes it into the XR scene as a
+   camera-facing widget, and always writes a PNG + JSON next to the demos.
+
+The XR widget is built on ``omni.kit.xr.scene_view.utils``, the same machinery
+behind Isaac Lab's ``show_instruction``. That renders into the XR scene view, so
+it *is* visible over CloudXR in the headset -- unlike an ``omni.ui`` window,
+which is desktop-only Kit UI and never reaches the goggles.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+# --- palette -----------------------------------------------------------------
+# Dark-surface steps from the reference data-viz palette. Validated as a pair on
+# this surface: CVD dE 26.8 (protan), normal-vision dE 31.8, both >= 3:1 contrast.
+SURFACE = "#1a1a19"
+INK_PRIMARY = "#ffffff"
+INK_SECONDARY = "#c3c2b7"
+INK_MUTED = "#898781"
+GRIDLINE = "#2c2c2a"
+BASELINE = "#383835"
+SERIES_COVERAGE = "#3987e5"  # slot 1, blue  -- initial-state coverage
+SERIES_STRATEGY = "#d95926"  # slot 2, orange -- approach strategies
+GOOD = "#0ca30c"
+
+
+def _fmt(value, digits: int = 2, dash: str = "--") -> str:
+    if value is None:
+        return dash
+    try:
+        if float(value) != float(value):  # NaN
+            return dash
+        return f"{float(value):.{digits}f}".rstrip("0").rstrip(".") or "0"
+    except (TypeError, ValueError):
+        return str(value)
+
+
+def summarize_report(report: dict, session_count: int | None = None) -> dict:
+    """Flatten the pieces of an ``analyze_demos`` report the panel shows."""
+    coverage = report.get("initial_state_coverage") or {}
+    saturation = coverage.get("saturation") or {}
+    strategy = report.get("strategy") or {}
+    octant = strategy.get("approach_octant") or {}
+    onset = strategy.get("onset_step") or {}
+    regrasp = strategy.get("regrasp_proxy") or {}
+    motion = strategy.get("motion") or {}
+
+    return {
+        "task": report.get("task", "?"),
+        "robot_type": report.get("robot_type"),
+        "n_episodes": int(report.get("n_episodes", 0) or 0),
+        "session_count": session_count,
+        "coverage_curve": list(saturation.get("curve") or []),
+        "coverage_n95": saturation.get("n95"),
+        "coverage_final": saturation.get("final"),
+        "mode_counts": dict(octant.get("counts") or {}),
+        "mode_perplexity": octant.get("perplexity"),
+        "mode_distinct": octant.get("distinct"),
+        "mode_top_share": octant.get("top_share"),
+        "onset_median": onset.get("median"),
+        "regrasp_mean": regrasp.get("mean"),
+        "regrasp_nonzero": regrasp.get("nonzero_episodes"),
+        "motion": motion,
+        "warnings": list(report.get("warnings") or []),
+    }
+
+
+def digest_text(summary: dict) -> str:
+    """Compact console/fallback-panel digest of a summary."""
+    n = summary["n_episodes"]
+    lines = [f"{summary['task']}  |  {n} demo(s)"]
+    if summary.get("session_count") is not None:
+        lines[0] += f"  ({summary['session_count']} this session)"
+    n95 = summary.get("coverage_n95")
+    if n95 is not None:
+        lines.append(f"start coverage: n95 = {n95}/{n}  (higher = starts still diversifying)")
+    if summary.get("mode_perplexity") is not None:
+        lines.append(
+            f"approach strategies: {_fmt(summary['mode_perplexity'])} effective"
+            f"  ({summary.get('mode_distinct', '?')} distinct,"
+            f" top {int(round(100 * (summary.get('mode_top_share') or 0)))}%)"
+        )
+    if summary.get("regrasp_mean") is not None:
+        lines.append(f"regrasp proxy: {_fmt(summary['regrasp_mean'])} mean")
+    for w in summary.get("warnings", []):
+        lines.append(f"! {w}")
+    return "\n".join(lines)
+
+
+# --- figure ------------------------------------------------------------------
+
+
+def _style_axes(ax) -> None:
+    ax.set_facecolor(SURFACE)
+    for side in ("top", "right"):
+        ax.spines[side].set_visible(False)
+    for side in ("left", "bottom"):
+        ax.spines[side].set_color(BASELINE)
+        ax.spines[side].set_linewidth(1.0)
+    ax.tick_params(colors=INK_MUTED, labelsize=11, length=3, width=1.0)
+    ax.xaxis.label.set_color(INK_MUTED)
+    ax.yaxis.label.set_color(INK_MUTED)
+
+
+def _draw_kpis(ax, summary: dict) -> None:
+    """Top row of hero numbers -- these are magnitudes with no comparison, so
+    they are stat tiles rather than a chart (see the form heuristic)."""
+    ax.set_axis_off()
+    n = summary["n_episodes"]
+    session = summary.get("session_count")
+    tiles = [
+        ("DEMOS", str(n), f"{session} this session" if session is not None else ""),
+        (
+            "START COVERAGE",
+            f"{summary['coverage_n95']}/{n}" if summary.get("coverage_n95") is not None else "--",
+            "n95 -- new starts still adding",
+        ),
+        (
+            "EFFECTIVE STRATEGIES",
+            _fmt(summary.get("mode_perplexity")),
+            f"{summary.get('mode_distinct', '?')} distinct approaches",
+        ),
+        (
+            "REGRASP PROXY",
+            _fmt(summary.get("regrasp_mean")),
+            f"{summary.get('regrasp_nonzero', 0)} episode(s) > 0",
+        ),
+    ]
+    for i, (label, value, sub) in enumerate(tiles):
+        x = i / len(tiles) + 0.012
+        ax.text(x, 0.90, label, transform=ax.transAxes, color=INK_MUTED,
+                fontsize=11, fontweight="bold", va="top", ha="left")
+        ax.text(x, 0.60, value, transform=ax.transAxes, color=INK_PRIMARY,
+                fontsize=30, fontweight="bold", va="top", ha="left")
+        if sub:
+            ax.text(x, 0.10, sub, transform=ax.transAxes, color=INK_SECONDARY,
+                    fontsize=10, va="bottom", ha="left")
+
+
+def _draw_coverage(ax, summary: dict) -> None:
+    curve = summary.get("coverage_curve") or []
+    _style_axes(ax)
+    ax.set_title("Initial-state coverage", color=INK_PRIMARY, fontsize=13,
+                 fontweight="bold", loc="left", pad=10)
+    if len(curve) < 2:
+        ax.text(0.5, 0.5, "needs 2+ demos", transform=ax.transAxes, color=INK_MUTED,
+                fontsize=12, ha="center", va="center")
+        ax.set_xticks([])
+        ax.set_yticks([])
+        return
+    xs = np.arange(1, len(curve) + 1)
+    ys = np.asarray(curve, dtype=float)
+    ax.grid(True, axis="y", color=GRIDLINE, linewidth=1.0, zorder=0)
+    ax.set_axisbelow(True)
+    # Single series -- the title names it, so no legend box.
+    ax.plot(xs, ys, color=SERIES_COVERAGE, linewidth=2.0, zorder=3,
+            solid_capstyle="round")
+    ax.plot(xs[-1:], ys[-1:], marker="o", markersize=8, color=SERIES_COVERAGE, zorder=4)
+    # One direct label on the live end, never a number on every point.
+    ax.annotate(f"{ys[-1]:.0f} bins", xy=(xs[-1], ys[-1]), xytext=(-4, 10),
+                textcoords="offset points", color=INK_PRIMARY, fontsize=11,
+                fontweight="bold", ha="right")
+    n95 = summary.get("coverage_n95")
+    if n95 is not None and 0 < n95 <= len(curve):
+        ax.axvline(n95, color=INK_MUTED, linewidth=1.0, linestyle=(0, (4, 3)), zorder=2)
+        ax.annotate("n95", xy=(n95, ax.get_ylim()[0]), xytext=(4, 6),
+                    textcoords="offset points", color=INK_MUTED, fontsize=10)
+    ax.set_xlabel("demos")
+    ax.set_ylabel("occupied bins")
+
+
+def _draw_strategies(ax, summary: dict) -> None:
+    counts = summary.get("mode_counts") or {}
+    _style_axes(ax)
+    ax.set_title("Approach strategies at onset", color=INK_PRIMARY,
+                 fontsize=13, fontweight="bold", loc="left", pad=10)
+    if not counts:
+        ax.text(0.5, 0.5, "no palm model for this embodiment",
+                transform=ax.transAxes, color=INK_MUTED, fontsize=12,
+                ha="center", va="center")
+        ax.set_xticks([])
+        ax.set_yticks([])
+        return
+    items = sorted(counts.items(), key=lambda kv: kv[1], reverse=True)[:6]
+    labels = [(k if len(k) <= 14 else k[:13] + "\u2026") for k, _ in items][::-1]
+    values = [v for _, v in items][::-1]
+    ypos = np.arange(len(labels))
+    ax.grid(True, axis="x", color=GRIDLINE, linewidth=1.0, zorder=0)
+    ax.set_axisbelow(True)
+    # Single measure across categories -> one hue, not a categorical rainbow.
+    ax.barh(ypos, values, height=0.62, color=SERIES_STRATEGY, zorder=3)
+    ax.set_yticks(ypos)
+    ax.set_yticklabels(labels, color=INK_SECONDARY, fontsize=11)
+    # Reserve a minimum number of category slots so a task with a single
+    # observed mode shows a thin bar rather than one filling the panel.
+    ax.set_ylim(-0.6, max(len(labels), 4) - 0.4)
+    ax.set_xlabel("episodes")
+    for y, v in zip(ypos, values):
+        ax.annotate(str(v), xy=(v, y), xytext=(6, 0), textcoords="offset points",
+                    color=INK_PRIMARY, fontsize=11, fontweight="bold", va="center")
+    ax.set_xlim(0, max(values) * 1.18)
+
+
+def render_report_figure(summary: dict, width_px: int = 1024, height_px: int = 620,
+                         dpi: int = 100) -> np.ndarray:
+    """Render the panel to an ``(H, W, 4)`` uint8 RGBA array.
+
+    Uses the Agg canvas directly rather than pyplot so this stays free of global
+    state and safe to call from the sim loop.
+    """
+    from matplotlib.backends.backend_agg import FigureCanvasAgg
+    from matplotlib.figure import Figure
+
+    fig = Figure(figsize=(width_px / dpi, height_px / dpi), dpi=dpi, facecolor=SURFACE)
+    canvas = FigureCanvasAgg(fig)
+    gs = fig.add_gridspec(2, 2, height_ratios=[0.9, 2.0], hspace=0.42, wspace=0.30,
+                          left=0.065, right=0.975, top=0.90, bottom=0.11)
+
+    header = fig.add_subplot(gs[0, :])
+    _draw_kpis(header, summary)
+    _draw_coverage(fig.add_subplot(gs[1, 0]), summary)
+    _draw_strategies(fig.add_subplot(gs[1, 1]), summary)
+
+    title = summary.get("task", "?")
+    if summary.get("robot_type"):
+        title += f"   ·   {summary['robot_type']}"
+    fig.text(0.065, 0.965, title, color=INK_SECONDARY, fontsize=12, va="top", ha="left")
+
+    canvas.draw()
+    return np.asarray(canvas.buffer_rgba()).copy()
+
+
+# --- XR display --------------------------------------------------------------
+
+_ACTIVE_CONTAINERS: dict[str, object] = {}
+
+
+def _build_image_widget_class():
+    """Define the image widget lazily -- ``omni.ui`` only exists inside Kit."""
+    import omni.ui as ui
+
+    class StatsImageWidget(ui.Widget):
+        """Full-bleed RGBA image, for showing a rendered figure in the XR scene."""
+
+        def __init__(self, rgba: np.ndarray, **kwargs):
+            super().__init__(**kwargs)
+            height, width = int(rgba.shape[0]), int(rgba.shape[1])
+            self._provider = ui.ByteImageProvider()
+            self._provider.set_data_array(np.ascontiguousarray(rgba, dtype=np.uint8),
+                                          [width, height])
+            with ui.ZStack():
+                ui.Rectangle(style={"Rectangle": {"background_color": 0xFF1A1A19,
+                                                  "border_radius": 0.05}})
+                ui.ImageWithProvider(self._provider,
+                                     fill_policy=ui.IwpFillPolicy.IWP_PRESERVE_ASPECT_FIT)
+
+    return StatsImageWidget
+
+
+def show_image_panel(rgba: np.ndarray, *, target_prim_path: str = "/DexVerseStatsPanel",
+                     prim_path_source: str | None = "/_xr/stage/xrCamera",
+                     translation=(0.0, 0.45, -1.35), width: float = 1.1,
+                     resolution_scale: float = 900.0) -> bool:
+    """Show ``rgba`` as a camera-facing panel in the XR scene.
+
+    Mirrors Isaac Lab's ``show_instruction``: the container is torn down and
+    rebuilt on each update, which is the path already proven in this stack (the
+    default ``WidgetComponent`` update policy only redraws on mouse hover, which
+    never fires in VR).
+    """
+    global _ACTIVE_CONTAINERS
+    try:
+        import isaaclab.sim as sim_utils
+        import omni.kit.commands
+        from omni.kit.xr.scene_view.utils import UiContainer, WidgetComponent
+        from omni.kit.xr.scene_view.utils.spatial_source import SpatialSource
+        from pxr import Gf
+    except ImportError as exc:
+        logger.debug("stats_panel: XR widget stack unavailable (%s)", exc)
+        return False
+
+    try:
+        hide_image_panel(target_prim_path)
+
+        height_px, width_px = int(rgba.shape[0]), int(rgba.shape[1])
+        height = width * (height_px / max(width_px, 1))
+
+        widget_component = WidgetComponent(
+            _build_image_widget_class(),
+            width=width,
+            height=height,
+            resolution_scale=resolution_scale,
+            widget_args=[rgba],
+        )
+
+        stage = sim_utils.get_current_stage()
+        if stage is not None and stage.GetPrimAtPath(target_prim_path).IsValid():
+            sim_utils.delete_prim(target_prim_path)
+
+        space_stack = []
+        if prim_path_source:
+            copied = omni.kit.commands.execute(
+                "CopyPrim", path_from=prim_path_source, path_to=target_prim_path,
+                exclusive_select=False, copy_to_introducing_layer=False,
+            )
+            if copied is not None:
+                space_stack.append(SpatialSource.new_prim_path_source(target_prim_path))
+        space_stack.extend([
+            SpatialSource.new_translation_source(Gf.Vec3d(*translation)),
+            SpatialSource.new_look_at_camera_source(),
+        ])
+
+        _ACTIVE_CONTAINERS[target_prim_path] = UiContainer(widget_component,
+                                                           space_stack=space_stack)
+        return True
+    except Exception as exc:
+        logger.warning("stats_panel: could not show XR image panel: %s", exc)
+        return False
+
+
+def hide_image_panel(target_prim_path: str = "/DexVerseStatsPanel") -> None:
+    container = _ACTIVE_CONTAINERS.pop(target_prim_path, None)
+    if container is not None:
+        try:
+            container.root.clear()
+        except Exception:  # teardown races with Kit shutdown; not worth raising
+            pass
+
+
+# --- orchestration -----------------------------------------------------------
+
+
+class TeleopStatsPanel:
+    """Recompute and publish demo-diversity stats after each recorded trajectory.
+
+    Every stage is defensive: a statistics failure must never take down a teleop
+    session that is mid-collection, so :meth:`publish` swallows and logs rather
+    than propagating.
+    """
+
+    def __init__(self, *, task: str, category: str = "", robot_type: str | None = None,
+                 output_dir: Path | str | None = None, session_file: Path | str | None = None,
+                 include_history: bool = True, xr: bool = False,
+                 width_px: int = 1024, height_px: int = 620, verbose: bool = True):
+        self.task = task
+        self.category = category
+        self.robot_type = robot_type
+        self.session_file = Path(session_file) if session_file else None
+        self.output_dir = Path(output_dir) if output_dir else (
+            self.session_file.parent if self.session_file else Path.cwd())
+        # Sibling pickles for this task are the "already collected" history; the
+        # session's own file is excluded because finalize_episode keeps it
+        # flushed and it would double-count every in-memory episode.
+        self.history_dir = self.output_dir if include_history else None
+        self.xr = bool(xr)
+        self.width_px = width_px
+        self.height_px = height_px
+        self.verbose = verbose
+        self.last_summary: dict | None = None
+
+    def publish(self, episodes: list[dict]) -> dict | None:
+        """Score ``episodes``, render the panel and push it to the headset."""
+        try:
+            from dexverse.teleop_utils import diversity_core as dc
+
+            demos = dc.demos_from_episodes(
+                episodes,
+                task=self.task,
+                category=self.category,
+                robot_type=self.robot_type,
+                history_dir=self.history_dir,
+                exclude=self.session_file,
+            )
+            if demos.num_episodes == 0:
+                return None
+            report = dc.analyze_demos(demos, include_knn=False)
+            if "error" in report:
+                return None
+            summary = summarize_report(report, session_count=len(episodes))
+            self.last_summary = summary
+
+            if self.verbose:
+                print("\n" + digest_text(summary) + "\n")
+            self._write_artifacts(report, summary)
+
+            if self.xr:
+                try:
+                    rgba = render_report_figure(summary, self.width_px, self.height_px)
+                    if not show_image_panel(rgba):
+                        self._show_text_fallback(summary)
+                except Exception as exc:
+                    logger.warning("stats_panel: figure render failed (%s); using text panel", exc)
+                    self._show_text_fallback(summary)
+            return summary
+        except Exception as exc:
+            logger.warning("stats_panel: skipped this episode: %s", exc)
+            return None
+
+    def _write_artifacts(self, report: dict, summary: dict) -> None:
+        stem = f"{self.task}_stats"
+        try:
+            self.output_dir.mkdir(parents=True, exist_ok=True)
+            (self.output_dir / f"{stem}.json").write_text(json.dumps(report, indent=2, default=str))
+        except Exception as exc:
+            logger.debug("stats_panel: could not write JSON report: %s", exc)
+        try:
+            from PIL import Image
+
+            rgba = render_report_figure(summary, self.width_px, self.height_px)
+            Image.fromarray(rgba).save(self.output_dir / f"{stem}.png")
+        except Exception as exc:
+            logger.debug("stats_panel: could not write PNG: %s", exc)
+
+    def _show_text_fallback(self, summary: dict) -> None:
+        try:
+            from isaaclab.ui.xr_widgets import show_instruction
+
+            show_instruction(
+                digest_text(summary), prim_path_source="/_xr/stage/xrCamera",
+                translation=(0.0, 0.45, -1.35), display_duration=None,
+                font_size=0.05, max_width=2.4, min_width=1.4,
+                target_prim_path="/DexVerseStatsText",
+            )
+        except Exception as exc:
+            logger.debug("stats_panel: text fallback unavailable: %s", exc)
+
+    def close(self) -> None:
+        hide_image_panel()

--- a/source/dexverse/setup.py
+++ b/source/dexverse/setup.py
@@ -39,10 +39,9 @@ setup(
     install_requires=INSTALL_REQUIRES,
     license="BSD-3-Clause",
     include_package_data=True,
-    python_requires=">=3.10",
+    python_requires=">=3.11",
     classifiers=[
         "Natural Language :: English",
-        "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Isaac Sim :: 4.5.0",
         "Isaac Sim :: 5.0.0",


### PR DESCRIPTION
For the 19 Baseline tasks, they are either fixed or improved. The upgraded tasks are made as "v1" versions of the old baseline tasks, and they are designed to be more challenging cases of the "v0" tasks. The challenges comes from more diverse spatial variances, which in turn requires the dexterous manipulation to engage the objects and tasks in more diverse contact modes and trajectories. New demos, 50 trajectories per task with the Shadow hand, are also collected and released on HuggingFace. Necessary changes to the utilities are also make, together with improvement on various tool scripts. 